### PR TITLE
SLIDESNET-44358: IPictureFillFormat.DeletePictureCroppedAreas method added to "Picture Frame" article

### DIFF
--- a/cpp/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/cpp/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -254,6 +254,24 @@ presentation->Save(outPptxFile, Aspose::Slides::Export::SaveFormat::Pptx);
 
 ```
 
+## Delete Cropped Areas of Picture
+
+If you want to delete the cropped areas of an image contained in a frame, you can use the [IPictureFillFormat::DeletePictureCroppedAreas()](https://reference.aspose.com/slides/cpp/aspose.slides/ipicturefillformat/deletepicturecroppedareas/) method. This method returns the cropped image or the origin image if cropping is unnecessary.
+
+This C++ code demonstrates the operation: xxx 
+
+```c++
+
+```
+
+{{% alert title="NOTE" color="warning" %}} 
+
+The [IPictureFillFormat::DeletePictureCroppedAreas()](https://reference.aspose.com/slides/cpp/aspose.slides/ipicturefillformat/deletepicturecroppedareas/) method adds the cropped image to the presentation image collection. If the image is only used in the processed [PictureFrame](https://reference.aspose.com/slides/cpp/aspose.slides/pictureframe/), this setup can reduce the presentation size. Otherwise, the number of images in the resulting presentation will increase.
+
+This method converts WMF/EMF metafiles to raster PNG image in the cropping operation. 
+
+{{% /alert %}}
+
 ## **Lock Aspect Ratio**
 
 If you want a shape containing an image to retain its aspect ratio even after you change the image dimensions, you can use the [set_AspectRatioLocked()](https://reference.aspose.com/slides/cpp/aspose.slides/ipictureframelock/set_aspectratiolocked/) method to set the *Lock Aspect Ratio* setting. 

--- a/cpp/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/cpp/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -258,10 +258,20 @@ presentation->Save(outPptxFile, Aspose::Slides::Export::SaveFormat::Pptx);
 
 If you want to delete the cropped areas of an image contained in a frame, you can use the [IPictureFillFormat::DeletePictureCroppedAreas()](https://reference.aspose.com/slides/cpp/aspose.slides/ipicturefillformat/deletepicturecroppedareas/) method. This method returns the cropped image or the origin image if cropping is unnecessary.
 
-This C++ code demonstrates the operation: xxx 
+This C++ code demonstrates the operation: 
 
 ```c++
+System::SharedPtr<Presentation> presentation = System::MakeObject<Presentation>(u"PictureFrameCrop.pptx");
+System::SharedPtr<ISlide> slide = presentation->get_Slide(0);
 
+// Gets the PictureFrame from the first slide
+System::SharedPtr<IPictureFrame> picFrame = System::AsCast<IPictureFrame>(slide->get_Shape(0));
+
+// Deletes cropped areas of the PictureFrame image and returns the cropped image
+System::SharedPtr<IPPImage> croppedImage = picFrame->get_PictureFormat()->DeletePictureCroppedAreas();
+
+// Saves the result
+presentation->Save(u"PictureFrameDeleteCroppedAreas.pptx", SaveFormat::Pptx);
 ```
 
 {{% alert title="NOTE" color="warning" %}} 

--- a/java/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/java/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -252,6 +252,24 @@ try {
 }
 ```
 
