### PR TITLE
Removed "related documentation" header from php-java docs

### DIFF
--- a/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-10-release-notes/_index.md
+++ b/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-10-release-notes/_index.md
@@ -11,9 +11,9 @@ This page contains release notes for [Aspose.Slides for PHP via Java](https://pa
 
 {{% /alert %}} 
 
-|**Key**|**Summary**|**Category**|**Related Documentation**|
-| :- | :- | :- | :- |
-|SLIDESPHP-13|[Use Aspose.Slides for Java 22.10 features](/slides/java/aspose-slides-for-java-22-10-release-notes/)|Enhancement| |
+|**Key**|**Summary**|**Category**|
+| :- | :- | :- |
+|SLIDESPHP-13|[Use Aspose.Slides for Java 22.10 features](/slides/java/aspose-slides-for-java-22-10-release-notes/)|Enhancement|
 
 
 ## Public API Changes ##

--- a/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-11-release-notes/_index.md
+++ b/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-11-release-notes/_index.md
@@ -11,9 +11,9 @@ This page contains release notes for [Aspose.Slides for PHP via Java](https://pa
 
 {{% /alert %}} 
 
-|**Key**|**Summary**|**Category**|**Related Documentation**|
-| :- | :- | :- | :- |
-|SLIDESPHP-15|[Use Aspose.Slides for Java 22.11 features](/slides/java/aspose-slides-for-java-22-11-release-notes/)|Enhancement| |
+|**Key**|**Summary**|**Category**|
+| :- | :- | :- |
+|SLIDESPHP-15|[Use Aspose.Slides for Java 22.11 features](/slides/java/aspose-slides-for-java-22-11-release-notes/)|Enhancement|
 
 
 ## Public API Changes ##

--- a/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-12-release-notes/_index.md
+++ b/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-12-release-notes/_index.md
@@ -11,7 +11,7 @@ This page contains release notes for [Aspose.Slides for PHP via Java](https://pa
 
 {{% /alert %}} 
 
-|**Key**|**Summary**|**Category**|**Related Documentation**|
-| :- | :- | :- | :- |
-|SLIDESPHP-17|[Use Aspose.Slides for Java 22.12 features](/slides/java/aspose-slides-for-java-22-12-release-notes/)|Enhancement| |
+|**Key**|**Summary**|**Category**|
+| :- | :- | :- |
+|SLIDESPHP-17|[Use Aspose.Slides for Java 22.12 features](/slides/java/aspose-slides-for-java-22-12-release-notes/)|Enhancement|
 

--- a/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-5-release-notes/_index.md
+++ b/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-5-release-notes/_index.md
@@ -11,8 +11,8 @@ This page contains release notes for [Aspose.Slides for PHP via Java](https://pa
 
 {{% /alert %}} 
 
-|**Key**|**Summary**|**Category**|**Related Documentation**|
-| :- | :- | :- | :- |
-|SLIDESPHP-2|[Use Aspose.Slides for Java 22.5 features](/slides/java/aspose-slides-for-java-22-5-release-notes/)|Enhancement| |
+|**Key**|**Summary**|**Category**|
+| :- | :- | :- |
+|SLIDESPHP-2|[Use Aspose.Slides for Java 22.5 features](/slides/java/aspose-slides-for-java-22-5-release-notes/)|Enhancement|
 
 

--- a/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-6-release-notes/_index.md
+++ b/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-6-release-notes/_index.md
@@ -11,9 +11,9 @@ This page contains release notes for [Aspose.Slides for PHP via Java](https://pa
 
 {{% /alert %}} 
 
-|**Key**|**Summary**|**Category**|**Related Documentation**|
-| :- | :- | :- | :- |
-|SLIDESPHP-4|[Use Aspose.Slides for Java 22.6 features](/slides/java/aspose-slides-for-java-22-6-release-notes/)|Enhancement| |
+|**Key**|**Summary**|**Category**|
+| :- | :- | :- |
+|SLIDESPHP-4|[Use Aspose.Slides for Java 22.6 features](/slides/java/aspose-slides-for-java-22-6-release-notes/)|Enhancement|
 
 ## Public API Changes ##
 

--- a/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-7-release-notes/_index.md
+++ b/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-7-release-notes/_index.md
@@ -11,6 +11,6 @@ This page contains release notes for [Aspose.Slides for PHP via Java](https://pa
 
 {{% /alert %}} 
 
-|**Key**|**Summary**|**Category**|**Related Documentation**|
-| :- | :- | :- | :- |
-|SLIDESPHP-7|[Use Aspose.Slides for Java 22.7 features](/slides/java/aspose-slides-for-java-22-7-release-notes/)|Enhancement| |
+|**Key**|**Summary**|**Category**|
+| :- | :- | :- |
+|SLIDESPHP-7|[Use Aspose.Slides for Java 22.7 features](/slides/java/aspose-slides-for-java-22-7-release-notes/)|Enhancement|

--- a/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-8-release-notes/_index.md
+++ b/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-8-release-notes/_index.md
@@ -11,9 +11,9 @@ This page contains release notes for [Aspose.Slides for PHP via Java](https://pa
 
 {{% /alert %}} 
 
-|**Key**|**Summary**|**Category**|**Related Documentation**|
-| :- | :- | :- | :- |
-|SLIDESPHP-9|[Use Aspose.Slides for Java 22.8 features](/slides/java/aspose-slides-for-java-22-8-release-notes/)|Enhancement| |
+|**Key**|**Summary**|**Category**|
+| :- | :- | :- |
+|SLIDESPHP-9|[Use Aspose.Slides for Java 22.8 features](/slides/java/aspose-slides-for-java-22-8-release-notes/)|Enhancement|
 
 
 ## Public API Changes ##

--- a/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-9-release-notes/_index.md
+++ b/php-java/release-notes/release-notes-2022/aspose-slides-for-php-via-java-22-9-release-notes/_index.md
@@ -11,9 +11,9 @@ This page contains release notes for [Aspose.Slides for PHP via Java](https://pa
 
 {{% /alert %}} 
 
-|**Key**|**Summary**|**Category**|**Related Documentation**|
-| :- | :- | :- | :- |
-|SLIDESPHP-11|[Use Aspose.Slides for Java 22.9 features](/slides/java/aspose-slides-for-java-22-9-release-notes/)|Enhancement| |
+|**Key**|**Summary**|**Category**|
+| :- | :- | :- |
+|SLIDESPHP-11|[Use Aspose.Slides for Java 22.9 features](/slides/java/aspose-slides-for-java-22-9-release-notes/)|Enhancement|
 
 
 ## Public API Changes ##


### PR DESCRIPTION
Removed "related documentation" header from php-java docs