### PR TITLE
SLIDESDOC-496 The size and location of OLE object frame is changed after updating links

### DIFF
--- a/en/androidjava/developer-guide/presentation-content/manage-ole/_index.md
+++ b/en/androidjava/developer-guide/presentation-content/manage-ole/_index.md
@@ -3,6 +3,21 @@ title: Manage OLE
 type: docs
 weight: 40
 url: /androidjava/manage-ole/
+keywords:
+- add OLE
+- embed OLE
+- add an object
+- embed an object
+- embed a file
+- linked object
+- Object Linking & Embedding
+- OLE object
+- PowerPoint 
+- presentation
+- Android
+- Java
+- Aspose.Slides for Android via Java
+description: Add OLE objects to PowerPoint presentations in Java
 ---
 
 {{% alert color="primary" %}} 
@@ -265,6 +280,14 @@ try {
 } finally {
     if (pres != null) pres.dispose();
 }
+```
+
+## **Prevent an OLE Object Frame from Being Resized and Pepositioned**
+
+After you add a linked OLE object to a presentation slide, when you open the presentation in PowerPoint, you might see a message asking you to update the links. Clicking the "Update Links" button may change the size and position of the OLE object frame because PowerPoint updates the data from the linked OLE object and refreshes the object preview. To prevent PowerPoint from prompting to update the object's data, set the `setUpdateAutomatic` method of the [IOleObjectFrame](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ioleobjectframe/) interface to `false`:
+
+```java
+oleObjectFrame.setUpdateAutomatic(false);
 ```
 
 ## Extracting Embedded Files

--- a/en/cpp/developer-guide/presentation-content/manage-ole/_index.md
+++ b/en/cpp/developer-guide/presentation-content/manage-ole/_index.md
@@ -3,8 +3,20 @@ title: Manage OLE
 type: docs
 weight: 40
 url: /cpp/manage-ole/
-keywords: "Add OLE, Add object, Embed object Object Linking & Embedding, OLE Object Frame, Embed OLE, PowerPoint presentation, C++, CPP, Aspose.Slides for C++ "
-description: "Add OLE object to PowerPoint presentation in C++"
+keywords:
+- add OLE
+- embed OLE
+- add an object
+- embed an object
+- embed a file
+- linked object
+- Object Linking & Embedding
+- OLE object
+- PowerPoint 
+- presentation
+- C++
+- Aspose.Slides for C++
+description: Add OLE objects to PowerPoint presentations in C++
 ---
 
 {{% alert title="Info" color="info" %}}
@@ -263,6 +275,14 @@ oleObjectFrame->get_SubstitutePictureFormat()->get_Picture()->set_Image(oleImage
 oleObjectFrame->set_IsObjectIcon(false);
 
 pres->Save(u"embeddedOle-newImage.pptx", SaveFormat::Pptx);
+```
+
+## **Prevent an OLE Object Frame from Being Resized and Pepositioned**
+
+After you add a linked OLE object to a presentation slide, when you open the presentation in PowerPoint, you might see a message asking you to update the links. Clicking the "Update Links" button may change the size and position of the OLE object frame because PowerPoint updates the data from the linked OLE object and refreshes the object preview. To prevent PowerPoint from prompting to update the object's data, set the `set_UpdateAutomatic` method of the [IOleObjectFrame](https://reference.aspose.com/slides/cpp/aspose.slides/ioleobjectframe/) interface to `false`:
+
+```cpp
+oleObjectFrame->set_UpdateAutomatic(false);
 ```
 
 ## Extracting Embedded Files

--- a/en/java/developer-guide/presentation-content/manage-ole/_index.md
+++ b/en/java/developer-guide/presentation-content/manage-ole/_index.md
@@ -3,6 +3,20 @@ title: Manage OLE
 type: docs
 weight: 40
 url: /java/manage-ole/
+keywords:
+- add OLE
+- embed OLE
+- add an object
+- embed an object
+- embed a file
+- linked object
+- Object Linking & Embedding
+- OLE object
+- PowerPoint 
+- presentation
+- Java
+- Aspose.Slides for Java
+description: Add OLE objects to PowerPoint presentations in Java
 ---
 
 {{% alert color="primary" %}} 
