### PR TITLE
SLIDESDOC-595 Incorrect language used in documentation articles

### DIFF
--- a/de/python-net/developer-guide/presentation-slide/slide-size/_index.md
+++ b/de/python-net/developer-guide/presentation-slide/slide-size/_index.md
@@ -2,7 +2,7 @@
 title: Foliengröße
 type: docs
 weight: 70
-url: /python-net/slide-size/
+url: /de/python-net/slide-size/
 keywords: "Folie festlegen, Foliengröße bearbeiten, PowerPoint-Präsentation, benutzerdefinierte Foliengröße, Folienprobleme lösen, Python, Aspose.Slides"
 descriptions: "Foliegröße oder Seitenverhältnis in PowerPoint in Python festlegen und bearbeiten"
 ---

--- a/de/python-net/developer-guide/technical-articles/get-the-entire-presentation-slide-background-as-an-image/_index.md
+++ b/de/python-net/developer-guide/technical-articles/get-the-entire-presentation-slide-background-as-an-image/_index.md
@@ -2,7 +2,7 @@
 title: Holen Sie sich den gesamten Hintergrund der Präsentationsfolie als Bild
 type: docs
 weight: 95
-url: /python-net/get-the-entire-presentation-slide-background-as-an-image/
+url: /de/python-net/get-the-entire-presentation-slide-background-as-an-image/
 keywords:
 - folien
 - hintergrund

--- a/de/python-net/developer-guide/technical-articles/replacing-images-inside-presentation-image-collection/_index.md
+++ b/de/python-net/developer-guide/technical-articles/replacing-images-inside-presentation-image-collection/_index.md
@@ -2,7 +2,7 @@
 title: Ersetzen von Bildern in der Präsentationsbildsammlung
 type: docs
 weight: 110
-url: /python-net/replacing-images-inside-presentation-image-collection/
+url: /de/python-net/replacing-images-inside-presentation-image-collection/
 ---
 
 {{% alert color="primary" %}} 


### PR DESCRIPTION
Fixed links:
/de/python-net/slide-size/
/de/python-net/get-the-entire-presentation-slide-background-as-an-image/ 
/de/python-net/replacing-images-inside-presentation-image-collection/