### PR TITLE
SLIDESDOC-507 The article "API Reference" is missing for Python via .NET and Android via Java

### DIFF
--- a/en/androidjava/api-reference/_index.md
+++ b/en/androidjava/api-reference/_index.md
@@ -1,0 +1,21 @@
+---
+title: API Reference
+type: docs
+weight: 50
+url: /androidjava/api-reference/
+keywords:
+- API reference
+- PowerPoint
+- presentation
+- Android
+- Java
+- Aspose.Slides for Android via Java
+---
+
+{{% alert color="primary" %}} 
+
+Aspose.Slides for Android via Java is a class library that enables Java applications for Android to read and write presentation documents without using Microsoft PowerPoint® or other software. Aspose.Slides for Android via Java allows you to manage text, shapes, tables, and animations; add audio and video to slides; preview slides; and export slides to SVG, PDF format, and more.
+
+Latest API Reference can be found at [Aspose.Slides for Android via Java API Reference](https://reference.aspose.com/slides/androidjava/).
+
+{{% /alert %}}

--- a/en/python-net/api-reference/_index.md
+++ b/en/python-net/api-reference/_index.md
@@ -1,31 +1,21 @@
 ---
-title: Aspose.Slides for Python via .NET
-second_title: Aspose.Sildes for Python via .NET API Reference
-description: 
+title: API Reference
 type: docs
-weight: 10
+weight: 50
 url: /python-net/api-reference/
+keywords:
+- API reference
+- PowerPoint
+- presentation
+- Python
+- .NET
+- Aspose.Slides for Python via .NET
 ---
 
-## Namespaces
-| Namespace | Description |
-| :- | :- |
-|[aspose.slides](/slides/python-net/api-reference/aspose.slides/)|Contains classes for work with Microsoft PowerPoint presentations without utilizing Microsoft PowerPoint.|
-|[aspose.slides.animation](/slides/python-net/api-reference/aspose.slides.animation/)|Contains classes for work with animation in Microsoft PowerPoint presentations.|
-|[aspose.slides.charts](/slides/python-net/api-reference/aspose.slides.charts/)|Contains classes for work with charts in Microsoft PowerPoint presentations.|
-|[aspose.slides.dom.ole](/slides/python-net/api-reference/aspose.slides.dom.ole/)|Contains classes for work with OLE objects in Microsoft PowerPoint presentations.|
-|[aspose.slides.effects](/slides/python-net/api-reference/aspose.slides.effects/)|Contains classes for work with various effects in Microsoft PowerPoint presentations.|
-|[aspose.slides.export](/slides/python-net/api-reference/aspose.slides.export/)|Contains classes for exporting Microsoft PowerPoint presentations to different formats like HTML, PDF, SVG, XPS and others.|
-|[aspose.slides.export.web](/slides/python-net/api-reference/aspose.slides.export.web/)|Contains classes for exporting Microsoft PowerPoint presentations to HTML with extension projects.|
-|[aspose.slides.export.xaml](/slides/python-net/api-reference/aspose.slides.export.xaml/)|Contains classes for exporting Microsoft PowerPoint presentations to XAML.|
-|[aspose.slides.import](/slides/python-net/api-reference/aspose.slides.import/)|Contains classes for importing data into Microsoft PowerPoint presentations.|
-|[aspose.slides.ink](/slides/python-net/api-reference/aspose.slides.ink/)|Contains classes for work with Ink|
-|[aspose.slides.lowcode](/slides/python-net/api-reference/aspose.slides.lowcode/)|Contains classes that allows you to perform popular operations using only a few lines of code.|
-|[aspose.slides.mathtext](/slides/python-net/api-reference/aspose.slides.mathtext/)|Contains classes for work with mathematical text in Microsoft PowerPoint presentations.|
-|[aspose.slides.slideshow](/slides/python-net/api-reference/aspose.slides.slideshow/)|Contains classes for managing slideshows and slide transitions.|
-|[aspose.slides.smartart](/slides/python-net/api-reference/aspose.slides.smartart/)|Contains classes for work with SmartArt objects.|
-|[aspose.slides.spreadsheet](/slides/python-net/api-reference/aspose.slides.spreadsheet/)|Contains classes for work with spreadsheet objects in Microsoft PowerPoint presentations.|
-|[aspose.slides.theme](/slides/python-net/api-reference/aspose.slides.theme/)|Contains classes for work with different types of themes.|
-|[aspose.slides.util](/slides/python-net/api-reference/aspose.slides.util/)|Contains util classes that helps to work with presentations.|
-|[aspose.slides.vba](/slides/python-net/api-reference/aspose.slides.vba/)|Contains classes for work with VBA macros.|
-|[aspose.slides.warnings](/slides/python-net/api-reference/aspose.slides.warnings/)|Contains classes that represents various kind of warnings.|
+{{% alert color="primary" %}} 
+
+Aspose.Slides for Python via .NET is a class library that enables Python applications to read and write presentation documents without using Microsoft PowerPoint® or other software. Aspose.Slides for Python via .NET allows you to manage text, shapes, tables, and animations; add audio and video to slides; preview slides; and export slides to SVG, PDF format, and more.
+
+Latest API Reference can be found at [Aspose.Slides for Python via .NET API Reference](https://reference.aspose.com/slides/python-net/).
+
+{{% /alert %}}


### PR DESCRIPTION
Updated the article "API Reference" for Python via .NET. Added the article "API Reference" for Android via Java.