### PR TITLE
SLIDESDOC-521 Update articles related to the SLIDESNET-44775 issue

### DIFF
--- a/en/androidjava/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/androidjava/developer-guide/manage-presentation/save-presentation/_index.md
@@ -131,6 +131,34 @@ Saving in the Zip64Mode.Never mode will throw a [PptxException](https://referenc
 
 {{% /alert %}}
 
+## **Save a Presentation without Refreshing the Thumbnail**
+
+The [**IPptxOptions.setRefreshThumbnail**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ipptxoptions/#setRefreshThumbnail-boolean-) method allows you to control the generation of the thumbnail when saving a presentation in PPTX format:
+
+- When the value **true** is passed, the presentation thumbnail will be refreshed while saving. This is the *default* value.
+- When the value **false** is passed, the current thumbnail will be saved as is. If the presentation doesn't have a thumbnail, no thumbnail will be generated.
+
+In the code below, we saved the presentation to PPTX format without refreshing its thumbnail:
+
+```java
+Presentation presentation = new Presentation("Sample.pptx");
+try {
+    PptxOptions pptxOptions = new PptxOptions();
+    pptxOptions.setRefreshThumbnail(false);
+
+    presentation.save("Sample_with_old_thumbnail.pptx", SaveFormat.Pptx, pptxOptions);
+}
+finally {
+    presentation.dispose();
+}
+```
+
+{{% alert title="Info" color="info" %}}
+
+This option allows you to save time when saving a presentation in PPTX format.
+
+{{% /alert %}}
+
 ## **Save Progress Updates in Percentage**
 New [**IProgressCallback**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/IProgressCallback) interface has been added to [**ISaveOptions**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ISaveOptions) interface and [**SaveOptions** ](https://reference.aspose.com/slides/androidjava/com.aspose.slides/SaveOptions)abstract class. [**IProgressCallback**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/IProgressCallback) interface represents a callback object for saving progress updates in percentage.  
 

--- a/en/cpp/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/cpp/developer-guide/manage-presentation/save-presentation/_index.md
@@ -39,6 +39,30 @@ The following sample code creates a presentation and saves it in the Strict Offi
 
 {{< gist "aspose-com-gists" "81aeb05e6d3a070aa76fdea22ed53bc7" "Examples-SlidesCPP-SaveToStrictOpenXML-SaveToStrictOpenXML.cpp" >}}
 
+## **Save a Presentation without Refreshing the Thumbnail**
+
+The [**IPptxOptions.set_RefreshThumbnail**](https://reference.aspose.com/slides/cpp/aspose.slides.export/ipptxoptions/set_refreshthumbnail/) method allows you to control the generation of the thumbnail when saving a presentation in PPTX format:
+
+- When the value **true** is passed, the presentation thumbnail will be refreshed while saving. This is the *default* value.
+- When the value **false** is passed, the current thumbnail will be saved as is. If the presentation doesn't have a thumbnail, no thumbnail will be generated.
+
+In the code below, we saved the presentation to PPTX format without refreshing its thumbnail:
+
+```cpp
+auto presentation = MakeObject<Presentation>(u"Sample.pptx");
+    
+auto pptxOptions = MakeObject<PptxOptions>();
+pptxOptions->set_RefreshThumbnail(false);
+
+presentation->Save(u"Sample_with_old_thumbnail.pptx", SaveFormat::Pptx, pptxOptions);
+presentation->Dispose();
+```
+
+{{% alert title="Info" color="info" %}}
+
+This option allows you to save time when saving a presentation in PPTX format.
+
+{{% /alert %}}
 
 ## **Save Progress Updates in Percentage**
  New **IProgressCallback** interface has been added to **ISaveOptions** interface and **SaveOptions** abstract class. **IProgressCallback** interface represents a callback object for saving progress updates in percentage.  

--- a/en/java/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/java/developer-guide/manage-presentation/save-presentation/_index.md
@@ -131,6 +131,34 @@ Saving in the Zip64Mode.Never mode will throw a [PptxException](https://referenc
 
 {{% /alert %}}
 
+## **Save a Presentation without Refreshing the Thumbnail**
+
+The [**IPptxOptions.setRefreshThumbnail**](https://reference.aspose.com/slides/java/com.aspose.slides/ipptxoptions/#setRefreshThumbnail-boolean-) method allows you to control the generation of the thumbnail when saving a presentation in PPTX format:
+
+- When the value **true** is passed, the presentation thumbnail will be refreshed while saving. This is the *default* value.
+- When the value **false** is passed, the current thumbnail will be saved as is. If the presentation doesn't have a thumbnail, no thumbnail will be generated.
+
+In the code below, we saved the presentation to PPTX format without refreshing its thumbnail:
+
+```java
+Presentation presentation = new Presentation("Sample.pptx");
+try {
+    PptxOptions pptxOptions = new PptxOptions();
+    pptxOptions.setRefreshThumbnail(false);
+
+    presentation.save("Sample_with_old_thumbnail.pptx", SaveFormat.Pptx, pptxOptions);
+}
+finally {
+    presentation.dispose();
+}
+```
+
+{{% alert title="Info" color="info" %}}
+
+This option allows you to save time when saving a presentation in PPTX format.
+
+{{% /alert %}}
+
 ## **Save Progress Updates in Percentage**
 New [**IProgressCallback**](https://reference.aspose.com/slides/java/com.aspose.slides/IProgressCallback) interface has been added to [**ISaveOptions**](https://reference.aspose.com/slides/java/com.aspose.slides/ISaveOptions) interface and [**SaveOptions** ](https://reference.aspose.com/slides/java/com.aspose.slides/SaveOptions)abstract class. [**IProgressCallback**](https://reference.aspose.com/slides/java/com.aspose.slides/IProgressCallback) interface represents a callback object for saving progress updates in percentage.  
 

--- a/en/nodejs-java/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/nodejs-java/developer-guide/manage-presentation/save-presentation/_index.md
@@ -130,6 +130,34 @@ Saving in the Zip64Mode.Never mode will throw a [PptxException](https://referenc
 
 {{% /alert %}}
 
+## **Save a Presentation without Refreshing the Thumbnail**
+
+The [**PptxOptions.setRefreshThumbnail**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/pptxoptions/#setRefreshThumbnail) method allows you to control the generation of the thumbnail when saving a presentation in PPTX format:
+
+- When the value **true** is passed, the presentation thumbnail will be refreshed while saving. This is the *default* value.
+- When the value **false** is passed, the current thumbnail will be saved as is. If the presentation doesn't have a thumbnail, no thumbnail will be generated.
+
+In the code below, we saved the presentation to PPTX format without refreshing its thumbnail:
+
+```js
+var presentation = new aspose.slides.Presentation("Sample.pptx");
+try {
+    var pptxOptions = new aspose.slides.PptxOptions();
+    pptxOptions.setRefreshThumbnail(false);
+
+    presentation.save("Sample_with_old_thumbnail.pptx", aspose.slides.SaveFormat.Pptx, pptxOptions);
+}
+finally {
+    presentation.dispose();
+}
+```
+
+{{% alert title="Info" color="info" %}}
+
+This option allows you to save time when saving a presentation in PPTX format.
+
+{{% /alert %}}
+
 ## **Save Progress Updates in Percentage**
 New [**ProgressCallback**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/ProgressCallback) class has been added to [**SaveOptions**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/SaveOptions) class and [**SaveOptions** ](https://reference.aspose.com/slides/nodejs-java/aspose.slides/SaveOptions)abstract class. [**ProgressCallback**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/ProgressCallback) class represents a callback object for saving progress updates in percentage.  
 

--- a/en/php-java/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/php-java/developer-guide/manage-presentation/save-presentation/_index.md
@@ -128,6 +128,34 @@ Saving in the Zip64Mode.Never mode will throw a [PptxException](https://referenc
 
 {{% /alert %}}
 
+## **Save a Presentation without Refreshing the Thumbnail**
+
+The [**PptxOptions.setRefreshThumbnail**](https://reference.aspose.com/slides/php-java/aspose.slides/pptxoptions/#setRefreshThumbnail) method allows you to control the generation of the thumbnail when saving a presentation in PPTX format:
+
+- When the value **true** is passed, the presentation thumbnail will be refreshed while saving. This is the *default* value.
+- When the value **false** is passed, the current thumbnail will be saved as is. If the presentation doesn't have a thumbnail, no thumbnail will be generated.
+
+In the code below, we saved the presentation to PPTX format without refreshing its thumbnail:
+
+```php
+$presentation = new Presentation("Sample.pptx");
+try {
+    $pptxOptions = new PptxOptions();
+    $pptxOptions->setRefreshThumbnail(false);
+
+    $presentation->save("Sample_with_old_thumbnail.pptx", SaveFormat::Pptx, $pptxOptions);
+}
+finally {
+    $presentation->dispose();
+}
+```
+
+{{% alert title="Info" color="info" %}}
+
+This option allows you to save time when saving a presentation in PPTX format.
+
+{{% /alert %}}
+
 ## **Save Progress Updates in Percentage**
 New [**IProgressCallback**](https://reference.aspose.com/slides/php-java/aspose.slides/IProgressCallback) interface has been added to [**ISaveOptions**](https://reference.aspose.com/slides/php-java/aspose.slides/ISaveOptions) interface and [**SaveOptions** ](https://reference.aspose.com/slides/php-java/aspose.slides/SaveOptions)abstract class. [**IProgressCallback**](https://reference.aspose.com/slides/php-java/aspose.slides/IProgressCallback) interface represents a callback object for saving progress updates in percentage.  
 

--- a/en/python-net/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/python-net/developer-guide/manage-presentation/save-presentation/_index.md
@@ -84,6 +84,29 @@ with slides.Presentation() as presentation:
 
 ```
 
+### **Saving a Presentation without Refreshing the Thumbnail**
+
+The [**PptxOptions.refresh_thumbnail**](https://reference.aspose.com/slides/python-net/aspose.slides.export/pptxoptions/refresh_thumbnail/) property allows you to control the generation of the thumbnail when saving a presentation in PPTX format:
+
+- When the property value is **True**, the presentation thumbnail will be refreshed while saving. This is the *default* value.
+- When the property value is **False**, the current thumbnail will be saved as is. If the presentation doesn't have a thumbnail, no thumbnail will be generated.
+
+In the code below, we saved the presentation to PPTX format without refreshing its thumbnail:
+
+```py
+with slides.Presentation("Sample.pptx") as presentation:
+    
+    pptx_options = slides.export.PptxOptions()
+    pptx_options.refresh_thumbnail = False
+    
+    presentation.save("Sample_with_old_thumbnail.pptx", slides.export.SaveFormat.PPTX, pptx_options)
+```
+
+{{% alert title="Info" color="info" %}}
+
+This option allows you to save time when saving a presentation in PPTX format.
+
+{{% /alert %}}
 
 ### **Saving Progress Updates in Percentage**
 New [**IProgressCallback** ](https://reference.aspose.com/slides/python-net/aspose.slides/iprogresscallback/)interface has been added to [**ISaveOptions** ](https://reference.aspose.com/slides/python-net/aspose.slides.export/isaveoptions/)interface and [**SaveOptions** ](https://reference.aspose.com/slides/python-net/aspose.slides.export/saveoptions/)abstract class. **IProgressCallback** interface represents a callback object for saving progress updates in percentage.


### PR DESCRIPTION
Added the section "Save a Presentation without Refreshing the Thumbnail" to the article "Save Presentation" (Android via Java, C++, Java, Node.js via Java, PHP via Java, Python via .NET).