### PR TITLE
SLIDESDOC-293: Thread safety - Licensing - J, C, P

### DIFF
--- a/cpp/getting-started/licensing/_index.md
+++ b/cpp/getting-started/licensing/_index.md
@@ -94,6 +94,6 @@ if(!isLicensed)
 
 {{% alert title="Note" color="warning" %}} 
 
-The `license->SetLicense` method is not thread safe. If this method has to be called simultaneously from many threads, you may want to use synchronization primitives (like a lock) to avoid issues. 
+The [License::SetLicense()](https://reference.aspose.com/slides/cpp/class/aspose.slides.license#a44102d1d52a5e45643345448b1814a67) method is not thread safe. If this method has to be called simultaneously from many threads, you may want to use synchronization primitives (like a lock) to avoid issues. 
 
 {{% /alert %}}

--- a/cpp/getting-started/licensing/_index.md
+++ b/cpp/getting-started/licensing/_index.md
@@ -89,3 +89,11 @@ if(!isLicensed)
 
 
 ```
+
+## **Thread Safety**
+
+{{% alert title="Note" color="warning" %}} 
+
+The `license->SetLicense` method is not thread safe. If this method has to be called simultaneously from many threads, you may want to use synchronization primitives (like a lock) to avoid issues. 
+
+{{% /alert %}}

--- a/java/getting-started/licensing/_index.md
+++ b/java/getting-started/licensing/_index.md
@@ -100,3 +100,10 @@ if (License.isLicensed())
 }
 ```
 
+## **Thread Safety**
+
+{{% alert title="Note" color="warning" %}} 
+
+The `license.setLicense` method is not thread safe. If this method has to be called simultaneously from many threads, you may want to use synchronization primitives (like a lock) to avoid issues. 
+
+{{% /alert %}}

--- a/java/getting-started/licensing/_index.md
+++ b/java/getting-started/licensing/_index.md
@@ -104,6 +104,6 @@ if (License.isLicensed())
 
 {{% alert title="Note" color="warning" %}} 
 
-The `license.setLicense` method is not thread safe. If this method has to be called simultaneously from many threads, you may want to use synchronization primitives (like a lock) to avoid issues. 
+The [`license.setLicense`](https://reference.aspose.com/slides/java/com.aspose.slides/License#setLicense-java.io.InputStream-) method is not thread safe. If this method has to be called simultaneously from many threads, you may want to use synchronization primitives (like a lock) to avoid issues. 
 
 {{% /alert %}}

--- a/python-net/getting-started/licensing/_index.md
+++ b/python-net/getting-started/licensing/_index.md
@@ -145,5 +145,10 @@ Please note that you must have a stable Internet connection for the correct use 
 
 {{% /alert %}}
 
+## **Thread Safety**
 
+{{% alert title="Note" color="warning" %}} 
 
+The `license.set_license` method is not thread safe. If this method has to be called simultaneously from many threads, you may want to use synchronization primitives (like a lock) to avoid issues. 
+
+{{% /alert %}}

--- a/python-net/getting-started/licensing/_index.md
+++ b/python-net/getting-started/licensing/_index.md
@@ -85,7 +85,7 @@ license = slides.License()
 license.set_license("Aspose.Slides.lic")
 ```
 
-When calling the SetLicense method, the license name should be same as that of your license file. For example, you can change the license file name to "Aspose.Slides.lic.xml". Then, in your code, you have to pass the new license name (Aspose.Slides.lic.xml) to the SetLicense method.
+When calling the set_license method, the license name should be same as that of your license file. For example, you can change the license file name to "Aspose.Slides.lic.xml". Then, in your code, you have to pass the new license name (Aspose.Slides.lic.xml) to the set_license method.
 
 #### **Applying a License from a Stream**
 You can load a license from a stream. 
@@ -149,6 +149,6 @@ Please note that you must have a stable Internet connection for the correct use 
 
 {{% alert title="Note" color="warning" %}} 
 
-The `license.set_license` method is not thread safe. If this method has to be called simultaneously from many threads, you may want to use synchronization primitives (like a lock) to avoid issues. 
+The [`License.set_license()`](https://docs.aspose.com/slides/python-net/api-reference/aspose.slides/license/) method is not thread safe. If this method has to be called simultaneously from many threads, you may want to use synchronization primitives (like a lock) to avoid issues. 
 
 {{% /alert %}}


### PR DESCRIPTION
@stasmiroshnichenko Please, check and confirm that the **Thread Safety** note is appropriate for Python.

@petrtetenko Please, check and confirm that the **Thread Safety** note is appropriate for Java.

@nikolaysaulyak Please, check and confirm that the **Thread Safety** note is appropriate for C++.