### PR TITLE
SLIDESDOC-503 "keySlides" field in the header of articles

### DIFF
--- a/en/nodejs-net/getting-started/installation/_index.md
+++ b/en/nodejs-net/getting-started/installation/_index.md
@@ -3,7 +3,15 @@ title: Installation
 type: docs
 weight: 70
 url: /nodejs-net/installation/
-keySlides: "Download Aspose.Slides, Install Aspose.Slides, Aspose.Slides Installation, Windows, macOS, Linux, JavaScript, Node.js"
+keywords:
+- download Aspose.Slides
+- install Aspose.Slides
+- Aspose.Slides installation
+- Windows
+- macOS
+- Linux
+- JavaScript
+- Node.js
 description: "Install Aspose.Slides for Node.js via .NET in Windows, Linux or macOS"
 ---
 

--- a/en/php-java/getting-started/installation/_index.md
+++ b/en/php-java/getting-started/installation/_index.md
@@ -3,7 +3,14 @@ title: Installation
 type: docs
 weight: 70
 url: /php-java/installation/
-keySlides: "Download Aspose.Slides, Install Aspose.Slides, Aspose.Slides Installation, Windows, macOS, Linux, PHP"
+keywords:
+- download Aspose.Slides
+- install Aspose.Slides
+- Aspose.Slides installation
+- Windows
+- macOS
+- Linux
+- PHP
 description: "Install Aspose.Slides for PHP via Java in Windows, Linux or macOS"
 ---
 

--- a/en/python-java/getting-started/installation/_index.md
+++ b/en/python-java/getting-started/installation/_index.md
@@ -3,7 +3,14 @@ title: Installation
 type: docs
 weight: 70
 url: /python-java/installation/
-keySlides: "Download Aspose.Slides, Install Aspose.Slides, Aspose.Slides Installation, Windows, macOS, Linux, Python"
+keywords:
+- download Aspose.Slides
+- install Aspose.Slides
+- Aspose.Slides installation
+- Windows
+- macOS
+- Linux
+- Python
 description: "Install Aspose.Slides for Python via Java in Windows, Linux or macOS"
 ---
 


### PR DESCRIPTION
Replaced the  "keySlides" field with "keywords".