@@ -265,6 +279,14 @@ try {
 } finally {
     if (pres != null) pres.dispose();
 }
+```
+
+## **Prevent an OLE Object Frame from Being Resized and Pepositioned**
+
+After you add a linked OLE object to a presentation slide, when you open the presentation in PowerPoint, you might see a message asking you to update the links. Clicking the "Update Links" button may change the size and position of the OLE object frame because PowerPoint updates the data from the linked OLE object and refreshes the object preview. To prevent PowerPoint from prompting to update the object's data, set the `setUpdateAutomatic` method of the [IOleObjectFrame](https://reference.aspose.com/slides/java/com.aspose.slides/ioleobjectframe/) interface to `false`:
+
+```java
+oleObjectFrame.setUpdateAutomatic(false);
 ```
 
 ## Extracting Embedded Files

--- a/en/net/developer-guide/presentation-content/manage-ole/_index.md
+++ b/en/net/developer-guide/presentation-content/manage-ole/_index.md
@@ -17,7 +17,7 @@ keywords:
 - C#
 - Csharp
 - Aspose.Slides for .NET
-description: "Add OLE objects to PowerPoint presentations in C# or .NET"
+description: Add OLE objects to PowerPoint presentations in C# or .NET
 ---
 
 {{% alert title="Info" color="info" %}}
@@ -295,7 +295,7 @@ using (Presentation pres = new Presentation("embeddedOle.pptx"))
 
 ## **Prevent an OLE Object Frame from Being Resized and Pepositioned**
 
-After you add a linked OLE object to a presentation slide, when you open the presentation in PowerPoint, you might see a message asking you to update the links. Clicking the "Update Links" button may change the size and position of the OLE object frame because PowerPoint updates the data from the linked OLE object and refreshes the object preview. To prevent PowerPoint from prompting to update the object's data, set the `UpdateAutomatic` property of the `OleObjectFrame` to `false`:
+After you add a linked OLE object to a presentation slide, when you open the presentation in PowerPoint, you might see a message asking you to update the links. Clicking the "Update Links" button may change the size and position of the OLE object frame because PowerPoint updates the data from the linked OLE object and refreshes the object preview. To prevent PowerPoint from prompting to update the object's data, set the `UpdateAutomatic` property of the [IOleObjectFrame](https://reference.aspose.com/slides/net/aspose.slides/ioleobjectframe/) interface to `false`:
 
 ```cs
 oleObjectFrame.UpdateAutomatic = false;

--- a/en/net/developer-guide/presentation-content/manage-ole/_index.md
+++ b/en/net/developer-guide/presentation-content/manage-ole/_index.md
@@ -3,8 +3,21 @@ title: Manage OLE
 type: docs
 weight: 40
 url: /net/manage-ole/
-keywords: "Add OLE, Add object, Embed object Object Linking & Embedding, OLE Object Frame, Embed OLE, PowerPoint presentation, C#, Csharp, Aspose.Slides for .NET "
-description: "Add OLE object to PowerPoint presentation in C# or .NET"
+keywords:
+- add OLE
+- embed OLE
+- add an object
+- embed an object
+- embed a file
+- linked object
+- Object Linking & Embedding
+- OLE object
+- PowerPoint 
+- presentation
+- C#
+- Csharp
+- Aspose.Slides for .NET
+description: "Add OLE objects to PowerPoint presentations in C# or .NET"
 ---
 
 {{% alert title="Info" color="info" %}}