+## Delete Cropped Areas of Picture
+
+If you want to delete the cropped areas of an image contained in a frame, you can use the [deletePictureCroppedAreas()](https://reference.aspose.com/slides/java/com.aspose.slides/ipicturefillformat/#deletePictureCroppedAreas--) method. This method returns the cropped image or the origin image if cropping is unnecessary.
+
+This Java code demonstrates the operation:
+
+```java
+
+```
+
+{{% alert title="NOTE" color="warning" %}} 
+
+The [deletePictureCroppedAreas()](https://reference.aspose.com/slides/java/com.aspose.slides/ipicturefillformat/#deletePictureCroppedAreas--) method adds the cropped image to the presentation image collection. If the image is only used in the processed [PictureFrame](https://reference.aspose.com/slides/java/com.aspose.slides/pictureframe/), this setup can reduce the presentation size. Otherwise, the number of images in the resulting presentation will increase.
+
+This method converts WMF/EMF metafiles to raster PNG image in the cropping operation. 
+
+{{% /alert %}}
+
 ## **Lock Aspect Ratio**
 
 If you want a shape containing an image to retain its aspect ratio even after you change the image dimensions, you can use the [setAspectRatioLocked](https://reference.aspose.com/slides/java/com.aspose.slides/ipictureframelock/#setAspectRatioLocked-boolean-) method to set the *Lock Aspect Ratio* setting. 

--- a/java/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/java/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -259,7 +259,21 @@ If you want to delete the cropped areas of an image contained in a frame, you ca
 This Java code demonstrates the operation:
 
 ```java
+Presentation presentation = new Presentation("PictureFrameCrop.pptx");
+try {
+    ISlide slide = presentation.getSlides().get_Item(0);
 
+    // Gets the PictureFrame from the first slide
+    IPictureFrame picFrame = (IPictureFrame)slide.getShapes().get_Item(0);
+
+    // Deletes cropped areas of the PictureFrame image and returns the cropped image
+    IPPImage croppedImage = picFrame.getPictureFormat().deletePictureCroppedAreas();
+
+    // Saves the result
+    presentation.save("PictureFrameDeleteCroppedAreas.pptx", SaveFormat.Pptx);
+} finally {
+    if (presentation != null) presentation.dispose();
+}
 ```
 
 {{% alert title="NOTE" color="warning" %}} 

--- a/net/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/net/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -248,7 +248,7 @@ using (Presentation presentation = new Presentation())
 
 ## Delete Cropped Areas of Picture
 
-If you want to delete the cropped areas of the contained image, you can use the [IPictureFillFormat.DeletePictureCroppedAreas](https://reference.aspose.com/slides/net/aspose.slides/ipicturefillformat/deletepicturecroppedareas/) method. This method returns the cropped image or the origin image if cropping is not necessary.
+If you want to delete the cropped areas of an image contained in a frame, you can use the [IPictureFillFormat.DeletePictureCroppedAreas](https://reference.aspose.com/slides/net/aspose.slides/ipicturefillformat/deletepicturecroppedareas/) method. This method returns the cropped image or the origin image if cropping is unnecessary.
 
 This C# code demonstrates the operation:
 
@@ -270,9 +270,9 @@ using (Presentation presentation = new Presentation("PictureFrameCrop.pptx"))
 
 {{% alert title="NOTE" color="warning" %}} 
 
-The [IPictureFillFormat.DeletePictureCroppedAreas](https://reference.aspose.com/slides/net/aspose.slides/ipicturefillformat/deletepicturecroppedareas/) adds the cropped image to the presentation image collection. If the image is only used in the processed [PictureFrame](https://reference.aspose.com/slides/net/aspose.slides/pictureframe/), it can help reduce presentation size. Otherwise the number of images in the result presentation will increase.
+The [IPictureFillFormat.DeletePictureCroppedAreas](https://reference.aspose.com/slides/net/aspose.slides/ipicturefillformat/deletepicturecroppedareas/) method adds the cropped image to the presentation image collection. If the image is only used in the processed [PictureFrame](https://reference.aspose.com/slides/net/aspose.slides/pictureframe/), this setup can reduce the presentation size. Otherwise, the number of images in the resulting presentation will increase.
 
-This method converts WMF/EMF metafiles to raster PNG image while cropping.
+This method converts WMF/EMF metafiles to raster PNG image in the cropping operation. 
 
 {{% /alert %}}
 
@@ -292,7 +292,7 @@ using (Presentation pres = new Presentation("pres.pptx"))
 
     IPictureFrame pictureFrame = emptySlide.Shapes.AddPictureFrame(ShapeType.Rectangle, 50, 150, presImage.Width, presImage.Height, presImage);
 
-    // set shape to have to preserve aspect ratio on resizing
+    // Sets shape to preserve aspect ratio on resizing
     pictureFrame.PictureFrameLock.AspectRatioLocked = true;
 }
 ```
@@ -305,7 +305,7 @@ This *Lock Aspect Ratio* setting preserves only the aspect ratio of the shape an
 
 ## **Use StretchOff Property**
 
-Using the [StretchOffsetLeft](https://reference.aspose.com/slides/net/aspose.slides/picturefillformat/properties/stretchoffsetleft), [StretchOffsetTop](https://reference.aspose.com/slides/net/aspose.slides/picturefillformat/properties/stretchoffsettop), [StretchOffsetRight](https://reference.aspose.com/slides/net/aspose.slides/picturefillformat/properties/stretchoffsetright) and [StretchOffsetBottom](https://reference.aspose.com/slides/net/aspose.slides/picturefillformat/properties/stretchoffsetbottom) properties from the [IPictureFillFormat](https://reference.aspose.com/slides/net/aspose.slides/ipicturefillformat) interface and [PictureFillFormat](https://reference.aspose.com/slides/net/aspose.slides/picturefillformat) class, you can specify a fill rectangle. 
+Using the [StretchOffsetLeft](https://reference.aspose.com/slides/net/aspose.slides/picturefillformat/properties/stretchoffsetleft), [StretchOffsetTop](https://reference.aspose.com/slides/net/aspose.slides/picturefillformat/properties/stretchoffsettop), [StretchOffsetRight,](https://reference.aspose.com/slides/net/aspose.slides/picturefillformat/properties/stretchoffsetright) and [StretchOffsetBottom](https://reference.aspose.com/slides/net/aspose.slides/picturefillformat/properties/stretchoffsetbottom) properties from the [IPictureFillFormat](https://reference.aspose.com/slides/net/aspose.slides/ipicturefillformat) interface and [PictureFillFormat](https://reference.aspose.com/slides/net/aspose.slides/picturefillformat) class, you can specify a fill rectangle. 
 
 When stretching is specified for an image, a source rectangle is scaled to fit the specified fill rectangle. Each edge of the fill rectangle is defined by a percentage offset from the corresponding edge of the shape's bounding box. A positive percentage specifies an inset while a negative percentage specifies an outset.
 

--- a/net/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/net/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -242,9 +242,39 @@ using (Presentation presentation = new Presentation())
     picFrame.PictureFormat.CropBottom = 31;
 
     // Saves the result
-    presentation.Save(outPptxFile, SaveFormat.Pptx);
+    presentation.Save("PictureFrameCrop.pptx", SaveFormat.Pptx);
 }
 ```
+
+## Delete Cropped Areas of Picture
+
+If you want to delete the cropped areas of the contained image, you can use the [IPictureFillFormat.DeletePictureCroppedAreas](https://reference.aspose.com/slides/net/aspose.slides/ipicturefillformat/deletepicturecroppedareas/) method. This method returns the cropped image or the origin image if cropping is not necessary.
+
+This C# code demonstrates the operation:
+
+```c#
+using (Presentation presentation = new Presentation("PictureFrameCrop.pptx"))
+{
+    ISlide slide = presentation.Slides[0];
+
+    // Gets the PictureFrame from the first slide
+    IPictureFrame picFrame = slide.Shapes[0] as IPictureFrame;
+
+    // Deletes cropped areas of the PictureFrame image and returns the cropped image
+    IPPImage croppedImage = picFrame.PictureFormat.DeletePictureCroppedAreas();
+
+    // Saves the result
+    presentation.Save("PictureFrameDeleteCroppedAreas.pptx", SaveFormat.Pptx);
+}
+```
+
+{{% alert title="NOTE" color="warning" %}} 
+
+The [IPictureFillFormat.DeletePictureCroppedAreas](https://reference.aspose.com/slides/net/aspose.slides/ipicturefillformat/deletepicturecroppedareas/) adds the cropped image to the presentation image collection. If the image is only used in the processed [PictureFrame](https://reference.aspose.com/slides/net/aspose.slides/pictureframe/), it can help reduce presentation size. Otherwise the number of images in the result presentation will increase.
+
+This method converts WMF/EMF metafiles to raster PNG image while cropping.
+
+{{% /alert %}}
 
 ## **Lock Aspect Ratio**
 

--- a/python-net/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/python-net/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -230,6 +230,24 @@ with slides.Presentation() as presentation:
 
 ```
 
+## Delete Cropped Areas of Picture
+
+If you want to delete the cropped areas of an image contained in a frame, you can use the `delete_picture_cropped_areas` (xxx - where is the method? It does not exist in the python API reference) method. This method returns the cropped image or the origin image if cropping is unnecessary.
+
+This Python code demonstrates the operation: xxx
+
+```c#
+
+```
+
+{{% alert title="NOTE" color="warning" %}} 
+
+The delete_picture_cropped_areas method adds the cropped image to the presentation image collection. If the image is only used in the processed [PictureFrame](https://reference.aspose.com/slides/python-net/aspose.slides/pictureframe/), this setup can reduce the presentation size. Otherwise, the number of images in the resulting presentation will increase.
+
+This method converts WMF/EMF metafiles to raster PNG image in the cropping operation. 
+
+{{% /alert %}}
+
 ## **Lock Aspect Ratio**
 
 If you want a shape containing an image to retain its aspect ratio even after you change the image dimensions, you can use the *aspect_ratio_locked* property to set the *Lock Aspect Ratio* setting. 

--- a/python-net/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/python-net/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -232,12 +232,24 @@ with slides.Presentation() as presentation:
 
 ## Delete Cropped Areas of Picture
 
-If you want to delete the cropped areas of an image contained in a frame, you can use the `delete_picture_cropped_areas` (xxx - where is the method? It does not exist in the python API reference) method. This method returns the cropped image or the origin image if cropping is unnecessary.
+If you want to delete the cropped areas of an image contained in a frame, you can use the [delete_picture_cropped_areas](https://reference.aspose.com/slides/python-net/aspose.slides/ipicturefillformat/) method. This method returns the cropped image or the origin image if cropping is unnecessary.
 
-This Python code demonstrates the operation: xxx
+This Python code demonstrates the operation:
 
-```c#
+```python
+import aspose.slides as slides
 
+with slides.Presentation(path + "PictureFrameCrop.pptx") as pres:
+    slide = pres.slides[0]
+
+    # Gets the PictureFrame from the first slide
+    picture_frame = slides.shape[0]
+
+    # Deletes cropped areas of the PictureFrame image and returns the cropped image
+    cropped_image = picture_frame.picture_format.delete_picture_cropped_areas()
+
+    # Saves the result
+    pres.save(path + "PictureFrameDeleteCroppedAreas.pptx", slides.export.SaveFormat.PPTX)
 ```
 
 {{% alert title="NOTE" color="warning" %}} 


### PR DESCRIPTION
[SLIDESNET-44358](https://issue.lutsk.dynabic.com/issues/SLIDESNET-44358)