### PR TITLE
SLIDESDOC-472 Detecting if a rectangle is a "real" text box

### DIFF
--- a/en/androidjava/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
+++ b/en/androidjava/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
@@ -3,7 +3,18 @@ title: Manage TextBox
 type: docs
 weight: 20
 url: /androidjava/manage-textbox/
-description: Create Text Box on PowerPoint Slides using Java. Add Column in Text Box or Text Frame in PowerPoint Slides using Java. Add Text Box with Hyperlink in PowerPoint Slides using Java.
+keywords:
+- text box
+- text frame
+- add text
+- update text
+- text box with a hyperlink
+- PowerPoint
+- presentation
+- Android
+- Java
+- Aspose.Slides for Android via Java
+description: "Manage a text box or text frame in PowerPoint presentations using Java"
 ---
 
 
@@ -67,26 +78,51 @@ try {
 
 ## **Check for Text Box Shape**
 
-Aspose.Slides provides the [isTextBox()](https://reference.aspose.com/slides/androidjava/com.aspose.slides/autoshape/#isTextBox--) property (from the [AutoShape](https://reference.aspose.com/slides/androidjava/com.aspose.slides/autoshape/) class) to allow you to examine shapes and find text boxes.
+Aspose.Slides provides the [isTextBox](https://reference.aspose.com/slides/net/aspose.slides/autoshape/istextbox/) method from the [IAutoShape](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iautoshape/) interface, allowing you to examine shapes and identify text boxes.
 
 ![Text box and shape](istextbox.png)
 
 This Java code shows you how to check whether a shape was created as a text box: 
 
 ```java
-Presentation pres = new Presentation("pres.pptx");
+Presentation presentation = new Presentation("sample.pptx");
 try {
-    ForEach.shape(pres, (shape, slide, index) ->
-    {
-        if (shape instanceof AutoShape)
-        {
-            AutoShape autoShape = (AutoShape)shape;
-            System.out.println(autoShape.isTextBox() ? "shape is text box" : "shape is text not box");
+    ForEach.shape(presentation, (shape, slide, index) -> {
+        if (shape instanceof IAutoShape) {
+            IAutoShape autoShape = (IAutoShape) shape;
+            System.out.println(autoShape.isTextBox() ? "shape is a text box" : "shape is not a text box");
         }
     });
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
+```
+
+Note that if you simply add an autoshape using the `addAutoShape` method from the [IShapeCollection](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ishapecollection/) interface, the `isTextBox` method of the autoshape will return `false`. However, after you add text to the autoshape using the `addTextFrame` method or the `setText` method, the `isTextBox` property returns `true`.
+
+```java
+Presentation presentation = new Presentation();
+ISlide slide = presentation.getSlides().get_Item(0);
+
+IAutoShape shape1 = slide.getShapes().addAutoShape(ShapeType.Rectangle, 10, 10, 100, 40);
+// shape1.isTextBox() returns false
+shape1.addTextFrame("shape 1");
+// shape1.isTextBox() returns true
+
+IAutoShape shape2 = slide.getShapes().addAutoShape(ShapeType.Rectangle, 10, 110, 100, 40);
+// shape2.isTextBox() returns false
+shape2.getTextFrame().setText("shape 2");
+// shape2.isTextBox() returns true
+
+IAutoShape shape3 = slide.getShapes().addAutoShape(ShapeType.Rectangle, 10, 210, 100, 40);
+// shape3.isTextBox() returns false
+shape3.addTextFrame("");
+// shape3.isTextBox() returns false
+
+IAutoShape shape4 = slide.getShapes().addAutoShape(ShapeType.Rectangle, 10, 310, 100, 40);
+// shape4.isTextBox() returns false
+shape4.getTextFrame().setText("");
+// shape4.isTextBox() returns false
 ```
 
 ## **Add Column In Text Box**

--- a/en/androidjava/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
+++ b/en/androidjava/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
@@ -78,7 +78,7 @@ try {
 
 ## **Check for Text Box Shape**
 
-Aspose.Slides provides the [isTextBox](https://reference.aspose.com/slides/net/aspose.slides/autoshape/istextbox/) method from the [IAutoShape](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iautoshape/) interface, allowing you to examine shapes and identify text boxes.
+Aspose.Slides provides the [isTextBox](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iautoshape/#isTextBox--) method from the [IAutoShape](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iautoshape/) interface, allowing you to examine shapes and identify text boxes.
 
 ![Text box and shape](istextbox.png)
 

--- a/en/cpp/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
+++ b/en/cpp/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
@@ -3,8 +3,17 @@ title: Manage TextBox
 type: docs
 weight: 20
 url: /cpp/manage-textbox/
-keywords: "Textbox, Text frame, Add textbox, Textbox with hyperlink, C++, Aspose.Slides for C++"
-description: "Add textbox or text frame to PowerPoint presentations in C++"
+keywords:
+- text box
+- text frame
+- add text
+- update text
+- text box with a hyperlink
+- PowerPoint
+- presentation
+- C++
+- Aspose.Slides for .С++
+description: "Manage a text box or text frame in PowerPoint presentations using C++"
 ---
 
 Texts on slides typically exist in text boxes or shapes. Therefore, to add a text to a slide, you have to add a text box and then put some text inside the textbox. Aspose.Slides for C++ provides the [IAutoShape](https://reference.aspose.com/slides/cpp/class/aspose.slides.i_auto_shape) interface that allows you to add a shape containing some text.
@@ -71,18 +80,47 @@ Aspose.Slides provides the [get_IsTextBox()](https://reference.aspose.com/slides
 This C++ code shows you how to check whether a shape was created as a text box: 
 
 ```c++
-auto pres = System::MakeObject<Presentation>(u"pres.pptx");
-for (auto&& slide : pres->get_Slides())
+auto presentation = MakeObject<Presentation>(u"sample.pptx");
+for (auto&& slide : presentation->get_Slides())
 {
     for (auto&& shape : slide->get_Shapes())
     {
-        auto autoShape = System::DynamicCast_noexcept<Aspose::Slides::AutoShape>(shape);
-        if (autoShape != nullptr)
+        if (ObjectExt::Is<IAutoShape>(shape))
         {
-            System::Console::WriteLine(autoShape->get_IsTextBox() ? System::String(u"shape is text box") : System::String(u"shape is not text box"));
+            auto autoShape = ExplicitCast<IAutoShape>(shape);
+            Console::WriteLine(autoShape->get_IsTextBox() ? u"shape is a text box" : u"shape is not a text box");
         }
     }
 }
+
+presentation->Dispose();
+```
+
+Note that if you simply add an autoshape using the `AddAutoShape` method from the [IShapeCollection](https://reference.aspose.com/slides/cpp/aspose.slides/ishapecollection/) interface, the `get_IsTextBox` method of the autoshape will return `false`. However, after you add text to the autoshape using the `AddTextFrame` method or the `set_Text` method, the `get_IsTextBox` method returns `true`.
+
+```cpp
+auto presentation = MakeObject<Presentation>();
+auto slide = presentation->get_Slide(0);
+
+auto shape1 = slide->get_Shapes()->AddAutoShape(ShapeType::Rectangle, 10, 10, 100, 40);
+// shape1->get_IsTextBox() returns false
+shape1->AddTextFrame(u"shape 1");
+// shape1->get_IsTextBox() returns true
+
+auto shape2 = slide->get_Shapes()->AddAutoShape(ShapeType::Rectangle, 10, 110, 100, 40);
+// shape2->get_IsTextBox() returns false
+shape2->get_TextFrame()->set_Text(u"shape 2");
+// shape2->get_IsTextBox() returns true
+
+auto shape3 = slide->get_Shapes()->AddAutoShape(ShapeType::Rectangle, 10, 210, 100, 40);
+// shape3->get_IsTextBox() returns false
+shape3->AddTextFrame(u"");
+// shape3->get_IsTextBox() returns false
+
+auto shape4 = slide->get_Shapes()->AddAutoShape(ShapeType::Rectangle, 10, 310, 100, 40);
+// shape4->get_IsTextBox() returns false
+shape4->get_TextFrame()->set_Text(u"");
+// shape4->get_IsTextBox() returns false
 ```
 
 ## **Add Column In Text Box**

--- a/en/cpp/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
+++ b/en/cpp/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
@@ -73,7 +73,7 @@ pres->Save(u"TextBox_out.pptx", SaveFormat::Pptx);
 
 ## **Check for Text Box Shape**
 
-Aspose.Slides provides the [get_IsTextBox()](https://reference.aspose.com/slides/net/aspose.slides/autoshape/istextbox/) method (from the [AutoShape](https://reference.aspose.com/slides/cpp/aspose.slides/autoshape/) class) to allow you to examine shapes and find text boxes.
+Aspose.Slides provides the [get_IsTextBox](https://reference.aspose.com/slides/cpp/aspose.slides/iautoshape/get_istextbox/) method from the [IAutoShape](https://reference.aspose.com/slides/cpp/aspose.slides/iautoshape/) interface, allowing you to examine shapes and identify text boxes.
 
 ![Text box and shape](istextbox.png)
 

--- a/en/java/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
+++ b/en/java/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
@@ -3,7 +3,17 @@ title: Manage TextBox
 type: docs
 weight: 20
 url: /java/manage-textbox/
-description: Create Text Box on PowerPoint Slides using Java. Add Column in Text Box or Text Frame in PowerPoint Slides using Java. Add Text Box with Hyperlink in PowerPoint Slides using Java.
+keywords:
+- text box
+- text frame
+- add text
+- update text
+- text box with a hyperlink
+- PowerPoint
+- presentation
+- Java
+- Aspose.Slides for Java
+description: "Manage a text box or text frame in PowerPoint presentations using Java"
 ---
 
 
@@ -67,26 +77,51 @@ try {
 
 ## **Check for Text Box Shape**
 
-Aspose.Slides provides the [isTextBox()](https://reference.aspose.com/slides/java/com.aspose.slides/autoshape/#isTextBox--) property (from the [AutoShape](https://reference.aspose.com/slides/java/com.aspose.slides/autoshape/) class) to allow you to examine shapes and find text boxes.
+Aspose.Slides provides the [isTextBox](https://reference.aspose.com/slides/java/com.aspose.slides/autoshape/#isTextBox--) method from the [IAutoShape](https://reference.aspose.com/slides/java/com.aspose.slides/iautoshape/) interface, allowing you to examine shapes and identify text boxes.
 
 ![Text box and shape](istextbox.png)
 
 This Java code shows you how to check whether a shape was created as a text box: 
 
 ```java
-Presentation pres = new Presentation("pres.pptx");
+Presentation presentation = new Presentation("sample.pptx");
 try {
-    ForEach.shape(pres, (shape, slide, index) ->
-    {
-        if (shape instanceof AutoShape)
-        {
-            AutoShape autoShape = (AutoShape)shape;
-            System.out.println(autoShape.isTextBox() ? "shape is text box" : "shape is text not box");
+    ForEach.shape(presentation, (shape, slide, index) -> {
+        if (shape instanceof IAutoShape) {
+            IAutoShape autoShape = (IAutoShape) shape;
+            System.out.println(autoShape.isTextBox() ? "shape is a text box" : "shape is not a text box");
         }
     });
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
+```
+
+Note that if you simply add an autoshape using the `addAutoShape` method from the [IShapeCollection](https://reference.aspose.com/slides/java/com.aspose.slides/ishapecollection/) interface, the `isTextBox` method of the autoshape will return `false`. However, after you add text to the autoshape using the `addTextFrame` method or the `setText` method, the `isTextBox` property returns `true`.
+
+```java
+Presentation presentation = new Presentation();
+ISlide slide = presentation.getSlides().get_Item(0);
+
+IAutoShape shape1 = slide.getShapes().addAutoShape(ShapeType.Rectangle, 10, 10, 100, 40);
+// shape1.isTextBox() returns false
+shape1.addTextFrame("shape 1");
+// shape1.isTextBox() returns true
+
+IAutoShape shape2 = slide.getShapes().addAutoShape(ShapeType.Rectangle, 10, 110, 100, 40);
+// shape2.isTextBox() returns false
+shape2.getTextFrame().setText("shape 2");
+// shape2.isTextBox() returns true
+
+IAutoShape shape3 = slide.getShapes().addAutoShape(ShapeType.Rectangle, 10, 210, 100, 40);
+// shape3.isTextBox() returns false
+shape3.addTextFrame("");
+// shape3.isTextBox() returns false
+
+IAutoShape shape4 = slide.getShapes().addAutoShape(ShapeType.Rectangle, 10, 310, 100, 40);
+// shape4.isTextBox() returns false
+shape4.getTextFrame().setText("");
+// shape4.isTextBox() returns false
 ```
 
 ## **Add Column In Text Box**

--- a/en/net/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
+++ b/en/net/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
@@ -3,8 +3,18 @@ title: Manage TextBox
 type: docs
 weight: 20
 url: /net/manage-textbox/
-keywords: "Textbox, Text frame, Add textbox, Textbox with hyperlink, C#, Csharp, Aspose.Slides for .NET"
-description: "Add textbox or text frame to PowerPoint presentations in C# or .NET"
+keywords:
+- text box
+- text frame
+- add text
+- update text
+- text box with a hyperlink
+- PowerPoint
+- presentation
+- C#
+- Csharp
+- Aspose.Slides for .NET
+description: "Manage a text box or text frame in PowerPoint presentations using C# or .NET"
 ---
 
 Texts on slides typically exist in text boxes or shapes. Therefore, to add text to a slide, you have to add a textbox first and then put some text inside the textbox. 

--- a/en/nodejs-java/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
+++ b/en/nodejs-java/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
@@ -3,7 +3,18 @@ title: Manage TextBox
 type: docs
 weight: 20
 url: /nodejs-java/manage-textbox/
-description: Create Text Box on PowerPoint Slides using JavaScript. Add Column in Text Box or Text Frame in PowerPoint Slides using JavaScript. Add Text Box with Hyperlink in PowerPoint Slides using JavaScript.
+keywords:
+- text box
+- text frame
+- add text
+- update text
+- text box with a hyperlink
+- PowerPoint
+- presentation
+- Node.js
+- JavaScript
+- Aspose.Slides for Node.js via Java
+description: "Manage a text box or text frame in PowerPoint presentations using JavaScript"
 ---
 
 
@@ -62,26 +73,51 @@ try {
 
 ## **Check for Text Box Shape**
 
-Aspose.Slides provides the [isTextBox()](https://reference.aspose.com/slides/nodejs-java/aspose.slides/autoshape/#isTextBox--) method (from the [AutoShape](https://reference.aspose.com/slides/nodejs-java/aspose.slides/autoshape/) class) to allow you to examine shapes and find text boxes.
+Aspose.Slides provides the [isTextBox](https://reference.aspose.com/slides/nodejs-java/aspose.slides/autoshape/#isTextBox) method from the [AutoShape](https://reference.aspose.com/slides/nodejs-java/aspose.slides/autoshape/) class, allowing you to examine shapes and identify text boxes.
 
 ![Text box and shape](istextbox.png)
 
 This JavaScript code shows you how to check whether a shape was created as a text box:
 
 ```javascript
-var pres = new aspose.slides.Presentation("pres.pptx");
+var presentation = new aspose.slides.Presentation("sample.pptx");
 try {
-    java.callStaticMethodSync("ForEach", "shape", pres, (shape, slide, index) -> {
+    java.callStaticMethodSync("ForEach", "shape", presentation, (shape, slide, index) -> {
         if (java.instanceOf(shape, "com.aspose.slides.AutoShape")) {
             var autoShape = shape;
-            System.out.println(autoShape.isTextBox() ? "shape is text box" : "shape is text not box");
+            console.log(autoShape.isTextBox() ? "shape is a text box" : "shape is not a text box");
         }
     });
 } finally {
-    if (pres != null) {
-        pres.dispose();
-    }
+    presentation.dispose();
 }
+```
+
+Note that if you simply add an autoshape using the `addAutoShape` method from the [ShapeCollection](https://reference.aspose.com/slides/nodejs-java/aspose.slides/shapecollection/) class, the `isTextBox` method of the autoshape will return `false`. However, after you add text to the autoshape using the `addTextFrame` method or the `setText` method, the `isTextBox` property returns `true`.
+
+```javascript
+var presentation = new aspose.slides.Presentation();
+var slide = presentation.getSlides().get_Item(0);
+
+var shape1 = slide.getShapes().addAutoShape(aspose.slides.ShapeType.Rectangle, 10, 10, 100, 40);
+// shape1.isTextBox() returns false
+shape1.addTextFrame("shape 1");
+// shape1.isTextBox() returns true
+
+var shape2 = slide.getShapes().addAutoShape(aspose.slides.ShapeType.Rectangle, 10, 110, 100, 40);
+// shape2.isTextBox() returns false
+shape2.getTextFrame().setText("shape 2");
+// shape2.isTextBox() returns true
+
+var shape3 = slide.getShapes().addAutoShape(aspose.slides.ShapeType.Rectangle, 10, 210, 100, 40);
+// shape3.isTextBox() returns false
+shape3.addTextFrame("");
+// shape3.isTextBox() returns false
+
+var shape4 = slide.getShapes().addAutoShape(aspose.slides.ShapeType.Rectangle, 10, 310, 100, 40);
+// shape4.isTextBox() returns false
+shape4.getTextFrame().setText("");
+// shape4.isTextBox() returns false
 ```
 
 ## **Add Column In Text Box**

--- a/en/php-java/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
+++ b/en/php-java/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
@@ -3,7 +3,18 @@ title: Manage TextBox
 type: docs
 weight: 20
 url: /php-java/manage-textbox/
-description: Create Text Box on PowerPoint Slides using PHP. Add Column in Text Box or Text Frame in PowerPoint Slides using PHP. Add Text Box with Hyperlink in PowerPoint Slides using PHP.
+keywords:
+- text box
+- text frame
+- add text
+- update text
+- text box with a hyperlink
+- PowerPoint
+- presentation
+- PHP
+- Java
+- Aspose.Slides for PHP via Java
+description: "Manage a text box or text frame in PowerPoint presentations using PHP"
 ---
 
 
@@ -62,7 +73,7 @@ This PHP code—an implementation of the steps above—shows you how to add text
 
 ## **Check for Text Box Shape**
 
-Aspose.Slides provides the [isTextBox()](https://reference.aspose.com/slides/php-java/aspose.slides/autoshape/#isTextBox--) property (from the [AutoShape](https://reference.aspose.com/slides/php-java/aspose.slides/autoshape/) class) to allow you to examine shapes and find text boxes.
+Aspose.Slides provides the [isTextBox](https://reference.aspose.com/slides/php-java/aspose.slides/autoshape/#isTextBox--) method from the [AutoShape](https://reference.aspose.com/slides/php-java/aspose.slides/autoshape/) class, allowing you to examine shapes and identify text boxes.
 
 ![Text box and shape](istextbox.png)
 
@@ -70,22 +81,48 @@ This PHP code shows you how to check whether a shape was created as a text box:
 
 ```php
 class ShapeCallback {
-    function invoke($shape, $slide, $index){
-        if (java_instanceof($shape, new JavaClass("com.aspose.slides.AutoShape")))
-        $autoShape = $shape;
-        echo(java_is_true($autoShape->isTextBox()) ? "shape is text box" : "shape is text not box");
+    function invoke($shape, $slide, $index) {
+        if (java_instanceof($shape, new JavaClass("com.aspose.slides.AutoShape"))) {
+            $autoShape = $shape;
+            echo(java_is_true($autoShape->isTextBox()) ? "shape is a text box" : "shape is not a text box");
+        }
     }
 }
 
-  $pres = new Presentation("pres.pptx");
-  try {
+$presentation = new Presentation("sample.pptx");
+try {
     $forEachShapeCallback = java_closure(new ShapeCallback(), null, java("com.aspose.slides.ForEachSlideCallback"));
-    ForEach::shape($pres, $forEachShapeCallback);
-  } finally {
-    if (!java_is_null($pres)) {
-      $pres->dispose();
-    }
-  }
+    ForEach::shape($presentation, $forEachShapeCallback);
+} finally {
+    $presentation->dispose();
+}
+```
+
+Note that if you simply add an autoshape using the `addAutoShape` method from the [ShapeCollection](https://reference.aspose.com/slides/php-java/aspose.slides/shapecollection/) class, the `isTextBox` method of the autoshape will return `false`. However, after you add text to the autoshape using the `addTextFrame` method or the `setText` method, the `isTextBox` property returns `true`.
+
+```php
+$presentation = new Presentation();
+$slide = $presentation->getSlides()->get_Item(0);
+
+$shape1 = $slide->getShapes()->addAutoShape(ShapeType::Rectangle, 10, 10, 100, 40);
+// shape1->isTextBox() returns false
+$shape1->addTextFrame("shape 1");
+// shape1->isTextBox() returns true
+
+$shape2 = $slide->getShapes()->addAutoShape(ShapeType::Rectangle, 10, 110, 100, 40);
+// shape2->isTextBox() returns false
+$shape2->getTextFrame()->setText("shape 2");
+// shape2->isTextBox() returns true
+
+$shape3 = $slide->getShapes()->addAutoShape(ShapeType::Rectangle, 10, 210, 100, 40);
+// shape3->isTextBox() returns false
+$shape3->addTextFrame("");
+// shape3->isTextBox() returns false
+
+$shape4 = $slide->getShapes()->addAutoShape(ShapeType::Rectangle, 10, 310, 100, 40);
+// shape4->isTextBox() returns false
+$shape4->getTextFrame()->setText("");
+// shape4->isTextBox() returns false
 ```
 
 ## **Add Column In Text Box**

--- a/en/python-net/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
+++ b/en/python-net/developer-guide/presentation-content/manage-text/manage-textbox/_index.md
@@ -3,8 +3,17 @@ title: Manage TextBox
 type: docs
 weight: 20
 url: /python-net/manage-textbox/
-keywords: "Textbox, Text frame, Add textbox, Textbox with hyperlink, Python, Aspose.Slides for Python via .NET"
-description: "Add textbox or text frame to PowerPoint presentations in Python or ,NET"
+keywords:
+- text box
+- text frame
+- add text
+- update text
+- text box with a hyperlink
+- PowerPoint
+- presentation
+- Python
+- Aspose.Slides for Python via .NET
+description: "Manage a text box or text frame in PowerPoint presentations using Python"
 ---
 
 Texts on slides typically exist in text boxes or shapes. Therefore, to add a text to a slide, you have to add a text box and then put some text inside the textbox. Aspose.Slides for Python via .NET provides the [IAutoShape](https://reference.aspose.com/slides/python-net/aspose.slides/iautoshape/) interface that allows you to add a shape containing some text.
@@ -66,20 +75,49 @@ with slides.Presentation() as pres:
 
 ## **Check for Text Box Shape**
 
-Aspose.Slides provides the `is_text_box` property (from the [AutoShape](https://reference.aspose.com/slides/python-net/aspose.slides/autoshape/) class) to allow you to examine shapes and find text boxes.
+Aspose.Slides provides the [is_text_box](https://reference.aspose.com/slides/python-net/aspose.slides/autoshape/is_text_box/) property from the [AutoShape](https://reference.aspose.com/slides/python-net/aspose.slides/autoshape/) class, allowing you to examine shapes and identify text boxes.
 
 ![Text box and shape](istextbox.png)
 
 This Python code shows you how to check whether a shape was created as a text box: xxx
 
 ```python
-from aspose.slides import Presentation, AutoShape
+import aspose.slides as slides
 
-with Presentation("pres.pptx") as pres:
-    for slide in pres.slides:
+with slides.Presentation("sample.pptx") as presentation:
+    for slide in presentation.slides:
         for shape in slide.shapes:
-            if (type(shape) is AutoShape):
-                print("shape is text box" if shape.is_text_box else "shape is text not box")
+            if isinstance(shape, slides.AutoShape):
+                print("shape is a text box" if shape.is_text_box else "shape is not a text box")
+```
+
+Note that if you simply add an autoshape using the `add_auto_shape` method from the [ShapeCollection](https://reference.aspose.com/slides/python-net/aspose.slides/shapecollection/) class, the `is_text_box` property of the autoshape will return `False`. However, after you add text to the autoshape using the `add_text_frame` method or the `text` property, the `is_text_box` property returns `True`.
+
+```py
+import aspose.slides as slides
+
+with slides.Presentation() as presentation:
+    slide = presentation.slides[0]
+
+    shape1 = slide.shapes.add_auto_shape(slides.ShapeType.RECTANGLE, 10, 10, 100, 40)
+    # shape1.is_text_box is false
+    shape1.add_text_frame("shape 1")
+    # shape1.is_text_box is true
+
+    shape2 = slide.shapes.add_auto_shape(slides.ShapeType.RECTANGLE, 10, 110, 100, 40)
+    # shape2.is_text_box is false
+    shape2.text_frame.text = "shape 2"
+    # shape2.is_text_box is true
+
+    shape3 = slide.shapes.add_auto_shape(slides.ShapeType.RECTANGLE, 10, 210, 100, 40)
+    # shape3.is_text_box is false
+    shape3.add_text_frame("")
+    # shape3.is_text_box is false
+
+    shape4 = slide.shapes.add_auto_shape(slides.ShapeType.RECTANGLE, 10, 310, 100, 40)
+    # shape4.is_text_box is false
+    shape4.text_frame.text = ""
+    # shape4.is_text_box is false
 ```
 
 ## **Add Column In Text Box**


### PR DESCRIPTION
Added information to the section "Check for Text Box Shape" in the article "Manage TextBox" (Android via Java, C++, Java, Node.js via Java, PHP via Java, Python via .NET). 
Made some minor corrections.
The previous pull request: https://github.com/aspose-slides/Aspose.Slides-Documentation/pull/669