@@ -279,6 +292,15 @@ using (Presentation pres = new Presentation("embeddedOle.pptx"))
     pres.Save("embeddedOle-newImage.pptx", SaveFormat.Pptx);
 }
 ```
+
+## **Prevent an OLE Object Frame from Being Resized and Pepositioned**
+
+After you add a linked OLE object to a presentation slide, when you open the presentation in PowerPoint, you might see a message asking you to update the links. Clicking the "Update Links" button may change the size and position of the OLE object frame because PowerPoint updates the data from the linked OLE object and refreshes the object preview. To prevent PowerPoint from prompting to update the object's data, set the `UpdateAutomatic` property of the `OleObjectFrame` to `false`:
+
+```cs
+oleObjectFrame.UpdateAutomatic = false;
+```
+
 ## **Extracting Embedded Files**
 
 Aspose.Slides for .NET allows you to extract the files embedded in slides as OLE objects this way:

--- a/en/php-java/developer-guide/presentation-content/manage-ole/_index.md
+++ b/en/php-java/developer-guide/presentation-content/manage-ole/_index.md
@@ -3,6 +3,21 @@ title: Manage OLE
 type: docs
 weight: 40
 url: /php-java/manage-ole/
+keywords:
+- add OLE
+- embed OLE
+- add an object
+- embed an object
+- embed a file
+- linked object
+- Object Linking & Embedding
+- OLE object
+- PowerPoint 
+- presentation
+- PHP
+- Java
+- Aspose.Slides for PHP via Java
+description: Add OLE objects to PowerPoint presentations in PHP
 ---
 
 {{% alert color="primary" %}} 
@@ -286,6 +301,14 @@ This PHP code shows you how to set the icon image and title for an embedded obje
       $pres->dispose();
     }
   }
+```
+
+## **Prevent an OLE Object Frame from Being Resized and Pepositioned**
+
+After you add a linked OLE object to a presentation slide, when you open the presentation in PowerPoint, you might see a message asking you to update the links. Clicking the "Update Links" button may change the size and position of the OLE object frame because PowerPoint updates the data from the linked OLE object and refreshes the object preview. To prevent PowerPoint from prompting to update the object's data, set the `setUpdateAutomatic` method of the [OleObjectFrame](https://reference.aspose.com/slides/php-java/aspose.slides/oleobjectframe/) class to `false`:
+
+```php
+$oleObjectFrame->setUpdateAutomatic(false);
 ```
 
 ## Extracting Embedded Files

--- a/en/python-net/developer-guide/presentation-content/manage-ole/_index.md
+++ b/en/python-net/developer-guide/presentation-content/manage-ole/_index.md
@@ -3,8 +3,20 @@ title: Manage OLE
 type: docs
 weight: 40
 url: /python-net/manage-ole/
-keywords: "Add OLE, Add object, Embed object Object Linking & Embedding, OLE Object Frame, Embed OLE, PowerPoint presentation, Python, Aspose.Slides for Python via .NET "
-description: "Add OLE object to PowerPoint presentation in Python"
+keywords:
+- add OLE
+- embed OLE
+- add an object
+- embed an object
+- embed a file
+- linked object
+- Object Linking & Embedding
+- OLE object
+- PowerPoint 
+- presentation
+- Python
+- Aspose.Slides for Python via .NET
+description: Add OLE objects to PowerPoint presentations in Python
 ---
 
 {{% alert title="Info" color="info" %}}
@@ -198,7 +210,13 @@ with slides.Presentation("embeddedOle.pptx") as pres:
     pres.save("embeddedOle-newImage.pptx", slides.export.SaveFormat.PPTX)
 ```
 
+## **Prevent an OLE Object Frame from Being Resized and Pepositioned**
 
+After you add a linked OLE object to a presentation slide, when you open the presentation in PowerPoint, you might see a message asking you to update the links. Clicking the "Update Links" button may change the size and position of the OLE object frame because PowerPoint updates the data from the linked OLE object and refreshes the object preview. To prevent PowerPoint from prompting to update the object's data, set the `update_automatic` property of the [OleObjectFrame](https://reference.aspose.com/slides/python-net/aspose.slides/oleobjectframe/) class to `False`:
+
+```py
+oleObjectFrame.update_automatic = False
+```
 
 ## Extracting Embedded Files
 


### PR DESCRIPTION
Updated keywords and added the section "Prevent an OLE Object Frame from Being Resized and Pepositioned" to the article "Manage OLE" (.NET).