### PR TITLE
SLIDESDOC-352: How macros are handled

### DIFF
--- a/cpp/developer-guide/presentation-via-vba/_index.md
+++ b/cpp/developer-guide/presentation-via-vba/_index.md
@@ -11,7 +11,11 @@ The [Aspose.Slides.Vba](https://reference.aspose.com/slides/cpp/namespace/aspose
 
 {{% alert title="Note" color="warning" %}} 
 
-Aspose.Slides never runs the macros in a presentation. Additionally, in an operation where a PowerPoint presentation is converted to another file, Aspose.Slides ignores all macros (macros are not carried into the resulting file).
+When you convert a presentation containing macros to a different file format (PDF, HTML, etc.), Aspose.Slides ignores all macros (macros are not carried into the resulting file).
+
+When you add macros to a presentation or resave a presentation containing macros, Aspose.Slides simply writes the bytes for the macros.
+
+Aspose.Slides **never** runs the macros in a presentation.
 
 {{% /alert %}}
 

--- a/cpp/developer-guide/presentation-via-vba/_index.md
+++ b/cpp/developer-guide/presentation-via-vba/_index.md
@@ -3,25 +3,66 @@ title: Presentation via VBA
 type: docs
 weight: 250
 url: /cpp/presentation-via-vba/
+keywords: "Macro, macros, VBA, VBA macro, add macro, remove macro, add VBA, remove VBA, extract macro, extract VBA, PowerPoint macro, PowerPoint presentation, C++, CPP, Aspose.Slides for C++"
+description: "Add, remove, and extract VBA macros in PowerPoint presentations in C++"
 ---
 
-## **Add VBA Macros**
-The [Presentation](https://reference.aspose.com/slides/cpp/class/aspose.slides.presentation) class previous [VbaProject](https://reference.aspose.com/slides/cpp/class/aspose.slides.vba.vba_project) property has been replaced. Now instead of the raw bytes of the [VbaProject](https://reference.aspose.com/slides/cpp/class/aspose.slides.vba.vba_project) property representation of VBA project, the new [IVbaProject](https://reference.aspose.com/slides/cpp/class/aspose.slides.vba.i_vba_project) interface implementation has been added. Use `IVbaProject` to manage VBA embedded in a presentation. You can add new project references, edit existing modules and create new ones. Also, you can create a new VBA project using the `VbaProject` class which implements the `VbaProject` interface. The following example shows how to create a simple VBA project. It contains one module and adds two required references to the libraries.
+The [Aspose.Slides.Vba](https://reference.aspose.com/slides/cpp/namespace/aspose.slides.vba/) namespace contains classes and interfaces for working with macros and VBA code.
 
-1. Create an instance of the [Presentation](https://reference.aspose.com/slides/cpp/class/aspose.slides.presentation) class.
-1. Add a new `VbaProject` with the `Presentation.VbaProject` property.
-1. Add a module to the [VbaProject](https://reference.aspose.com/slides/cpp/class/aspose.slides.vba.vba_project).
+{{% alert title="Note" color="warning" %}} 
+
+Aspose.Slides never runs the macros in a presentation. Additionally, in an operation where a PowerPoint presentation is converted to another file, Aspose.Slides ignores all macros (macros are not carried into the resulting file).
+
+{{% /alert %}}
+
+## **Add VBA Macros**
+
+Aspose.Slides provides the [VbaProject](https://reference.aspose.com/slides/cpp/class/aspose.slides.vba.vba_project) class to allow you to create VBA projects (and project references) and edit existing modules. You can use the [IVbaProject](https://reference.aspose.com/slides/cpp/class/aspose.slides.vba.i_vba_project/) interface to manage VBA embedded in a presentation.
+
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/cpp/class/aspose.slides.presentation) class.
+1. Use the [VbaProject](https://reference.aspose.com/slides/cpp/class/aspose.slides.vba.vba_project#a01b7a0287df8a75f2f8d85185f3e197b) constructor to add a new VBA project.
+1. Add a module to the VbaProject.
 1. Set the module source code.
 1. Add references to <stdole>.
 1. Add references to **Microsoft Office**.
-1. Associate the references with the `VbaProject`.
-1. Finally, write the PPTX file using the [Presentation](https://reference.aspose.com/slides/cpp/class/aspose.slides.presentation) object.
+1. Associate the references with the VBA project.
+1. Save the presentation.
 
-The implementation of the above steps is demonstrated in the example below.
+This C++ code shows you how to add a VBA macro from scratch to a presentation: 
+
+```c++
+
+// The path to the documents directory.
+const String outPath = u"../out/AddVBAMacros_out.pptm";
+
+// Creates an instance of the presentation class
+SharedPtr<Presentation> presentation = MakeObject<Presentation>();
+// Creates a new VBA Project
+presentation->set_VbaProject(MakeObject<VbaProject>());
+
+// Adds an empty module to the VBA project
+SharedPtr<IVbaModule> module = presentation->get_VbaProject()->get_Modules()->AddEmptyModule(u"Module");
+
+// Sets the module source code
+module->set_SourceCode(u"Sub Test(oShape As Shape) MsgBox \"Test\" End Sub");
+
+// Creates a reference to <stdole>
+SharedPtr<VbaReferenceOleTypeLib> stdoleReference =
+	MakeObject<VbaReferenceOleTypeLib>(u"stdole", u"*\\G{00020430-0000-0000-C000-000000000046}#2.0#0#C:\\Windows\\system32\\stdole2.tlb#OLE Automation");
+
+// Creates a reference to Office
+SharedPtr<VbaReferenceOleTypeLib> officeReference =
+	MakeObject<VbaReferenceOleTypeLib>(u"Office", u"*\\G{2DF8D04C-5BFA-101B-BDE5-00AA0044DE52}#2.0#0#C:\\Program Files\\Common Files\\Microsoft Shared\\OFFICE14\\MSO.DLL#Microsoft Office 14.0 Object Library");
+
+// Adds references to the VBA project
+presentation->get_VbaProject()->get_References()->Add(stdoleReference);
+presentation->get_VbaProject()->get_References()->Add(officeReference);
+
+// Saves the Presentation
+presentation->Save(outPath, Aspose::Slides::Export::SaveFormat::Pptm);
 
 
-
-{{< gist "aspose-slides" "a690df625dc0b1fff869ab198affe7a4" "Examples-SlidesCPP-AddVBAMacros-AddVBAMacros.cpp" >}}
+```
 
 {{% alert color="primary" %}} 
 
@@ -30,23 +71,61 @@ You may want to check out **Aspose** [Macro Remover](https://products.aspose.app
 {{% /alert %}} 
 
 ## **Remove VBA Macros**
-The [Presentation](https://reference.aspose.com/slides/cpp/class/aspose.slides.presentation) class now has included the support to remove the VBA macros inside presentation. The following example shows how to access and remove a VBA macro in presentation.
 
-1. Create an instance of the [Presentation](https://reference.aspose.com/slides/cpp/class/aspose.slides.presentation) class and load presentation with Macro.
-1. Access the Macro module and remove that
-1. Finally, write the PPTX file using the [Presentation](https://reference.aspose.com/slides/cpp/class/aspose.slides.presentation) class object.
+Using the [VbaProject](https://reference.aspose.com/slides/cpp/class/aspose.slides.presentation#ac9554082a2ac5ed57adf6012c90da5f4) property under the [Presentation](https://reference.aspose.com/slides/cpp/class/aspose.slides.presentation) class, you can remove a VBA macro.
 
-The implementation of the above steps is demonstrated in the example below.
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/cpp/class/aspose.slides.presentation) class and load the presentation containing the macro.
+1. Access the Macro module and remove it.
+1. Save the modified presentation.
 
-{{< gist "aspose-slides" "a690df625dc0b1fff869ab198affe7a4" "Examples-SlidesCPP-RemoveVBAMacros-RemoveVBAMacros.cpp" >}}
+This C++ code shows you how to remove a VBA macro: 
+
+```c++
+
+// The path to the documents directory.
+const String outPath = u"../out/RemoveVBAMacros_out.pptm";
+const String templatePath = u"../templates/vba.pptm";
+
+// Loads the presentation containing the macro
+SharedPtr<Presentation> presentation = MakeObject<Presentation>(templatePath);
+
+// Accesses the Vba module and removes it 
+presentation->get_VbaProject()->get_Modules()->Remove(presentation->get_VbaProject()->get_Modules()->idx_get(0));
+
+// Saves the Presentation
+presentation->Save(outPath, Aspose::Slides::Export::SaveFormat::Pptm);
+
+
+```
+
 ## **Extract VBA Macros**
-Aspose.Slides for C++ supports extracting VBA Macros from the slide. In order to extract VBA Macros, please follow the steps below:
 
-- Load a Presentation containing a VBA Macros
-- Check if Presentation contains VBA Project
-- Loop through all the modules that are contained in the VBA Project
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/cpp/class/aspose.slides.presentation) class and load the presentation containing the macro.
+2. Check if the presentation contains a VBA Project.
+3. Loop through all the modules contained in the VBA Project to view the macros.
 
-The implementation of the above steps is demonstrated in the example below.
+This C++ code shows you how to extract VBA macros from a presentation containing macros: 
 
-{{< gist "aspose-com-gists" "81aeb05e6d3a070aa76fdea22ed53bc7" "Examples-SlidesCPP-ExtractingVBAMacros-ExtractingVBAMacros.cpp" >}}
+```c++
+
+	// The path to the documents directory.
+	const String templatePath = u"../templates/VBA.pptm";
+
+	// Loads the presentation containing the macro
+	SharedPtr<Presentation> pres = MakeObject<Presentation>(templatePath);
+
+
+	if (pres->get_VbaProject() != NULL) // Checks whether the Presentation contains a VBA Project
+	{
+		
+		//for (SharedPtr<IVbaModule> module : pres->get_VbaProject()->get_Modules())
+		for (int i = 0; i < pres->get_VbaProject()->get_Modules()->get_Count(); i++)
+		{
+			SharedPtr<IVbaModule> module = pres->get_VbaProject()->get_Modules()->idx_get(i);
+
+			System::Console::WriteLine(module->get_Name());
+			System::Console::WriteLine(module->get_SourceCode());
+		}
+	}
+```
 

--- a/java/developer-guide/presentation-via-vba/_index.md
+++ b/java/developer-guide/presentation-via-vba/_index.md
@@ -3,55 +3,56 @@ title: Presentation via VBA
 type: docs
 weight: 250
 url: /java/presentation-via-vba/
+keywords: "Macro, macros, VBA, VBA macro, add macro, remove macro, add VBA, remove VBA, extract macro, extract VBA, PowerPoint macro, PowerPoint presentation, Java, Aspose.Slides for Java"
+description: "Add, remove, and extract VBA macros in PowerPoint presentations in Java"
 ---
 
-## **Add VBA Macros to Presentation**
-{{% alert color="primary" %}} 
+{{% alert title="Note" color="warning" %}} 
 
-Aspose.Slides for Java allows developers to manage VBA macros in a presentation. All you have to do is to add a VBA using the [IVbaProject](https://reference.aspose.com/slides/java/com.aspose.slides/IVbaProject) interface associated with the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) class using the [Presentation.getVbaProject()](https://reference.aspose.com/slides/java/com.aspose.slides/presentation/methods/getVbaProject\(\)/) method.
+Aspose.Slides never runs the macros in a presentation. Additionally, in an operation where a PowerPoint presentation is converted to another file, Aspose.Slides ignores all macros (macros are not carried into the resulting file).
 
-{{% /alert %}} 
+{{% /alert %}}
 
-The [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) class previous **getVbaProject()** method has been replaced. Now instead of the raw bytes of the [**getVbaProject()**](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation#getVbaProject--) method representation of VBA project, the new [IVbaProject](https://reference.aspose.com/slides/java/com.aspose.slides/IVbaProject) interface implementation has been added.
-Use IVbaProject to manage VBA embedded in a presentation. You can add new project references, edit existing modules and create new ones.
-Also, you can create a new VBA project using the [VbaProject](https://reference.aspose.com/slides/java/com.aspose.slides/classes/VbaProject) class which implements the `IVbaProject` interface.
-The following example shows how to create a simple VBA project. It contains one module and adds two required references to the libraries.
+## **Add VBA Macros**
+
+Aspose.Slides provides the [VbaProject](https://reference.aspose.com/slides/java/com.aspose.slides/vbaproject/) class to allow you to create VBA projects (and project references) and edit existing modules. You can use the [IVbaProject](https://reference.aspose.com/slides/java/com.aspose.slides/ivbaproject/) interface to manage VBA embedded in a presentation.
 
 1. Create an instance of the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) class.
-1. Add a new [VbaProject](https://reference.aspose.com/slides/java/com.aspose.slides/classes/VbaProject) with the [Presentation.setVbaProject()](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation#setVbaProject-com.aspose.slides.IVbaProject-) method.
-1. Add a module to the [VbaProject](https://reference.aspose.com/slides/java/com.aspose.slides/classes/VbaProject).
+1. Use the [VbaProject](https://reference.aspose.com/slides/java/com.aspose.slides/vbaproject/#VbaProject--) constructor to add a new VBA project.
+1. Add a module to the VbaProject.
 1. Set the module source code.
-1. Add references to <stdole>.
-1. Add references to **Microsoft Office**.
-1. Associate the references with the [VbaProject](https://reference.aspose.com/slides/java/com.aspose.slides/classes/VbaProject).
-1. Finally, write the PPTX file using the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) object.
+1. Add references to <stdole>.
+1. Add references to **Microsoft Office**.
+1. Associate the references with the VBA project.
+1. Save the presentation.
 
-The implementation of the above steps is demonstrated in the example below.
+This Java code shows you how to add a VBA macro from scratch to a presentation:
 
 ```java
-// Instantiate Presentation
+// Creates an instance of the presentation class
 Presentation pres = new Presentation();
 try {
-    // Create new VBA Project
+    // Creates a new VBA Project
     pres.setVbaProject(new VbaProject());
     
-    // Add empty module to the VBA project
+    // Adds an empty module to the VBA project
     IVbaModule module = pres.getVbaProject().getModules().addEmptyModule("Module");
     
-    // Set module source code
+    // Sets the module source code
     module.setSourceCode("Sub Test(oShape As Shape)MsgBox Test End Sub");
     
-    // Create reference to <stdole>
+    // Creates a reference to <stdole>
     VbaReferenceOleTypeLib stdoleReference = new VbaReferenceOleTypeLib("stdole", "*\\G{00020430-0000-0000-C000-000000000046}#2.0#0#C:\\Windows\\system32\\stdole2.tlb#OLE Automation");
     
-    // Create reference to Office
+    // Creates a reference to Office
     VbaReferenceOleTypeLib officeReference = new VbaReferenceOleTypeLib("Office",
             "*\\G{2DF8D04C-5BFA-101B-BDE5-00AA0044DE52}#2.0#0#C:\\Program Files\\Common Files\\Microsoft Shared\\OFFICE14\\MSO.DLL#Microsoft Office 14.0 Object Library");
     
-    // Add references to the VBA project
+    // Adds references to the VBA project
     pres.getVbaProject().getReferences().add(stdoleReference);
     pres.getVbaProject().getReferences().add(officeReference);
-    
+   
+    // Saves the Presentation
     pres.save("test.pptm", SaveFormat.Pptm);
 } finally {
     if (pres != null) pres.dispose();
@@ -64,30 +65,24 @@ You may want to check out **Aspose** [Macro Remover](https://products.aspose.app
 
 {{% /alert %}} 
 
-## **Remove VBA Macros from Presentation**
+## **Remove VBA Macros**
 
-{{% alert color="primary" %}} 
+Using the [VbaProject](https://reference.aspose.com/slides/java/com.aspose.slides/presentation/#getVbaProject--) property under the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) class, you can remove a VBA macro.
 
-Aspose.Slides for Java allows developers to remove VBA macros in a presentation. All you have to do is to add a VBA using the `1IVbaProject` interface associated with the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) class using the [Presentation.getVbaProject()](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation#getVbaProject--) method.
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) class and load the presentation containing the macro.
+1. Access the Macro module and remove it.
+1. Save the modified presentation.
 
-{{% /alert %}} 
-
-The [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) class now has included the support to remove the VBA macros inside presentation. The following example shows how to access and remove a VBA macro in presentation.
-
-1. Create an instance of the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) class and load presentation with Macro.
-1. Access the Macro module and remove that
-1. Finally, write the PPTX file using the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) object.
-
-The implementation of the above steps is demonstrated in the example below.
+This Java code shows you how to remove a VBA macro:
 
 ```java
-// Load Presentation
+// Loads the presentation containing the macro
 Presentation pres = new Presentation("VBA.pptm");
 try {
-    // Access the Vba module and remove
+    // Accesses the Vba module and removes it 
     pres.getVbaProject().getModules().remove(pres.getVbaProject().getModules().get_Item(0));
     
-    // Save Presentation
+    // Saves the Presentation
     pres.save("test.pptm", SaveFormat.Pptm);
 } finally {
     if (pres != null) pres.dispose();
@@ -95,19 +90,18 @@ try {
 ```
 
 ## **Extract VBA Macros**
-Aspose.Slides for Java supports extracting VBA Macros from the slide. In order to extract VBA Macros, please follow the steps below:
 
-- Load a [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) containing a VBA Macros
-- Check if [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) contains VBA Project
-- Loop through all the modules that are contained in the VBA Project
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) class and load the presentation containing the macro.
+2. Check if the presentation contains a VBA Project.
+3. Loop through all the modules contained in the VBA Project to view the macros.
 
-The implementation of the above steps is demonstrated in the example below.
+This Java code shows you how to extract VBA macros from a presentation containing macros:
 
 ```java
-// Load Presentation
+// Loads the presentation containing the macro
 Presentation pres = new Presentation("VBA.pptm");
 try {
-    if (pres.getVbaProject() != null) // check if Presentation contains VBA Project
+    if (pres.getVbaProject() != null) // Checks whether the Presentation contains a VBA Project
     {
         for (IVbaModule module : pres.getVbaProject().getModules())
         {

--- a/java/developer-guide/presentation-via-vba/_index.md
+++ b/java/developer-guide/presentation-via-vba/_index.md
@@ -9,7 +9,11 @@ description: "Add, remove, and extract VBA macros in PowerPoint presentations in
 
 {{% alert title="Note" color="warning" %}} 
 
-Aspose.Slides never runs the macros in a presentation. Additionally, in an operation where a PowerPoint presentation is converted to another file, Aspose.Slides ignores all macros (macros are not carried into the resulting file).
+When you convert a presentation containing macros to a different file format (PDF, HTML, etc.), Aspose.Slides ignores all macros (macros are not carried into the resulting file).
+
+When you add macros to a presentation or resave a presentation containing macros, Aspose.Slides simply writes the bytes for the macros.
+
+Aspose.Slides **never** runs the macros in a presentation.
 
 {{% /alert %}}
 

--- a/net/developer-guide/presentation-via-vba/_index.md
+++ b/net/developer-guide/presentation-via-vba/_index.md
@@ -7,47 +7,56 @@ keywords: "Macro, macros, VBA, VBA macro, add macro, remove macro, add VBA, remo
 description: "Add, remove, and extract VBA macros in PowerPoint presentations in C# or .NET"
 ---
 
-## **Add VBA Macros**
-The [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation) class previous [VbaProject](http://www.aspose.com/api/net/slides/aspose.slides.vba/vbaproject) property has been replaced. Now instead of the raw bytes of the [VbaProject](http://www.aspose.com/api/net/slides/aspose.slides.vba/vbaproject) property representation of VBA project, the new **IVbaProject** interface implementation has been added. Use **IVbaProject** to manage VBA embedded in a presentation. You can add new project references, edit existing modules and create new ones. Also, you can create a new VBA project using the **VbaProject** class which implements the **VbaProject** interface. The following example shows how to create a simple VBA project. It contains one module and adds two required references to the libraries.
+The [Aspose.Slides.Vba](https://reference.aspose.com/slides/net/aspose.slides.vba/) namespace contains classes and interfaces for working with macros and VBA code.
 
-1. Create an instance of the `Presentation` class.
-1. Add a new VbaProject with the **Presentation.VbaProject** property.
-1. Add a module to the [VbaProject](http://www.aspose.com/api/net/slides/aspose.slides.vba/vbaproject).
+{{% alert title="Note" color="warning" %}} 
+
+Aspose.Slides never runs the macros in a presentation. Additionally, in an operation where a PowerPoint presentation is converted to another file, Aspose.Slides ignores all macros (macros are not carried into  resulting file).
+
+{{% /alert %}}
+
+## **Add VBA Macros**
+
+Aspose.Slides provides the [VbaProject](https://reference.aspose.com/slides/net/aspose.slides.vba/vbaproject/) class to allow you to create VBA projects (and project references) edit existing modules. You can use the [IVbaProject](https://reference.aspose.com/slides/net/aspose.slides.vba/ivbaproject/) interface to manage VBA embedded in a presentation.
+
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class.
+1. Use the [VbaProject](https://reference.aspose.com/slides/net/aspose.slides.vba/vbaproject/vbaproject/#constructor) contructor to add a new VBA project.
+1. Add a module to the VbaProject.
 1. Set the module source code.
 1. Add references to <stdole>.
 1. Add references to **Microsoft Office**.
-1. Associate the references with the **VbaProject**.
-1. Finally, write the PPTX file using the `Presentation` object.
+1. Associate the references with the VBA project.
+1. Save the presentation.
 
-The implementation of the above steps is demonstrated in the example below.
+This C# code shows you how to add a VBA macro from scratch:
 
 ```c#
-// Instantiate Presentation
+    // Creates an instance of the presentation class
 using (Presentation presentation = new Presentation())
 {
-    // Create new VBA Project
+    // Creates a new VBA Project
     presentation.VbaProject = new VbaProject();
 
-    // Add empty module to the VBA project
+    // Adds an empty module to the VBA project
     IVbaModule module = presentation.VbaProject.Modules.AddEmptyModule("Module");
   
-    // Set module source code
+    // Sets the module source code
     module.SourceCode = @"Sub Test(oShape As Shape) MsgBox ""Test"" End Sub";
 
-    // Create reference to <stdole>
+    // Creates a reference to <stdole>
     VbaReferenceOleTypeLib stdoleReference =
         new VbaReferenceOleTypeLib("stdole", "*\\G{00020430-0000-0000-C000-000000000046}#2.0#0#C:\\Windows\\system32\\stdole2.tlb#OLE Automation");
 
-    // Create reference to Office
+    // Creates a reference to Office
     VbaReferenceOleTypeLib officeReference =
         new VbaReferenceOleTypeLib("Office", "*\\G{2DF8D04C-5BFA-101B-BDE5-00AA0044DE52}#2.0#0#C:\\Program Files\\Common Files\\Microsoft Shared\\OFFICE14\\MSO.DLL#Microsoft Office 14.0 Object Library");
 
-    // Add references to the VBA project
+    // Adds references to the VBA project
     presentation.VbaProject.References.Add(stdoleReference);
     presentation.VbaProject.References.Add(officeReference);
 
             
-    // Save Presentation
+    // Saves the Presentation
     presentation.Save(dataDir + "AddVBAMacros_out.pptm", SaveFormat.Pptm);
 }
 ```
@@ -59,40 +68,39 @@ You may want to check out **Aspose** [Macro Remover](https://products.aspose.app
 {{% /alert %}} 
 
 ## **Remove VBA Macros**
-The `Presentation` class now has included the support to remove the VBA macros inside presentation. The following example shows how to access and remove a VBA macro in presentation.
+Using the [VbaProject](https://reference.aspose.com/slides/net/aspose.slides/presentation/vbaproject/) under the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class, you can remove a VBA macro.
 
-1. Create an instance of the `Presentation` class and load presentation with Macro.
-1. Access the Macro module and remove that
-1. Finally, write the PPTX file using the `Presentation` class object.
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class and load the presentation containing the macro.
+1. Access the Macro module and remove it.
+1. Save the modified presentation.
 
-The implementation of the above steps is demonstrated in the example below.
+This C# code shows you how to remove a VBA macro:
 
 ```c#
-// Instantiate Presentation
+    // Loads the presentation containing the macro
 using (Presentation presentation = new Presentation(dataDir + "VBA.pptm"))
 {
-    // Access the Vba module and remove 
+    // Accesses the Vba module and removes it 
     presentation.VbaProject.Modules.Remove(presentation.VbaProject.Modules[0]);
 
-    // Save Presentation
+    // Saves the Presentation
     presentation.Save(dataDir + "RemovedVBAMacros_out.pptm", SaveFormat.Pptm);
 }
 ```
 
 
 ## **Extract VBA Macros**
-Aspose.Slides for .NET supports extracting VBA Macros from the slide. In order to extract VBA Macros, please follow the steps below:
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class and load the presentation containing the macro.
+2. Check if the presentation contains a VBA Project.
+3. Loop through all the modules contained in the VBA Project to view the macros.
 
-- Load a Presentation containing a VBA Macros
-- Check if Presentation contains VBA Project
-- Loop through all the modules that are contained in the VBA Project
-
-The implementation of the above steps is demonstrated in the example below.
+This C# code shows you how to extract VBA macros from a presentation containing macros:
 
 ```c#
+    // Loads the presentation containing the macro
 using (Presentation pres = new Presentation("VBA.pptm"))
 {
-	if (pres.VbaProject != null) // check if Presentation contains VBA Project
+	if (pres.VbaProject != null) // Checks whether the Presentation contains a VBA Project
 	{
 		foreach (IVbaModule module in pres.VbaProject.Modules)
 		{
@@ -102,4 +110,3 @@ using (Presentation pres = new Presentation("VBA.pptm"))
 	}
 }
 ```
-

--- a/net/developer-guide/presentation-via-vba/_index.md
+++ b/net/developer-guide/presentation-via-vba/_index.md
@@ -11,7 +11,11 @@ The [Aspose.Slides.Vba](https://reference.aspose.com/slides/net/aspose.slides.vb
 
 {{% alert title="Note" color="warning" %}} 
 
-Aspose.Slides never runs the macros in a presentation. Additionally, in an operation where a PowerPoint presentation is converted to another file, Aspose.Slides ignores all macros (macros are not carried into the resulting file).
+When you convert a presentation containing macros to a different file format (PDF, HTML, etc.), Aspose.Slides ignores all macros (macros are not carried into the resulting file).
+
+When you add macros to a presentation or resave a presentation containing macros, Aspose.Slides simply writes the bytes for the macros.
+
+Aspose.Slides **never** runs the macros in a presentation.
 
 {{% /alert %}}
 

--- a/net/developer-guide/presentation-via-vba/_index.md
+++ b/net/developer-guide/presentation-via-vba/_index.md
@@ -11,16 +11,16 @@ The [Aspose.Slides.Vba](https://reference.aspose.com/slides/net/aspose.slides.vb
 
 {{% alert title="Note" color="warning" %}} 
 
-Aspose.Slides never runs the macros in a presentation. Additionally, in an operation where a PowerPoint presentation is converted to another file, Aspose.Slides ignores all macros (macros are not carried into  resulting file).
+Aspose.Slides never runs the macros in a presentation. Additionally, in an operation where a PowerPoint presentation is converted to another file, Aspose.Slides ignores all macros (macros are not carried into the resulting file).
 
 {{% /alert %}}
 
 ## **Add VBA Macros**
 
-Aspose.Slides provides the [VbaProject](https://reference.aspose.com/slides/net/aspose.slides.vba/vbaproject/) class to allow you to create VBA projects (and project references) edit existing modules. You can use the [IVbaProject](https://reference.aspose.com/slides/net/aspose.slides.vba/ivbaproject/) interface to manage VBA embedded in a presentation.
+Aspose.Slides provides the [VbaProject](https://reference.aspose.com/slides/net/aspose.slides.vba/vbaproject/) class to allow you to create VBA projects (and project references) and edit existing modules. You can use the [IVbaProject](https://reference.aspose.com/slides/net/aspose.slides.vba/ivbaproject/) interface to manage VBA embedded in a presentation.
 
 1. Create an instance of the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class.
-1. Use the [VbaProject](https://reference.aspose.com/slides/net/aspose.slides.vba/vbaproject/vbaproject/#constructor) contructor to add a new VBA project.
+1. Use the [VbaProject](https://reference.aspose.com/slides/net/aspose.slides.vba/vbaproject/vbaproject/#constructor) constructor to add a new VBA project.
 1. Add a module to the VbaProject.
 1. Set the module source code.
 1. Add references to <stdole>.
@@ -28,7 +28,7 @@ Aspose.Slides provides the [VbaProject](https://reference.aspose.com/slides/net/
 1. Associate the references with the VBA project.
 1. Save the presentation.
 
-This C# code shows you how to add a VBA macro from scratch:
+This C# code shows you how to add a VBA macro from scratch to a presentation:
 
 ```c#
     // Creates an instance of the presentation class
@@ -68,7 +68,7 @@ You may want to check out **Aspose** [Macro Remover](https://products.aspose.app
 {{% /alert %}} 
 
 ## **Remove VBA Macros**
-Using the [VbaProject](https://reference.aspose.com/slides/net/aspose.slides/presentation/vbaproject/) under the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class, you can remove a VBA macro.
+Using the [VbaProject](https://reference.aspose.com/slides/net/aspose.slides/presentation/vbaproject/) property under the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class, you can remove a VBA macro.
 
 1. Create an instance of the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class and load the presentation containing the macro.
 1. Access the Macro module and remove it.

--- a/python-net/developer-guide/presentation-via-vba/_index.md
+++ b/python-net/developer-guide/presentation-via-vba/_index.md
@@ -7,46 +7,55 @@ keywords: "Macro, macros, VBA, VBA macro, add macro, remove macro, add VBA, remo
 description: "Add, remove, and extract VBA macros in PowerPoint presentations in Python"
 ---
 
-## **Add VBA Macros**
-The [Presentation](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/) class previous [VbaProject](https://reference.aspose.com/slides/python-net/aspose.slides.vba/vbaproject/) property has been replaced. Now instead of the raw bytes of the [VbaProject](https://reference.aspose.com/slides/python-net/aspose.slides.vba/vbaproject/) property representation of VBA project, the new **IVbaProject** interface implementation has been added. Use **IVbaProject** to manage VBA embedded in a presentation. You can add new project references, edit existing modules and create new ones. Also, you can create a new VBA project using the **VbaProject** class which implements the **VbaProject** interface. The following example shows how to create a simple VBA project. It contains one module and adds two required references to the libraries.
+The [Aspose.Slides.Vba](https://reference.aspose.com/slides/python-net/aspose.slides.vba/) namespace contains classes and interfaces for working with macros and VBA code.
 
-1. Create an instance of the `Presentation` class.
-1. Add a new VbaProject with the **Presentation.VbaProject** property.
-1. Add a module to the [VbaProject](https://reference.aspose.com/slides/python-net/aspose.slides.vba/vbaproject/).
+{{% alert title="Note" color="warning" %}} 
+
+Aspose.Slides never runs the macros in a presentation. Additionally, in an operation where a PowerPoint presentation is converted to another file, Aspose.Slides ignores all macros (macros are not carried into the resulting file).
+
+{{% /alert %}}
+
+## **Add VBA Macros**
+
+Aspose.Slides provides the [VbaProject](https://reference.aspose.com/slides/python-net/aspose.slides.vba/vbaproject/) class to allow you to create VBA projects (and project references) and edit existing modules. You can use the [IVbaProject](https://reference.aspose.com/slides/net/aspose.slides.vba/ivbaproject/) interface to manage VBA embedded in a presentation.
+
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/) class.
+1. Use the [VbaProject](https://reference.aspose.com/slides/python-net/aspose.slides.vba/vbaproject/#constructors) constructor to add a new VBA project.
+1. Add a module to the VbaProject.
 1. Set the module source code.
 1. Add references to <stdole>.
 1. Add references to **Microsoft Office**.
-1. Associate the references with the **VbaProject**.
-1. Finally, write the PPTX file using the `Presentation` object.
+1. Associate the references with the VBA project.
+1. Save the presentation.
 
-The implementation of the above steps is demonstrated in the example below.
+This Python code shows you how to add a VBA macro from scratch to a presentation:
 
-```py
+```python
 import aspose.slides as slides
 
-# Instantiate Presentation
+# Creates an instance of the presentation class
 with slides.Presentation() as presentation:
-    # Create new VBA Project
+    # Creates a new VBA Project
     presentation.vba_project = slides.vba.VbaProject()
 
-    # add empty module to the VBA project
+    # Adds an empty module to the VBA project
     module = presentation.vba_project.modules.add_empty_module("Module")
   
-    # Set module source code
+    # Sets the module source code
     module.source_code = "Sub Test(oShape As Shape) MsgBox ""Test"" End Sub"
 
-    # Create reference to <stdole>
+    # Creates a reference to <stdole>
     stdoleReference = slides.vba.VbaReferenceOleTypeLib("stdole", "*\\G{00020430-0000-0000-C000-000000000046}#2.0#0#C:\\Windows\\system32\\stdole2.tlb#OLE Automation")
 
-    # Create reference to Office
+    # Creates a reference to Office
     officeReference =slides.vba.VbaReferenceOleTypeLib("Office", "*\\G{2DF8D04C-5BFA-101B-BDE5-00AA0044DE52}#2.0#0#C:\\Program Files\\Common Files\\Microsoft Shared\\OFFICE14\\MSO.DLL#Microsoft Office 14.0 Object Library")
 
-    # add references to the VBA project
+    # Adds references to the VBA project
     presentation.vba_project.references.add(stdoleReference)
     presentation.vba_project.references.add(officeReference)
 
             
-    # save Presentation
+    # Saves the Presentation
     presentation.save("AddVBAMacros_out.pptm", slides.export.SaveFormat.PPTM)
 ```
 
@@ -57,43 +66,44 @@ You may want to check out **Aspose** [Macro Remover](https://products.aspose.app
 {{% /alert %}} 
 
 ## **Remove VBA Macros**
-The `Presentation` class now has included the support to remove the VBA macros inside presentation. The following example shows how to access and remove a VBA macro in presentation.
 
-1. Create an instance of the `Presentation` class and load presentation with Macro.
-1. Access the Macro module and remove that
-1. Finally, write the PPTX file using the `Presentation` class object.
+Using the [VbaProject](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/#properties) property under the [Presentation](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/) class, you can remove a VBA macro.
 
-The implementation of the above steps is demonstrated in the example below.
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/) class and load the presentation containing the macro.
+1. Access the Macro module and remove it.
+1. Save the modified presentation.
 
-```py
+This Python code shows you how to remove a VBA macro:
+
+```python
 import aspose.slides as slides
 
-# Instantiate Presentation
+# Loads the presentation containing the macro
 with slides.Presentation(path + "VBA.pptm") as presentation:
-    # Access the Vba module and remove 
+    # Accesses the Vba module and removes it  
     presentation.vba_project.modules.remove(presentation.vba_project.modules[0])
 
-    # save Presentation
+    # saves the Presentation
     presentation.save("RemovedVBAMacros_out.pptm", slides.export.SaveFormat.PPTM)
 ```
 
-
 ## **Extract VBA Macros**
-Aspose.Slides for Python via .NET supports extracting VBA Macros from the slide. In order to extract VBA Macros, please follow the steps below:
 
-- Load a Presentation containing a VBA Macros
-- Check if Presentation contains VBA Project
-- Loop through all the modules that are contained in the VBA Project
+1. Create an instance of the  [Presentation](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/) class and load the presentation containing the macro.
+2. Check if the presentation contains a VBA Project.
+3. Loop through all the modules contained in the VBA Project to view the macros.
 
-The implementation of the above steps is demonstrated in the example below.
+This Python code shows you how to extract VBA macros from a presentation containing macros:
 
-```py
+```python
 import aspose.slides as slides
 
 with slides.Presentation(path + "VBA.pptm") as pres:
-    if pres.vba_project is not None: # check if Presentation contains VBA Project
+    if pres.vba_project is not None: # Checks whether the Presentation contains a VBA Project
         for module in pres.vba_project.modules:
             print(module.name)
             print(module.source_code)
 ```
+
+
 

--- a/python-net/developer-guide/presentation-via-vba/_index.md
+++ b/python-net/developer-guide/presentation-via-vba/_index.md
@@ -11,7 +11,11 @@ The [Aspose.Slides.Vba](https://reference.aspose.com/slides/python-net/aspose.sl
 
 {{% alert title="Note" color="warning" %}} 
 
-Aspose.Slides never runs the macros in a presentation. Additionally, in an operation where a PowerPoint presentation is converted to another file, Aspose.Slides ignores all macros (macros are not carried into the resulting file).
+When you convert a presentation containing macros to a different file format (PDF, HTML, etc.), Aspose.Slides ignores all macros (macros are not carried into the resulting file).
+
+When you add macros to a presentation or resave a presentation containing macros, Aspose.Slides simply writes the bytes for the macros.
+
+Aspose.Slides **never** runs the macros in a presentation.
 
 {{% /alert %}}
 


### PR DESCRIPTION
@yury-knml

_Aspose.Slides never runs the macros in a presentation. Additionally, in an operation where a PowerPoint presentation is converted to another file, Aspose.Slides ignores all macros (macros are not carried into the resulting file)._