### PR TITLE
SLIDESDOC-646 Add the section "Saving Presentations to Office Open XML format in Zip64 mode" to the articles for other platforms

### DIFF
--- a/en/androidjava/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/androidjava/developer-guide/manage-presentation/save-presentation/_index.md
@@ -1,152 +1,154 @@
 ---
-title: Save Presentation
+title: Save Presentations on Android
+linktitle: Save Presentations
 type: docs
 weight: 80
 url: /androidjava/save-presentation/
+keywords:
+- save PowerPoint
+- save OpenDocument
+- save presentation
+- save slide
+- save PPT
+- save PPTX
+- save ODP
+- presentation to file
+- presentation to stream
+- predefined view type
+- Strict Office Open XML Format
+- Zip64 mode
+- refreshing thumbnail
+- saving progress
+- Android
+- Java
+- Aspose.Slides
+description: "Discover how to save presentations in Java using Aspose.Slides for Android—export to PowerPoint or OpenDocument while retaining layouts, fonts and effects."
 ---
 
 ## **Overview**
-{{% alert color="primary" %}} 
 
-[Opening Presentation](/slides/androidjava/open-presentation/) described how to use the [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation) class to open a presentation. This article explains how to create and save presentations.
+[Open Presentations on Android](/slides/androidjava/open-presentation/) described how to use the [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/presentation/) class to open a presentation. This article explains how to create and save presentations. The [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/presentation/) class contains a presentation’s contents. Whether you’re creating a presentation from scratch or modifying an existing one, you’ll want to save it when you’re finished. With Aspose.Slides for Android, you can save to a **file** or **stream**. This article explains the different ways to save a presentation.
 
-{{% /alert %}} 
+## **Save Presentations to Files**
 
-The [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation) class holds a presentation's content. Whether creating a presentation from scratch or modifying an existing one, when finished, you want to save the presentation. With Aspose.Slides for Android via Java, it can be saved as a **file** or **stream**. This article explains how to save a presentation in different ways:
-
-## **Save Presentation to File**
-Save a presentation to file by calling the [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation) class [**Save**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation#save-java.lang.String-int-) method. Simply pass the file name and [**SaveFormat**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/SaveFormat) to the [**Save**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation#save-java.lang.String-int-) method.
-
-The examples that follow show how to save a presentation with Aspose.Slides for Android via Java.
+Save a presentation to a file by calling the [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/presentation/) class’s `save` method. Pass the file name and save format to the method. The following example show how to save a presentation with Aspose.Slides.
 
 ```java
-// Instantiate a Presentation object that represents a PPT file
-Presentation pres = new Presentation();
+// Instantiate the Presentation class that represents a presentation file.
+Presentation presentation = new Presentation();
 try {
-    // ...do some work here...
-    
-    // Save your presentation to a file
-    pres.save("demoPass.pptx", com.aspose.slides.SaveFormat.Pptx);
+    // Do some work here...
+
+    // Save the presentation to a file.
+    presentation.save("Output.pptx", SaveFormat.Pptx);
 } finally {
-    if(pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
-## **Save Presentation to Stream**
-It is possible to save a presentation to a stream by passing an output stream to the [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation) class [**Save**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation#save-java.io.OutputStream-int-) method. There are many types of streams to which a presentation can be saved. In the below example we have created a new Presentation file, add text in shape and Save the presentation to the stream.
+## **Save Presentations to Streams**
+
+You can save a presentation to a stream by passing an output stream to the [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/presentation/) class’s `save` method. A presentation can be written to many stream types. In the example below, we create a new presentation and save it to a file stream.
 
 ```java
-// Instantiate a Presentation object that represents a PPT file
-Presentation pres = new Presentation();
+// Instantiate the Presentation class that represents a presentation file.
+Presentation presentation = new Presentation();
 try {
-    IAutoShape shape = pres.getSlides().get_Item(0).getShapes().addAutoShape(ShapeType.Rectangle, 200, 200, 200, 200);
-
-    // Add text to shape
-    shape.getTextFrame().setText("This demo shows how to Create PowerPoint file and save it to Stream.");
-
-    OutputStream os = new FileOutputStream("Save_As_Stream_out.pptx");
-
-    pres.save(os, com.aspose.slides.SaveFormat.Pptx);
-
-    os.close();
-} catch (IOException e) {
+    OutputStream fileStream = new FileOutputStream("Output.pptx");
+    try {
+        // Save the presentation to the stream.
+        presentation.save(fileStream, SaveFormat.Pptx);
+    } finally {
+        fileStream.close();
+    }
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
-## **Save Presentation with Predefined View Type**
-Aspose.Slides for Android via Java provides a facility to set the view type for the generated presentation when it is opened in PowerPoint through the [ViewProperties](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ViewProperties) class. The [**setLastView**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ViewProperties#setLastView-int-) property is used to set the view type by using the [**ViewType**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ViewType) enumerator.
+## **Save Presentations with a Predefined View Type**
+
+Aspose.Slides lets you set the initial view that PowerPoint uses when the generated presentation opens through the [ViewProperties](https://reference.aspose.com/slides/androidjava/com.aspose.slides/viewproperties/) class. Use the [setLastView](https://reference.aspose.com/slides/androidjava/com.aspose.slides/viewproperties/#setLastView-int-) method with a value from the [ViewType](https://reference.aspose.com/slides/androidjava/com.aspose.slides/viewtype/) enumeration.
 
 ```java
-// Opening the presentation file
-Presentation pres = new Presentation();
+// Instantiate the Presentation class that represents a presentation file.
+Presentation presentation = new Presentation();
 try {
-    // Setting view type
-    pres.getViewProperties().setLastView((byte) ViewType.SlideMasterView);
-    
-    // Saving presentation
-    pres.save("newDemo.pptx", SaveFormat.Pptx);
+    presentation.getViewProperties().setLastView(ViewType.SlideMasterView);
+    presentation.save("SlideMasterView.pptx", SaveFormat.Pptx);
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
-## **Saving Presentations to Strict Office Open XML Format**
-Aspose.Slides allows you to save the presentation in Strict Office Open XML format. For that purpose, it provides the [**PptxOptions**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/pptxoptions) class where you can set the Conformance property while saving the presentation file. If you set its value as [**Conformance.Iso29500_2008_Strict**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Conformance#Iso29500_2008_Strict), then the output presentation file will be saved in Strict Open XML format.
+## **Save Presentations in the Strict Office Open XML Format**
 
-The following sample code creates a presentation and saves it in the Strict Office Open XML format. While calling the [**Save**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation#save-java.lang.String-int-com.aspose.slides.ISaveOptions-) method for the presentation, the [**PptxOptions**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/pptxoptions) object is passed into it with the Conformance property set as [**Conformance.Iso29500_2008_Strict**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Conformance#Iso29500_2008_Strict).
+Aspose.Slides lets you save a presentation in the Strict Office Open XML format. Use the [PptxOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/pptxoptions/) class and set its conformance property when saving. If you set [Conformance.Iso29500_2008_Strict](https://reference.aspose.com/slides/androidjava/com.aspose.slides/conformance/#Iso29500-2008-Strict), the output file is saved in the Strict Office Open XML format.
+
+The example below creates a presentation and saves it in the Strict Office Open XML format.
 
 ```java
-// Instantiate a Presentation object that represents a PPT file
-Presentation pres = new Presentation();
-try {
-    // Get the first slide
-    ISlide slide = pres.getSlides().get_Item(0);
-    
-    // Add an autoshape of type line
-    slide.getShapes().addAutoShape(ShapeType.Line, 50, 150, 300, 0);
-    
-    //Set Strict Office Open XML Format save options
-    PptxOptions options = new PptxOptions();
-    options.setConformance(Conformance.Iso29500_2008_Strict);
-    
-    // Save your presentation to a file
-    pres.save("demoPass.pptx", SaveFormat.Pptx, options);
-} finally {
-    if (pres != null) pres.dispose();
-}
+PptxOptions options = new PptxOptions();
+options.setConformance(Conformance.Iso29500_2008_Strict);
 
+// Instantiate the Presentation class that represents a presentation file.
+Presentation presentation = new Presentation();
+try {
+    // Save the presentation in the Strict Office Open XML format.
+    presentation.save("StrictOfficeOpenXml.pptx", SaveFormat.Pptx, options);
+} finally {
+    presentation.dispose();
+}
 ```
 
-## **Saving Presentations to Office Open XML format in Zip64 mode**
+## **Save Presentations in Office Open XML Format in Zip64 Mode**
 
-An Office Open XML file is a ZIP-archive that has a 4 GB (2^32 bytes) limit on uncompressed size of a file, compressed size of a file, and total size of the archive, as well as a limit of 65,535 (2^16-1) files in the archive. ZIP64 format extensions increase the limits to 2^64.
+An Office Open XML file is a ZIP archive that imposes 4 GB (2^32 bytes) limits on the uncompressed size of any file, the compressed size of any file, and the total size of the archive, and it also limits the archive to 65,535 (2^16-1) files. ZIP64 format extensions raise these limits to 2^64.
 
-The new [**IPptxOptions.Zip64Mode**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/zip64mode/) property allows you to choose when to use ZIP64 format extensions for the saved Office Open XML file.
+The [IPptxOptions.setZip64Mode](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ipptxoptions/#setZip64Mode-int-) method lets you choose when to use ZIP64 format extensions when saving an Office Open XML file.
 
-This property provides the following modes:
+This method can be used with the following modes:
 
-- [Zip64Mode.IfNecessary](https://reference.aspose.com/slides/androidjava/com.aspose.slides/zip64mode/#IfNecessary) means that ZIP64 format extensions will only be used if the presentation falls outside the above limitations. This is the default mode.
-- [Zip64Mode.Never](https://reference.aspose.com/slides/androidjava/com.aspose.slides/zip64mode/#Never) means that ZIP64 format extensions will not be used.
-- [Zip64Mode.Always](https://reference.aspose.com/slides/androidjava/com.aspose.slides/zip64mode/#Always) means that ZIP64 format extensions will always be used.
+- [IfNecessary](https://reference.aspose.com/slides/androidjava/com.aspose.slides/zip64mode/#IfNecessary) uses ZIP64 format extensions only if the presentation exceeds the limitations above. This is the default mode.
+- [Never](https://reference.aspose.com/slides/androidjava/com.aspose.slides/zip64mode/#Never) never uses ZIP64 format extensions.
+- [Always](https://reference.aspose.com/slides/androidjava/com.aspose.slides/zip64mode/#Always) always uses ZIP64 format extensions.
 
-The following code demonstrates how to save the presentation to PPTX format with ZIP64 format extensions:
+The following code demonstrates how to save a presentation as PPTX with ZIP64 format extensions enabled:
 
 ```java
-Presentation pres = new Presentation("Sample.pptx");
+PptxOptions pptxOptions = new PptxOptions();
+pptxOptions.setZip64Mode(Zip64Mode.Always);
+
+Presentation presentation = new Presentation("Sample.pptx");
 try {
-    PptxOptions pptxOptions = new PptxOptions();
-    pptxOptions.setZip64Mode(Zip64Mode.Always);
-    
-    pres.save("Sample-zip64.pptx", SaveFormat.Pptx, pptxOptions);
+    presentation.save("OutputZip64.pptx", SaveFormat.Pptx, pptxOptions);
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
 {{% alert title="NOTE" color="warning" %}}
 
-Saving in the Zip64Mode.Never mode will throw a [PptxException](https://reference.aspose.com/slides/androidjava/com.aspose.slides/pptxexception/) if the presentation cannot be saved in ZIP32 format.
+When you save with [Zip64Mode.Never](https://reference.aspose.com/slides/androidjava/com.aspose.slides/zip64mode/#Never), a [PptxException](https://reference.aspose.com/slides/androidjava/com.aspose.slides/pptxexception/) is thrown if the presentation cannot be saved in ZIP32 format.
 
 {{% /alert %}}
 
-## **Save a Presentation without Refreshing the Thumbnail**
+## **Save Presentations without Refreshing the Thumbnail**
 
-The [**IPptxOptions.setRefreshThumbnail**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ipptxoptions/#setRefreshThumbnail-boolean-) method allows you to control the generation of the thumbnail when saving a presentation in PPTX format:
+The [PptxOptions.setRefreshThumbnail](https://reference.aspose.com/slides/androidjava/com.aspose.slides/pptxoptions/#setRefreshThumbnail-boolean-) method controls thumbnail generation when saving a presentation to PPTX:
 
-- When the value **true** is passed, the presentation thumbnail will be refreshed while saving. This is the *default* value.
-- When the value **false** is passed, the current thumbnail will be saved as is. If the presentation doesn't have a thumbnail, no thumbnail will be generated.
+- If set to `true`, the thumbnail is refreshed during save. This is the default.
+- If set to `false`, the current thumbnail is preserved. If the presentation has no thumbnail, none is generated.
 
-In the code below, we saved the presentation to PPTX format without refreshing its thumbnail:
+In the code below, the presentation is saved to PPTX without refreshing its thumbnail.
 
 ```java
+PptxOptions pptxOptions = new PptxOptions();
+pptxOptions.setRefreshThumbnail(false);
+
 Presentation presentation = new Presentation("Sample.pptx");
 try {
-    PptxOptions pptxOptions = new PptxOptions();
-    pptxOptions.setRefreshThumbnail(false);
-
-    presentation.save("Sample_with_old_thumbnail.pptx", SaveFormat.Pptx, pptxOptions);
+    presentation.save("Output.pptx", SaveFormat.Pptx, pptxOptions);
 }
 finally {
     presentation.dispose();
@@ -155,33 +157,33 @@ finally {
 
 {{% alert title="Info" color="info" %}}
 
-This option allows you to save time when saving a presentation in PPTX format.
+This option helps reduce the time required to save a presentation in PPTX format.
 
 {{% /alert %}}
 
 ## **Save Progress Updates in Percentage**
-New [**IProgressCallback**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/IProgressCallback) interface has been added to [**ISaveOptions**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ISaveOptions) interface and [**SaveOptions** ](https://reference.aspose.com/slides/androidjava/com.aspose.slides/SaveOptions)abstract class. [**IProgressCallback**](https://reference.aspose.com/slides/androidjava/com.aspose.slides/IProgressCallback) interface represents a callback object for saving progress updates in percentage.  
 
-The following code snippets below show how to use [IProgressCallback](https://reference.aspose.com/slides/androidjava/com.aspose.slides/IProgressCallback) interface:
+The [IProgressCallback](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iprogresscallback/) interface is used via the `setProgressCallback` method exposed by the [ISaveOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/isaveoptions/) interface and the abstract [SaveOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/saveoptions/) class. Assign an [IProgressCallback](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iprogresscallback/) implementation with `setProgressCallback` to receive save-progress updates as a percentage.
+
+The following code snippets show how to use `IProgressCallback`.
 
 ```java
-// Opening the presentation file
-Presentation pres = new Presentation("ConvertToPDF.pptx");
+ISaveOptions saveOptions = new PdfOptions();
+saveOptions.setProgressCallback(new ExportProgressHandler());
+
+Presentation presentation = new Presentation("Sample.pptx");
 try {
-    ISaveOptions saveOptions = new PdfOptions();
-    saveOptions.setProgressCallback((IProgressCallback) new ExportProgressHandler());
-    pres.save("ConvertToPDF.pdf", SaveFormat.Pdf, saveOptions);
+    presentation.save("Output.pdf", SaveFormat.Pdf, saveOptions);
 } finally {
-    pres.dispose();
+    presentation.dispose();
 }
 ```
 ```java
-class ExportProgressHandler implements IProgressCallback 
-{
-    public void reporting(double progressValue) 
-	{
-        // Use progress percentage value here
-        int progress = Double.valueOf(progressValue).intValue();
+class ExportProgressHandler implements IProgressCallback {
+    public void reporting(double progressValue) {
+        // Use the progress percentage value here.
+        int progress = (int) progressValue;
+
         System.out.println(progress + "% file converted");
     }
 }
@@ -189,6 +191,6 @@ class ExportProgressHandler implements IProgressCallback
 
 {{% alert title="Info" color="info" %}}
 
-Using its own API, Aspose developed a [free PowerPoint Splitter app](https://products.aspose.app/slides/splitter) that allows users to split their presentations into multiple files. Essentially, the app saves selected slides from a given presentation as new PowerPoint (PPTX or PPT) files. 
+Aspose has developed a [free PowerPoint Splitter app](https://products.aspose.app/slides/splitter) using its own API. The app lets you split a presentation into multiple files by saving selected slides as new PPTX or PPT files.
 
 {{% /alert %}}

--- a/en/androidjava/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/androidjava/developer-guide/manage-presentation/save-presentation/_index.md
@@ -71,7 +71,6 @@ try {
 Aspose.Slides lets you set the initial view that PowerPoint uses when the generated presentation opens through the [ViewProperties](https://reference.aspose.com/slides/androidjava/com.aspose.slides/viewproperties/) class. Use the [setLastView](https://reference.aspose.com/slides/androidjava/com.aspose.slides/viewproperties/#setLastView-int-) method with a value from the [ViewType](https://reference.aspose.com/slides/androidjava/com.aspose.slides/viewtype/) enumeration.
 
 ```java
-// Instantiate the Presentation class that represents a presentation file.
 Presentation presentation = new Presentation();
 try {
     presentation.getViewProperties().setLastView(ViewType.SlideMasterView);
@@ -184,7 +183,7 @@ class ExportProgressHandler implements IProgressCallback {
         // Use the progress percentage value here.
         int progress = (int) progressValue;
 
-        System.out.println(progress + "% file converted");
+        System.out.println(progress + "% of the file has been converted.");
     }
 }
 ```

--- a/en/cpp/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/cpp/developer-guide/manage-presentation/save-presentation/_index.md
@@ -1,80 +1,183 @@
 ---
-title: Save Presentation - C++ PowerPoint Library
-linktitle: Save Presentation
+title: Save Presentations in C++
+linktitle: Save Presentations
 type: docs
 weight: 80
 url: /cpp/save-presentation/
-description: C++ PowerPoint API or Library allows you to save presentation to file or stream. You can create a presentation from scratch or modify an existing one.
+keywords:
+- save PowerPoint
+- save OpenDocument
+- save presentation
+- save slide
+- save PPT
+- save PPTX
+- save ODP
+- presentation to file
+- presentation to stream
+- predefined view type
+- Strict Office Open XML Format
+- Zip64 mode
+- refreshing thumbnail
+- saving progress
+- C++
+- Aspose.Slides
+description: "Discover how to save presentations in C++ using Aspose.Slides—export to PowerPoint or OpenDocument while retaining layouts, fonts and effects."
 ---
 
-{{% alert title="Info" color="info" %}}
+## **Overview**
 
-To learn how to open or load presentations, see the [*Open Presentation*](https://docs.aspose.com/slides/cpp/open-presentation/) article. 
+[Open Presentations in C++](/slides/cpp/open-presentation/) described how to use the [Presentation](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/) class to open a presentation. This article explains how to create and save presentations. The [Presentation](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/) class contains a presentation’s contents. Whether you’re creating a presentation from scratch or modifying an existing one, you’ll want to save it when you’re finished. With Aspose.Slides for C++, you can save to a **file** or **stream**. This article explains the different ways to save a presentation.
+
+## **Save Presentations to Files**
+
+Save a presentation to a file by calling the [Presentation](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/) class’s `Save` method. Pass the file name and save format to the method. The following example show how to save a presentation with Aspose.Slides.
+
+```cpp
+// Instantiate the Presentation class that represents a presentation file.
+auto presentation = MakeObject<Presentation>();
+
+// Do some work here...
+
+// Save the presentation to a file.
+presentation->Save(u"Output.pptx", SaveFormat::Pptx);
+
+presentation->Dispose();
+```
+
+## **Save Presentations to Streams**
+
+You can save a presentation to a stream by passing an output stream to the [Presentation](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/) class’s `Save` method. A presentation can be written to many stream types. In the example below, we create a new presentation and save it to a file stream.
+
+```cpp
+// Instantiate the Presentation class that represents a presentation file.
+auto presentation = MakeObject<Presentation>();
+
+auto fileStream = MakeObject<FileStream>(u"Output.pptx", FileMode::Create);
+
+// Save the presentation to the stream.
+presentation->Save(fileStream, SaveFormat::Pptx);
+
+presentation->Dispose();
+fileStream->Close();
+```
+
+## **Save Presentations with a Predefined View Type**
+
+Aspose.Slides lets you set the initial view that PowerPoint uses when the generated presentation opens through the [ViewProperties](https://reference.aspose.com/slides/cpp/aspose.slides/viewproperties/) class. Use the [set_LastView](https://reference.aspose.com/slides/cpp/aspose.slides/viewproperties/set_lastview/) method with a value from the [ViewType](https://reference.aspose.com/slides/cpp/aspose.slides/viewtype/) enumeration.
+
+```cpp
+auto presentation = MakeObject<Presentation>();
+
+presentation->get_ViewProperties()->set_LastView(ViewType::SlideMasterView);
+
+presentation->Save(u"SlideMasterView.pptx", SaveFormat::Pptx);
+presentation->Dispose();
+```
+
+## **Save Presentations in the Strict Office Open XML Format**
+
+Aspose.Slides lets you save a presentation in the Strict Office Open XML format. Use the [PptxOptions](https://reference.aspose.com/slides/cpp/aspose.slides.export/pptxoptions/) class and set its conformance property when saving. If you set `Conformance.Iso29500_2008_Strict`, the output file is saved in the Strict Office Open XML format.
+
+The example below creates a presentation and saves it in the Strict Office Open XML format.
+
+```cpp
+auto options = MakeObject<PptxOptions>();
+options->set_Conformance(Conformance::Iso29500_2008_Strict);
+
+// Instantiate the Presentation class that represents a presentation file.
+auto presentation = MakeObject<Presentation>();
+
+// Save the presentation in the Strict Office Open XML format.
+presentation->Save(u"StrictOfficeOpenXml.pptx", SaveFormat::Pptx, options);
+presentation->Dispose();
+```
+
+## **Save Presentations in Office Open XML Format in Zip64 Mode**
+
+An Office Open XML file is a ZIP archive that imposes 4 GB (2^32 bytes) limits on the uncompressed size of any file, the compressed size of any file, and the total size of the archive, and it also limits the archive to 65,535 (2^16-1) files. ZIP64 format extensions raise these limits to 2^64.
+
+The [IPptxOptions.set_Zip64Mode](https://reference.aspose.com/slides/cpp/aspose.slides.export/ipptxoptions/set_zip64mode/) method lets you choose when to use ZIP64 format extensions when saving an Office Open XML file.
+
+This method can be used with the following modes:
+
+- `IfNecessary` uses ZIP64 format extensions only if the presentation exceeds the limitations above. This is the default mode.
+- `Never` never uses ZIP64 format extensions.
+- `Always` always uses ZIP64 format extensions.
+
+The following code demonstrates how to save a presentation as PPTX with ZIP64 format extensions enabled:
+
+```cpp
+auto pptxOptions = MakeObject<PptxOptions>();
+pptxOptions->set_Zip64Mode(Zip64Mode::Always);
+
+auto presentation = MakeObject<Presentation>(u"Sample.pptx");
+
+presentation->Save(u"OutputZip64.pptx", SaveFormat::Pptx, pptxOptions);
+presentation->Dispose();
+```
+
+{{% alert title="NOTE" color="warning" %}}
+
+When you save with `Zip64Mode.Never`, a [PptxException](https://reference.aspose.com/slides/cpp/aspose.slides/pptxexception/) is thrown if the presentation cannot be saved in ZIP32 format.
 
 {{% /alert %}}
 
-The article here explains how to save presentations.
+## **Save Presentations without Refreshing the Thumbnail**
 
-The [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation) class holds a presentation's content. Whether creating a presentation from scratch or modifying an existing one, when finished, you want to save the presentation. With Aspose.Slides for C++, it can be saved as a **file** or **stream**. This article explains how to save a presentation in different ways:
+The [PptxOptions.set_RefreshThumbnail](https://reference.aspose.com/slides/cpp/aspose.slides.export/pptxoptions/set_refreshthumbnail/) method controls thumbnail generation when saving a presentation to PPTX:
 
-## **Save Presentation to File**
-Save a presentation to files by calling the **Presentation** class [Save](https://reference.aspose.com/slides/net/aspose.slides/presentation/methods/save/index) method. Simply pass the file name and save format to the [Save](https://reference.aspose.com/slides/net/aspose.slides/presentation/methods/save/index) method. The examples that follow show how to save a presentation with Aspose.Slides for C++.
+- If set to `true`, the thumbnail is refreshed during save. This is the default.
+- If set to `false`, the current thumbnail is preserved. If the presentation has no thumbnail, none is generated.
 
-{{< gist "aspose-slides" "a690df625dc0b1fff869ab198affe7a4" "Examples-SlidesCPP-SaveToFile-SaveToFile.cpp" >}}
-## **Save Presentation to Stream**
-It is possible to save a presentation to a stream by passing an output stream to the [Presentation]() class Save method. There are many types of streams to which a presentation can be saved. In the below example we have created a new Presentation file, add text in shape and Save the presentation to the stream.
-
-{{< gist "aspose-com-gists" "81aeb05e6d3a070aa76fdea22ed53bc7" "Examples-SlidesCPP-SaveToStream-SaveToStream.cpp" >}}
-
-
-## **Save Presentation with Predefined View Type**
-Aspose.Slides for C++ provides a facility to set the view type for the generated presentation when it is opened in PowerPoint through the [ViewProperties](http://www.aspose.com/api/net/slides/aspose.slides/viewproperties) class. The [LastView](http://www.aspose.com/api/net/slides/aspose.slides/viewproperties/properties/index) property is used to set the view type by using the [ViewType](http://www.aspose.com/api/net/slides/aspose.slides/viewtype) enumerator.
-
-{{< gist "aspose-slides" "a690df625dc0b1fff869ab198affe7a4" "Examples-SlidesCPP-SaveAsPredefinedViewType-SaveAsPredefinedViewType.cpp" >}}
-
-## **Save Presentation to Strict Office Open XML Format**
-Aspose.Slides allows you to save the presentation in Strict Office Open XML format. For that purpose, it provides the **PptxOptions** class where you can set the Conformance property while saving the presentation file. If you set its value as **Conformance.Iso29500_2008_Strict**, then the output presentation file will be saved in Strict Office Open XML format.
-
-The following sample code creates a presentation and saves it in the Strict Office Open XML Format. While calling the Save method for the presentation, the **PptxOptions** object is passed into it with the Conformance property set as **Conformance.Iso29500_2008_Strict**.
-
-{{< gist "aspose-com-gists" "81aeb05e6d3a070aa76fdea22ed53bc7" "Examples-SlidesCPP-SaveToStrictOpenXML-SaveToStrictOpenXML.cpp" >}}
-
-## **Save a Presentation without Refreshing the Thumbnail**
-
-The [**IPptxOptions.set_RefreshThumbnail**](https://reference.aspose.com/slides/cpp/aspose.slides.export/ipptxoptions/set_refreshthumbnail/) method allows you to control the generation of the thumbnail when saving a presentation in PPTX format:
-
-- When the value **true** is passed, the presentation thumbnail will be refreshed while saving. This is the *default* value.
-- When the value **false** is passed, the current thumbnail will be saved as is. If the presentation doesn't have a thumbnail, no thumbnail will be generated.
-
-In the code below, we saved the presentation to PPTX format without refreshing its thumbnail:
+In the code below, the presentation is saved to PPTX without refreshing its thumbnail.
 
 ```cpp
-auto presentation = MakeObject<Presentation>(u"Sample.pptx");
-    
 auto pptxOptions = MakeObject<PptxOptions>();
 pptxOptions->set_RefreshThumbnail(false);
 
-presentation->Save(u"Sample_with_old_thumbnail.pptx", SaveFormat::Pptx, pptxOptions);
+auto presentation = MakeObject<Presentation>(u"Sample.pptx");
+
+presentation->Save(u"Output.pptx", SaveFormat::Pptx, pptxOptions);
 presentation->Dispose();
 ```
 
 {{% alert title="Info" color="info" %}}
 
-This option allows you to save time when saving a presentation in PPTX format.
+This option helps reduce the time required to save a presentation in PPTX format.
 
 {{% /alert %}}
 
 ## **Save Progress Updates in Percentage**
- New **IProgressCallback** interface has been added to **ISaveOptions** interface and **SaveOptions** abstract class. **IProgressCallback** interface represents a callback object for saving progress updates in percentage.  
 
-The following code snippets below shows how to use IProgressCallback interface:
+The [IProgressCallback](https://reference.aspose.com/slides/cpp/aspose.slides/iprogresscallback/) interface is used via the `set_ProgressCallback` method exposed by the [ISaveOptions](https://reference.aspose.com/slides/cpp/aspose.slides.export/isaveoptions/) interface and the abstract [SaveOptions](https://reference.aspose.com/slides/cpp/aspose.slides.export/saveoptions/) class. Assign an [IProgressCallback](https://reference.aspose.com/slides/cpp/aspose.slides/iprogresscallback/) implementation with `set_ProgressCallback` to receive save-progress updates as a percentage.
 
-{{< gist "aspose-com-gists" "81aeb05e6d3a070aa76fdea22ed53bc7" "Examples-SlidesCPP-CovertToPDFWithProgressUpdate-CovertToPDFWithProgressUpdate.cpp" >}}
+The following code snippets show how to use `IProgressCallback`.
 
-{{< gist "aspose-com-gists" "81aeb05e6d3a070aa76fdea22ed53bc7" "Examples-SlidesCPP-CovertToPDFWithProgressUpdate-ExportProgressHandler.cpp" >}}
+```cpp
+class ExportProgressHandler : public IProgressCallback
+{
+public:
+    void Reporting(double progressValue)
+    {
+        // Use the progress percentage value here.
+        int progress = static_cast<int>(progressValue);
+
+        Console::WriteLine(u"{0}% of the file has been converted.", progress);
+    }
+};
+```
+```cpp
+auto saveOptions = MakeObject<PdfOptions>();
+saveOptions->set_ProgressCallback(MakeObject<ExportProgressHandler>());
+
+auto presentation = MakeObject<Presentation>(u"Sample.pptx");
+
+presentation->Save(u"Output.pdf", SaveFormat::Pdf, saveOptions);
+presentation->Dispose();
+```
 
 {{% alert title="Info" color="info" %}}
 
-Using its own API, Aspose developed a [free PowerPoint Splitter app](https://products.aspose.app/slides/splitter) that allows users to split their presentations into multiple files. Essentially, the app saves selected slides from a given presentation as new PowerPoint (PPTX or PPT) files. 
+Aspose has developed a [free PowerPoint Splitter app](https://products.aspose.app/slides/splitter) using its own API. The app lets you split a presentation into multiple files by saving selected slides as new PPTX or PPT files.
 
 {{% /alert %}}

--- a/en/cpp/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/cpp/developer-guide/manage-presentation/save-presentation/_index.md
@@ -96,7 +96,7 @@ presentation->Dispose();
 
 An Office Open XML file is a ZIP archive that imposes 4 GB (2^32 bytes) limits on the uncompressed size of any file, the compressed size of any file, and the total size of the archive, and it also limits the archive to 65,535 (2^16-1) files. ZIP64 format extensions raise these limits to 2^64.
 
-The [IPptxOptions.set_Zip64Mode](https://reference.aspose.com/slides/cpp/aspose.slides.export/ipptxoptions/set_zip64mode/) method lets you choose when to use ZIP64 format extensions when saving an Office Open XML file.
+The [IPptxOptions::set_Zip64Mode](https://reference.aspose.com/slides/cpp/aspose.slides.export/ipptxoptions/set_zip64mode/) method lets you choose when to use ZIP64 format extensions when saving an Office Open XML file.
 
 This method can be used with the following modes:
 
@@ -124,7 +124,7 @@ When you save with `Zip64Mode.Never`, a [PptxException](https://reference.aspose
 
 ## **Save Presentations without Refreshing the Thumbnail**
 
-The [PptxOptions.set_RefreshThumbnail](https://reference.aspose.com/slides/cpp/aspose.slides.export/pptxoptions/set_refreshthumbnail/) method controls thumbnail generation when saving a presentation to PPTX:
+The [PptxOptions::set_RefreshThumbnail](https://reference.aspose.com/slides/cpp/aspose.slides.export/pptxoptions/set_refreshthumbnail/) method controls thumbnail generation when saving a presentation to PPTX:
 
 - If set to `true`, the thumbnail is refreshed during save. This is the default.
 - If set to `false`, the current thumbnail is preserved. If the presentation has no thumbnail, none is generated.

--- a/en/java/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/java/developer-guide/manage-presentation/save-presentation/_index.md
@@ -1,152 +1,152 @@
 ---
-title: Save Presentation
+title: Save Presentations in Java
+linktitle: Save Presentations
 type: docs
 weight: 80
 url: /java/save-presentation/
+keywords:
+- save PowerPoint
+- save OpenDocument
+- save presentation
+- save slide
+- save PPT
+- save PPTX
+- save ODP
+- presentation to file
+- presentation to stream
+- predefined view type
+- Strict Office Open XML Format
+- Zip64 mode
+- refreshing thumbnail
+- saving progress
+- Java
+- Aspose.Slides
+description: "Discover how to save presentations in Java using Aspose.Slides—export to PowerPoint or OpenDocument while retaining layouts, fonts and effects."
 ---
 
 ## **Overview**
-{{% alert color="primary" %}} 
 
-[Opening Presentation](/slides/java/open-presentation/) described how to use the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation) class to open a presentation. This article explains how to create and save presentations.
+[Open Presentations in Java](/slides/java/open-presentation/) described how to use the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation/) class to open a presentation. This article explains how to create and save presentations. The [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation/) class contains a presentation’s contents. Whether you’re creating a presentation from scratch or modifying an existing one, you’ll want to save it when you’re finished. With Aspose.Slides for Java, you can save to a **file** or **stream**. This article explains the different ways to save a presentation.
 
-{{% /alert %}} 
+## **Save Presentations to Files**
 
-The [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation) class holds a presentation's content. Whether creating a presentation from scratch or modifying an existing one, when finished, you want to save the presentation. With Aspose.Slides for Java, it can be saved as a **file** or **stream**. This article explains how to save a presentation in different ways:
-
-## **Save Presentation to File**
-Save a presentation to file by calling the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation) class [**Save**](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation#save-java.lang.String-int-) method. Simply pass the file name and [**SaveFormat**](https://reference.aspose.com/slides/java/com.aspose.slides/SaveFormat) to the [**Save**](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation#save-java.lang.String-int-) method.
-
-The examples that follow show how to save a presentation with Aspose.Slides for Java.
+Save a presentation to a file by calling the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation/) class’s `save` method. Pass the file name and save format to the method. The following example show how to save a presentation with Aspose.Slides.
 
 ```java
-// Instantiate a Presentation object that represents a PPT file
-Presentation pres = new Presentation();
+// Instantiate the Presentation class that represents a presentation file.
+Presentation presentation = new Presentation();
 try {
-    // ...do some work here...
-    
-    // Save your presentation to a file
-    pres.save("demoPass.pptx", com.aspose.slides.SaveFormat.Pptx);
+    // Do some work here...
+
+    // Save the presentation to a file.
+    presentation.save("Output.pptx", SaveFormat.Pptx);
 } finally {
-    if(pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
-## **Save Presentation to Stream**
-It is possible to save a presentation to a stream by passing an output stream to the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation) class [**Save**](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation#save-java.io.OutputStream-int-) method. There are many types of streams to which a presentation can be saved. In the below example we have created a new Presentation file, add text in shape and Save the presentation to the stream.
+## **Save Presentations to Streams**
+
+You can save a presentation to a stream by passing an output stream to the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation/) class’s `save` method. A presentation can be written to many stream types. In the example below, we create a new presentation and save it to a file stream.
 
 ```java
-// Instantiate a Presentation object that represents a PPT file
-Presentation pres = new Presentation();
+// Instantiate the Presentation class that represents a presentation file.
+Presentation presentation = new Presentation();
 try {
-    IAutoShape shape = pres.getSlides().get_Item(0).getShapes().addAutoShape(ShapeType.Rectangle, 200, 200, 200, 200);
-
-    // Add text to shape
-    shape.getTextFrame().setText("This demo shows how to Create PowerPoint file and save it to Stream.");
-
-    OutputStream os = new FileOutputStream("Save_As_Stream_out.pptx");
-
-    pres.save(os, com.aspose.slides.SaveFormat.Pptx);
-
-    os.close();
-} catch (IOException e) {
+    OutputStream fileStream = new FileOutputStream("Output.pptx");
+    try {
+        // Save the presentation to the stream.
+        presentation.save(fileStream, SaveFormat.Pptx);
+    } finally {
+        fileStream.close();
+    }
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
-## **Save Presentation with Predefined View Type**
-Aspose.Slides for Java provides a facility to set the view type for the generated presentation when it is opened in PowerPoint through the [ViewProperties](https://reference.aspose.com/slides/java/com.aspose.slides/ViewProperties) class. The [**setLastView**](https://reference.aspose.com/slides/java/com.aspose.slides/ViewProperties#setLastView-int-) property is used to set the view type by using the [**ViewType**](https://reference.aspose.com/slides/java/com.aspose.slides/ViewType) enumerator.
+## **Save Presentations with a Predefined View Type**
+
+Aspose.Slides lets you set the initial view that PowerPoint uses when the generated presentation opens through the [ViewProperties](https://reference.aspose.com/slides/java/com.aspose.slides/viewproperties/) class. Use the [setLastView](https://reference.aspose.com/slides/java/com.aspose.slides/viewproperties/#setLastView-int-) method with a value from the [ViewType](https://reference.aspose.com/slides/java/com.aspose.slides/viewtype/) enumeration.
 
 ```java
-// Opening the presentation file
-Presentation pres = new Presentation();
+Presentation presentation = new Presentation();
 try {
-    // Setting view type
-    pres.getViewProperties().setLastView((byte) ViewType.SlideMasterView);
-    
-    // Saving presentation
-    pres.save("newDemo.pptx", SaveFormat.Pptx);
+    presentation.getViewProperties().setLastView(ViewType.SlideMasterView);
+    presentation.save("SlideMasterView.pptx", SaveFormat.Pptx);
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
-## **Saving Presentations to Strict Office Open XML Format**
-Aspose.Slides allows you to save the presentation in Strict Office Open XML format. For that purpose, it provides the [**PptxOptions**](https://reference.aspose.com/slides/java/com.aspose.slides/pptxoptions) class where you can set the Conformance property while saving the presentation file. If you set its value as [**Conformance.Iso29500_2008_Strict**](https://reference.aspose.com/slides/java/com.aspose.slides/Conformance#Iso29500_2008_Strict), then the output presentation file will be saved in Strict Open XML format.
+## **Save Presentations in the Strict Office Open XML Format**
 
-The following sample code creates a presentation and saves it in the Strict Office Open XML format. While calling the [**Save**](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation#save-java.lang.String-int-com.aspose.slides.ISaveOptions-) method for the presentation, the [**PptxOptions**](https://reference.aspose.com/slides/java/com.aspose.slides/pptxoptions) object is passed into it with the Conformance property set as [**Conformance.Iso29500_2008_Strict**](https://reference.aspose.com/slides/java/com.aspose.slides/Conformance#Iso29500_2008_Strict).
+Aspose.Slides lets you save a presentation in the Strict Office Open XML format. Use the [PptxOptions](https://reference.aspose.com/slides/java/com.aspose.slides/pptxoptions/) class and set its conformance property when saving. If you set [Conformance.Iso29500_2008_Strict](https://reference.aspose.com/slides/java/com.aspose.slides/conformance/#Iso29500-2008-Strict), the output file is saved in the Strict Office Open XML format.
+
+The example below creates a presentation and saves it in the Strict Office Open XML format.
 
 ```java
-// Instantiate a Presentation object that represents a PPT file
-Presentation pres = new Presentation();
-try {
-    // Get the first slide
-    ISlide slide = pres.getSlides().get_Item(0);
-    
-    // Add an autoshape of type line
-    slide.getShapes().addAutoShape(ShapeType.Line, 50, 150, 300, 0);
-    
-    //Set Strict Office Open XML Format save options
-    PptxOptions options = new PptxOptions();
-    options.setConformance(Conformance.Iso29500_2008_Strict);
-    
-    // Save your presentation to a file
-    pres.save("demoPass.pptx", SaveFormat.Pptx, options);
-} finally {
-    if (pres != null) pres.dispose();
-}
+PptxOptions options = new PptxOptions();
+options.setConformance(Conformance.Iso29500_2008_Strict);
 
+// Instantiate the Presentation class that represents a presentation file.
+Presentation presentation = new Presentation();
+try {
+    // Save the presentation in the Strict Office Open XML format.
+    presentation.save("StrictOfficeOpenXml.pptx", SaveFormat.Pptx, options);
+} finally {
+    presentation.dispose();
+}
 ```
 
-## **Saving Presentations to Office Open XML format in Zip64 mode**
+## **Save Presentations in Office Open XML Format in Zip64 Mode**
 
-An Office Open XML file is a ZIP-archive that has a 4 GB (2^32 bytes) limit on uncompressed size of a file, compressed size of a file, and total size of the archive, as well as a limit of 65,535 (2^16-1) files in the archive. ZIP64 format extensions increase the limits to 2^64.
+An Office Open XML file is a ZIP archive that imposes 4 GB (2^32 bytes) limits on the uncompressed size of any file, the compressed size of any file, and the total size of the archive, and it also limits the archive to 65,535 (2^16-1) files. ZIP64 format extensions raise these limits to 2^64.
 
-The new [**IPptxOptions.Zip64Mode**](https://reference.aspose.com/slides/java/com.aspose.slides/zip64mode/) property allows you to choose when to use ZIP64 format extensions for the saved Office Open XML file.
+The [IPptxOptions.setZip64Mode](https://reference.aspose.com/slides/java/com.aspose.slides/ipptxoptions/#setZip64Mode-int-) method lets you choose when to use ZIP64 format extensions when saving an Office Open XML file.
 
-This property provides the following modes:
+This method can be used with the following modes:
 
-- [Zip64Mode.IfNecessary](https://reference.aspose.com/slides/java/com.aspose.slides/zip64mode/#IfNecessary) means that ZIP64 format extensions will only be used if the presentation falls outside the above limitations. This is the default mode.
-- [Zip64Mode.Never](https://reference.aspose.com/slides/java/com.aspose.slides/zip64mode/#Never) means that ZIP64 format extensions will not be used. 
-- [Zip64Mode.Always](https://reference.aspose.com/slides/java/com.aspose.slides/zip64mode/#Always) means that ZIP64 format extensions will always be used.
+- [IfNecessary](https://reference.aspose.com/slides/java/com.aspose.slides/zip64mode/#IfNecessary) uses ZIP64 format extensions only if the presentation exceeds the limitations above. This is the default mode.
+- [Never](https://reference.aspose.com/slides/java/com.aspose.slides/zip64mode/#Never) never uses ZIP64 format extensions.
+- [Always](https://reference.aspose.com/slides/java/com.aspose.slides/zip64mode/#Always) always uses ZIP64 format extensions.
 
-The following code demonstrates how to save the presentation to PPTX format with ZIP64 format extensions:
+The following code demonstrates how to save a presentation as PPTX with ZIP64 format extensions enabled:
 
 ```java
-Presentation pres = new Presentation("Sample.pptx");
+PptxOptions pptxOptions = new PptxOptions();
+pptxOptions.setZip64Mode(Zip64Mode.Always);
+
+Presentation presentation = new Presentation("Sample.pptx");
 try {
-    PptxOptions pptxOptions = new PptxOptions();
-    pptxOptions.setZip64Mode(Zip64Mode.Always);
-    
-    pres.save("Sample-zip64.pptx", SaveFormat.Pptx, pptxOptions);
+    presentation.save("OutputZip64.pptx", SaveFormat.Pptx, pptxOptions);
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
 {{% alert title="NOTE" color="warning" %}}
 
-Saving in the Zip64Mode.Never mode will throw a [PptxException](https://reference.aspose.com/slides/java/com.aspose.slides/pptxexception/) if the presentation cannot be saved in ZIP32 format.
+When you save with [Zip64Mode.Never](https://reference.aspose.com/slides/java/com.aspose.slides/zip64mode/#Never), a [PptxException](https://reference.aspose.com/slides/java/com.aspose.slides/pptxexception/) is thrown if the presentation cannot be saved in ZIP32 format.
 
 {{% /alert %}}
 
-## **Save a Presentation without Refreshing the Thumbnail**
+## **Save Presentations without Refreshing the Thumbnail**
 
-The [**IPptxOptions.setRefreshThumbnail**](https://reference.aspose.com/slides/java/com.aspose.slides/ipptxoptions/#setRefreshThumbnail-boolean-) method allows you to control the generation of the thumbnail when saving a presentation in PPTX format:
+The [PptxOptions.setRefreshThumbnail](https://reference.aspose.com/slides/java/com.aspose.slides/pptxoptions/#setRefreshThumbnail-boolean-) method controls thumbnail generation when saving a presentation to PPTX:
 
-- When the value **true** is passed, the presentation thumbnail will be refreshed while saving. This is the *default* value.
-- When the value **false** is passed, the current thumbnail will be saved as is. If the presentation doesn't have a thumbnail, no thumbnail will be generated.
+- If set to `true`, the thumbnail is refreshed during save. This is the default.
+- If set to `false`, the current thumbnail is preserved. If the presentation has no thumbnail, none is generated.
 
-In the code below, we saved the presentation to PPTX format without refreshing its thumbnail:
+In the code below, the presentation is saved to PPTX without refreshing its thumbnail.
 
 ```java
+PptxOptions pptxOptions = new PptxOptions();
+pptxOptions.setRefreshThumbnail(false);
+
 Presentation presentation = new Presentation("Sample.pptx");
 try {
-    PptxOptions pptxOptions = new PptxOptions();
-    pptxOptions.setRefreshThumbnail(false);
-
-    presentation.save("Sample_with_old_thumbnail.pptx", SaveFormat.Pptx, pptxOptions);
+    presentation.save("Output.pptx", SaveFormat.Pptx, pptxOptions);
 }
 finally {
     presentation.dispose();
@@ -155,40 +155,40 @@ finally {
 
 {{% alert title="Info" color="info" %}}
 
-This option allows you to save time when saving a presentation in PPTX format.
+This option helps reduce the time required to save a presentation in PPTX format.
 
 {{% /alert %}}
 
 ## **Save Progress Updates in Percentage**
-New [**IProgressCallback**](https://reference.aspose.com/slides/java/com.aspose.slides/IProgressCallback) interface has been added to [**ISaveOptions**](https://reference.aspose.com/slides/java/com.aspose.slides/ISaveOptions) interface and [**SaveOptions** ](https://reference.aspose.com/slides/java/com.aspose.slides/SaveOptions)abstract class. [**IProgressCallback**](https://reference.aspose.com/slides/java/com.aspose.slides/IProgressCallback) interface represents a callback object for saving progress updates in percentage.  
 
-The following code snippets below show how to use [IProgressCallback](https://reference.aspose.com/slides/java/com.aspose.slides/IProgressCallback) interface:
+The [IProgressCallback](https://reference.aspose.com/slides/java/com.aspose.slides/iprogresscallback/) interface is used via the `setProgressCallback` method exposed by the [ISaveOptions](https://reference.aspose.com/slides/java/com.aspose.slides/isaveoptions/) interface and the abstract [SaveOptions](https://reference.aspose.com/slides/java/com.aspose.slides/saveoptions/) class. Assign an [IProgressCallback](https://reference.aspose.com/slides/java/com.aspose.slides/iprogresscallback/) implementation with `setProgressCallback` to receive save-progress updates as a percentage.
+
+The following code snippets show how to use `IProgressCallback`.
 
 ```java
-// Opening the presentation file
-Presentation pres = new Presentation("ConvertToPDF.pptx");
+ISaveOptions saveOptions = new PdfOptions();
+saveOptions.setProgressCallback(new ExportProgressHandler());
+
+Presentation presentation = new Presentation("Sample.pptx");
 try {
-    ISaveOptions saveOptions = new PdfOptions();
-    saveOptions.setProgressCallback((IProgressCallback) new ExportProgressHandler());
-    pres.save("ConvertToPDF.pdf", SaveFormat.Pdf, saveOptions);
+    presentation.save("Output.pdf", SaveFormat.Pdf, saveOptions);
 } finally {
-    pres.dispose();
+    presentation.dispose();
 }
 ```
 ```java
-class ExportProgressHandler implements IProgressCallback 
-{
-    public void reporting(double progressValue) 
-	{
-        // Use progress percentage value here
-        int progress = Double.valueOf(progressValue).intValue();
-        System.out.println(progress + "% file converted");
+class ExportProgressHandler implements IProgressCallback {
+    public void reporting(double progressValue) {
+        // Use the progress percentage value here.
+        int progress = (int) progressValue;
+
+        System.out.println(progress + "% of the file has been converted.");
     }
 }
 ```
 
 {{% alert title="Info" color="info" %}}
 
-Using its own API, Aspose developed a [free PowerPoint Splitter app](https://products.aspose.app/slides/splitter) that allows users to split their presentations into multiple files. Essentially, the app saves selected slides from a given presentation as new PowerPoint (PPTX or PPT) files. 
+Aspose has developed a [free PowerPoint Splitter app](https://products.aspose.app/slides/splitter) using its own API. The app lets you split a presentation into multiple files by saving selected slides as new PPTX or PPT files.
 
 {{% /alert %}}

--- a/en/net/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/net/developer-guide/manage-presentation/save-presentation/_index.md
@@ -1,104 +1,116 @@
 ---
-title: Save Presentation in .NET
-linktitle: Save Presentation
+title: Save Presentations in .NET
+linktitle: Save Presentations
 type: docs
 weight: 80
 url: /net/save-presentation/
-keywords: "Save PowerPoint, PPT, PPTX, Save Presentation, file, stream, C#, Csharp, .NET"
-description: "Save PowerPoint Presentation as file or stream in C# or .NET"
+keywords:
+- save PowerPoint
+- save OpenDocument
+- save presentation
+- save slide
+- save PPT
+- save PPTX
+- save ODP
+- presentation to file
+- presentation to stream
+- predefined view type
+- Strict Office Open XML Format
+- Zip64 mode
+- refreshing thumbnail
+- saving progress
+- .NET
+- C#
+- Aspose.Slides
+description: "Discover how to save presentations in .NET using Aspose.Slides—export to PowerPoint or OpenDocument while retaining layouts, fonts and effects."
 ---
 
-## **Save Presentation**
-Opening a Presentation described how to use the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation) class to open a presentation. This article explains how to create and save presentations.
-The [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation) class holds a presentation's content. Whether creating a presentation from scratch or modifying an existing one, when finished, you want to save the presentation. With Aspose.Slides for .NET, it can be saved as a **file** or **stream**. This article explains how to save a presentation in different ways:
+## **Overview**
 
-### **Saving Presentation to Files**
-Save a presentation to files by calling the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation) class [Save](https://reference.aspose.com/slides/net/aspose.slides/presentation/methods/save/index) method. Simply pass the file name and save format to the [Save](https://reference.aspose.com/slides/net/aspose.slides/presentation/methods/save/index) method. The examples that follow show how to save a presentation with Aspose.Slides for .NET using C#.
+[Open Presentations in C#](/slides/net/open-presentation/) described how to use the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class to open a presentation. This article explains how to create and save presentations. The [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class contains a presentation’s contents. Whether you’re creating a presentation from scratch or modifying an existing one, you’ll want to save it when you’re finished. With Aspose.Slides for .NET, you can save to a **file** or **stream**. This article explains the different ways to save a presentation.
 
-```c#
-// Instantiate a Presentation object that represents a PPT file
-Presentation presentation= new Presentation();
+## **Save Presentations to Files**
 
-//...do some work here...
+Save a presentation to a file by calling the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class’s `Save` method. Pass the file name and save format to the method. The following example show how to save a presentation with Aspose.Slides.
 
-// Save your presentation to a file
-presentation.Save("Saved_out.pptx", Aspose.Slides.Export.SaveFormat.Pptx);
-```
-
-
-### **Saving Presentation to Streams**
-It is possible to save a presentation to a stream by passing an output stream to the  [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation) class Save method. There are many types of streams to which a presentation can be saved. In the below example we have created a new Presentation file, add text in shape and Save the presentation to the stream.
-
-```c#
-// Instantiate a Presentation object that represents a PPT file
+```cs
+// Instantiate the Presentation class that represents a presentation file.
 using (Presentation presentation = new Presentation())
 {
+    // Do some work here...
 
-    IAutoShape shape = presentation.Slides[0].Shapes.AddAutoShape(ShapeType.Rectangle, 200, 200, 200, 200);
-
-    // Add text to shape
-    shape.TextFrame.Text = "This demo shows how to Create PowerPoint file and save it to Stream.";
-
-    FileStream toStream = new FileStream("Save_As_Stream_out.pptx", FileMode.Create);
-    presentation.Save(toStream, Aspose.Slides.Export.SaveFormat.Pptx);
-    toStream.Close();
+    // Save the presentation to a file.
+    presentation.Save("Output.pptx", SaveFormat.Pptx);
 }
 ```
 
+## **Save Presentations to Streams**
 
-### **Saving Presentations with Predefined View Type**
-Aspose.Slides for .NET provides a facility to set the view type for the generated presentation when it is opened in PowerPoint through the [ViewProperties](https://reference.aspose.com/slides/net/aspose.slides/viewproperties) class. The [LastView](https://reference.aspose.com/slides/net/aspose.slides/viewproperties/properties/lastview) property is used to set the view type by using the [ViewType](https://reference.aspose.com/slides/net/aspose.slides/viewtype) enumerator.
+You can save a presentation to a stream by passing an output stream to the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class’s `Save` method. A presentation can be written to many stream types. In the example below, we create a new presentation and save it to a file stream.
 
-```csharp
-using (Presentation pres = new Presentation())
+```cs
+// Instantiate the Presentation class that represents a presentation file.
+using (Presentation presentation = new Presentation())
 {
-    pres.ViewProperties.LastView = ViewType.SlideMasterView;
-    pres.Save("pres-will-open-SlideMasterView.pptx", SaveFormat.Pptx);
+    using (FileStream fileStream = new FileStream("Output.pptx", FileMode.Create))
+    {
+        // Save the presentation to the stream.
+        presentation.Save(fileStream, SaveFormat.Pptx);
+    }
 }
 ```
 
-### **Saving Presentations to Strict Office Open XML Format**
-Aspose.Slides allows you to save the presentation in Strict Office Open XML format. For that purpose, it provides the [**Aspose.Slides.Export.PptxOptions**](https://reference.aspose.com/slides/net/aspose.slides.export/pptxoptions) class where you can set the Conformance property, while saving the presentation file. If you set its value as Conformance.Iso29500_2008_Strict, then the output presentation file will be saved in Strict Office Open XML format.
+## **Save Presentations with a Predefined View Type**
 
-The following sample code creates a presentation and saves it in the Strict Office Open XML Format. While calling the Save method for the presentation, the  **[Aspose.Slides.Export.PptxOptions](https://reference.aspose.com/slides/net/aspose.slides.export/pptxoptions)** object is passed into it with the [**Conformance** ](https://reference.aspose.com/slides/net/aspose.slides.export/pptxoptions/properties/conformance)property set as [**Conformance.Iso29500_2008_Strict**](https://reference.aspose.com/slides/net/aspose.slides.export/conformance).
+Aspose.Slides lets you set the initial view that PowerPoint uses when the generated presentation opens through the [ViewProperties](https://reference.aspose.com/slides/net/aspose.slides/viewproperties/) class. Set the [LastView](https://reference.aspose.com/slides/net/aspose.slides/viewproperties/lastview/) property to a value from the [ViewType](https://reference.aspose.com/slides/net/aspose.slides/viewtype/) enumeration.
 
-
-
-```csharp
-   // Instantiate a Presentation object that represents a presentation file
-   using (Presentation presentation = new Presentation())
-   {
-       // Get the first slide
-       ISlide slide = presentation.Slides[0];
-
-       // Add an autoshape of type line
-       slide.Shapes.AddAutoShape(ShapeType.Line, 50, 150, 300, 0);
-
-       // Save the presentation to Strict Office Open XML Format
-       presentation.Save(dataDir + "NewPresentation_out.pptx", Aspose.Slides.Export.SaveFormat.Pptx,
-           new PptxOptions() { Conformance = Conformance.Iso29500_2008_Strict });
-
-   }
-
+```cs
+// Instantiate the Presentation class that represents a presentation file.
+using (Presentation presentation = new Presentation())
+{
+    presentation.ViewProperties.LastView = ViewType.SlideMasterView;
+    presentation.Save("SlideMasterView.pptx", SaveFormat.Pptx);
+}
 ```
 
-### **Saving Presentations to Office Open XML format in Zip64 mode**
-An Office Open XML file is a ZIP-archive that has a 4 GB (2^32 bytes) limit on uncompressed size of a file, compressed size of a file, and total size of the archive, as well as a limit of 65,535 (2^16-1) files in the archive. ZIP64 format extensions increase the limits to 2^64.
+## **Save Presentations in the Strict Office Open XML Format**
 
-The new [**IPptxOptions.Zip64Mode**](https://reference.aspose.com/slides/net/aspose.slides.export/ipptxoptions/zip64mode/) property allows you to choose when to use ZIP64 format extensions for the saved Office Open XML file.
+Aspose.Slides lets you save a presentation in the Strict Office Open XML format. Use the [PptxOptions](https://reference.aspose.com/slides/net/aspose.slides.export/pptxoptions/) class and set its conformance property when saving. If you set `Conformance.Iso29500_2008_Strict`, the output file is saved in the Strict Office Open XML format.
+
+The example below creates a presentation and saves it in the Strict Office Open XML format.
+
+```cs
+PptxOptions options = new PptxOptions()
+{
+    Conformance = Conformance.Iso29500_2008_Strict
+};
+
+// Instantiate the Presentation class that represents a presentation file.
+using (Presentation presentation = new Presentation())
+{
+    // Save the presentation in the Strict Office Open XML format.
+    presentation.Save("StrictOfficeOpenXml.pptx", SaveFormat.Pptx, options);
+}
+```
+
+## **Save Presentations in Office Open XML Format in Zip64 Mode**
+
+An Office Open XML file is a ZIP archive that imposes 4 GB (2^32 bytes) limits on the uncompressed size of any file, the compressed size of any file, and the total size of the archive, and it also limits the archive to 65,535 (2^16-1) files. ZIP64 format extensions raise these limits to 2^64.
+
+The [IPptxOptions.Zip64Mode](https://reference.aspose.com/slides/net/aspose.slides.export/ipptxoptions/zip64mode/) property lets you choose when to use ZIP64 format extensions when saving an Office Open XML file.
 
 This property provides the following modes:
 
-- [Zip64Mode.IfNecessary](https://reference.aspose.com/slides/net/aspose.slides.export/zip64mode/) means that ZIP64 format extensions will only be used if the presentation falls outside the above limitations. This is the default mode.
-- [Zip64Mode.Never](https://reference.aspose.com/slides/net/aspose.slides.export/zip64mode/) means that ZIP64 format extensions will not be used. 
-- [Zip64Mode.Always](https://reference.aspose.com/slides/net/aspose.slides.export/zip64mode/) means that ZIP64 format extensions will always be used.
+- [IfNecessary](https://reference.aspose.com/slides/net/aspose.slides.export/zip64mode/) uses ZIP64 format extensions only if the presentation exceeds the limitations above. This is the default mode.
+- [Never](https://reference.aspose.com/slides/net/aspose.slides.export/zip64mode/) never uses ZIP64 format extensions.
+- [Always](https://reference.aspose.com/slides/net/aspose.slides.export/zip64mode/) always uses ZIP64 format extensions.
 
-The following C# code demonstrates how to save the presentation to PPTX format with ZIP64 format extensions:
+The following code demonstrates how to save a presentation as PPTX with ZIP64 format extensions enabled:
 
-```c#
-using (Presentation pres = new Presentation("Sample.pptx"))
+```cs
+using (Presentation presentation = new Presentation("Sample.pptx"))
 {
-    pres.Save("Sample-zip64.pptx", SaveFormat.Pptx, new PptxOptions()
+    presentation.Save("OutputZip64.pptx", SaveFormat.Pptx, new PptxOptions()
     {
         Zip64Mode = Zip64Mode.Always
     });
@@ -107,23 +119,23 @@ using (Presentation pres = new Presentation("Sample.pptx"))
 
 {{% alert title="NOTE" color="warning" %}}
 
-Saving in the Zip64Mode.Never mode will throw a [PptxException](https://reference.aspose.com/slides/net/aspose.slides/pptxexception/) if the presentation cannot be saved in ZIP32 format.
+When you save with `Zip64Mode.Never`, a [PptxException](https://reference.aspose.com/slides/net/aspose.slides/pptxexception/) is thrown if the presentation cannot be saved in ZIP32 format.
 
 {{% /alert %}}
 
-### **Saving Presentation without Refreshing Thumbnail**
+## **Save Presentations without Refreshing the Thumbnail**
 
-The new [**IPptxOptions.RefreshThumbnail**](https://reference.aspose.com/slides/net/aspose.slides.export/ipptxoptions/refreshthumbnail/) property allows you to control the generation of the thumbnail when saving a presentation in PPTX format:
+The [PptxOptions.RefreshThumbnail](https://reference.aspose.com/slides/net/aspose.slides.export/ipptxoptions/refreshthumbnail/) property controls thumbnail generation when saving a presentation to PPTX:
 
-- When the property value is **true**, the presentation thumbnail will be refreshed while saving. This is the *default* value.
-- When the property value is **false**, the current thumbnail will be saved as is. If the presentation doesn't have a thumbnail, no thumbnail will be generated.
+- If set to `true`, the thumbnail is refreshed during save. This is the default.
+- If set to `false`, the current thumbnail is preserved. If the presentation has no thumbnail, none is generated.
 
-In the code below, we saved the presentation to PPTX format without refreshing its thumbnail:
+In the code below, the presentation is saved to PPTX without refreshing its thumbnail.
 
-```c#
-using (Presentation pres = new Presentation("Sample.pptx"))
+```cs
+using (Presentation presentation = new Presentation("Sample.pptx"))
 {
-    pres.Save("Sample_with_old_thumbnail.pptx", SaveFormat.Pptx, new PptxOptions()
+    presentation.Save("Output.pptx", SaveFormat.Pptx, new PptxOptions()
     {
         RefreshThumbnail = false
     });
@@ -132,57 +144,41 @@ using (Presentation pres = new Presentation("Sample.pptx"))
 
 {{% alert title="Info" color="info" %}}
 
-This option allows you to save time when saving a presentation in PPTX format.
+This option helps reduce the time required to save a presentation in PPTX format.
 
 {{% /alert %}}
 
-### **Saving Progress Updates in Percentage**
-New [**IProgressCallback** ](https://reference.aspose.com/slides/net/aspose.slides/iprogresscallback)interface has been added to [**ISaveOptions** ](https://reference.aspose.com/slides/net/aspose.slides.export/isaveoptions)interface and [**SaveOptions** ](https://reference.aspose.com/slides/net/aspose.slides.export/saveoptions)abstract class. **IProgressCallback** interface represents a callback object for saving progress updates in percentage.
+## **Save Progress Updates in Percentage**
 
-The following code snippets below shows how to use IProgressCallback interface:
+The [IProgressCallback](https://reference.aspose.com/slides/net/aspose.slides/iprogresscallback/) interface is used via the `ProgressCallback` property exposed by the [ISaveOptions](https://reference.aspose.com/slides/net/aspose.slides.export/isaveoptions/) interface and the abstract [SaveOptions](https://reference.aspose.com/slides/net/aspose.slides.export/saveoptions/) class. Assign an [IProgressCallback](https://reference.aspose.com/slides/net/aspose.slides/iprogresscallback/) implementation to `ProgressCallback` to receive save-progress updates as a percentage.
 
-```c#
-using (Presentation presentation = new Presentation("ConvertToPDF.pptx"))
+The following code snippets show how to use `IProgressCallback`.
+
+```cs
+ISaveOptions saveOptions = new PdfOptions();
+saveOptions.ProgressCallback = new ExportProgressHandler();
+
+using (Presentation presentation = new Presentation("Sample.pptx"))
 {
-    ISaveOptions saveOptions = new PdfOptions();
-    saveOptions.ProgressCallback = new ExportProgressHandler();
-    presentation.Save("ConvertToPDF.pdf", SaveFormat.Pdf, saveOptions);
+    presentation.Save("Output.pdf", SaveFormat.Pdf, saveOptions);
 }
-
 ```
 
-
-
-```c#
+```cs
 class ExportProgressHandler : IProgressCallback
 {
     public void Reporting(double progressValue)
     {
-        // Use progress percentage value here
+        // Use the progress percentage value here.
         int progress = Convert.ToInt32(progressValue);
+
         Console.WriteLine(progress + "% file converted");
     }
 }
 ```
 
-
-
 {{% alert title="Info" color="info" %}}
 
-Using its own API, Aspose developed a [free PowerPoint Splitter app](https://products.aspose.app/slides/splitter) that allows users to split their presentations into multiple files. Essentially, the app saves selected slides from a given presentation as new PowerPoint (PPTX or PPT) files. 
+Aspose has developed a [free PowerPoint Splitter app](https://products.aspose.app/slides/splitter) using its own API. The app lets you split a presentation into multiple files by saving selected slides as new PPTX or PPT files.
 
 {{% /alert %}}
-
-<h2>Open and Save Presentation</h2>
-
-<a name="csharp-open-save-presentation"><strong>Steps: Open and Save Presentation in C#</strong></a>
-
-1. Create an instance of [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class with any format i.e. PPT, PPTX, ODP etc.
-2. Save _Presentation_ to any format supported by [SaveFormat](https://reference.aspose.com/slides/net/aspose.slides.export/saveformat/)
-
-```c#
-// Load any supported file in Presentation e.g. ppt, pptx, odp etc.
-Presentation presentation = new Presentation("Sample.odp");
-
-presentation.Save("OutputPresenation.pptx", SaveFormat.Pptx);
-```

--- a/en/net/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/net/developer-guide/manage-presentation/save-presentation/_index.md
@@ -65,7 +65,6 @@ using (Presentation presentation = new Presentation())
 Aspose.Slides lets you set the initial view that PowerPoint uses when the generated presentation opens through the [ViewProperties](https://reference.aspose.com/slides/net/aspose.slides/viewproperties/) class. Set the [LastView](https://reference.aspose.com/slides/net/aspose.slides/viewproperties/lastview/) property to a value from the [ViewType](https://reference.aspose.com/slides/net/aspose.slides/viewtype/) enumeration.
 
 ```cs
-// Instantiate the Presentation class that represents a presentation file.
 using (Presentation presentation = new Presentation())
 {
     presentation.ViewProperties.LastView = ViewType.SlideMasterView;
@@ -101,9 +100,9 @@ The [IPptxOptions.Zip64Mode](https://reference.aspose.com/slides/net/aspose.slid
 
 This property provides the following modes:
 
-- [IfNecessary](https://reference.aspose.com/slides/net/aspose.slides.export/zip64mode/) uses ZIP64 format extensions only if the presentation exceeds the limitations above. This is the default mode.
-- [Never](https://reference.aspose.com/slides/net/aspose.slides.export/zip64mode/) never uses ZIP64 format extensions.
-- [Always](https://reference.aspose.com/slides/net/aspose.slides.export/zip64mode/) always uses ZIP64 format extensions.
+- `IfNecessary` uses ZIP64 format extensions only if the presentation exceeds the limitations above. This is the default mode.
+- `Never` never uses ZIP64 format extensions.
+- `Always` always uses ZIP64 format extensions.
 
 The following code demonstrates how to save a presentation as PPTX with ZIP64 format extensions enabled:
 
@@ -172,7 +171,7 @@ class ExportProgressHandler : IProgressCallback
         // Use the progress percentage value here.
         int progress = Convert.ToInt32(progressValue);
 
-        Console.WriteLine(progress + "% file converted");
+        Console.WriteLine(progress + "% of the file has been converted.");
     }
 }
 ```

--- a/en/nodejs-java/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/nodejs-java/developer-guide/manage-presentation/save-presentation/_index.md
@@ -1,151 +1,153 @@
 ---
-title: Save Presentation
+title: Save Presentations in JavaScript
+linktitle: Save Presentations
 type: docs
 weight: 80
 url: /nodejs-java/save-presentation/
+keywords:
+- save PowerPoint
+- save OpenDocument
+- save presentation
+- save slide
+- save PPT
+- save PPTX
+- save ODP
+- presentation to file
+- presentation to stream
+- predefined view type
+- Strict Office Open XML Format
+- Zip64 mode
+- refreshing thumbnail
+- saving progress
+- Node.js
+- JavaScript
+- Aspose.Slides
+description: "Discover how to save presentations in JavaScript using Aspose.Slides—export to PowerPoint or OpenDocument while retaining layouts, fonts and effects."
 ---
 
 ## **Overview**
-{{% alert color="primary" %}} 
 
-[Opening Presentation](/slides/nodejs-java/open-presentation/) described how to use the [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Presentation) class to open a presentation. This article explains how to create and save presentations.
+[Open Presentations in JavaScript](/slides/nodejs-java/open-presentation/) described how to use the [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/) class to open a presentation. This article explains how to create and save presentations. The [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/) class contains a presentation’s contents. Whether you’re creating a presentation from scratch or modifying an existing one, you’ll want to save it when you’re finished. With Aspose.Slides for Node.js, you can save to a **file** or **stream**. This article explains the different ways to save a presentation.
 
-{{% /alert %}} 
+## **Save Presentations to Files**
 
-The [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Presentation) class holds a presentation's content. Whether creating a presentation from scratch or modifying an existing one, when finished, you want to save the presentation. With Aspose.Slides for Node.js via Java, it can be saved as a **file** or **stream**. This article explains how to save a presentation in different ways:
+Save a presentation to a file by calling the [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/) class’s `save` method. Pass the file name and save format to the method. The following example show how to save a presentation with Aspose.Slides.
 
-## **Save Presentation to File**
-Save a presentation to file by calling the [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Presentation) class [**Save**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Presentation#save-java.lang.String-int-) method. Simply pass the file name and [**SaveFormat**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/SaveFormat) to the [**Save**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Presentation#save-java.lang.String-int-) method.
-
-The examples that follow show how to save a presentation with Aspose.Slides for Node.js via Java.
-
-```javascript
-// Instantiate a Presentation object that represents a PPT file
-var pres = new aspose.slides.Presentation();
+```js
+// Instantiate the Presentation class that represents a presentation file.
+var presentation = new aspose.slides.Presentation();
 try {
-    // ...do some work here...
-    // Save your presentation to a file
-    pres.save("demoPass.pptx", aspose.slides.SaveFormat.Pptx);
+    // Do some work here...
+
+    // Save the presentation to a file.
+    presentation.save("Output.pptx", aspose.slides.SaveFormat.Pptx);
 } finally {
-    if (pres != null) {
-        pres.dispose();
-    }
+    presentation.dispose();
 }
 ```
 
-## **Save Presentation to Stream**
-It is possible to save a presentation to a stream by passing an output stream to the [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Presentation) class [**Save**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Presentation#save-java.io.OutputStream-int-) method. There are many types of streams to which a presentation can be saved. In the below example we have created a new Presentation file, add text in shape and Save the presentation to the stream.
+## **Save Presentations to Streams**
 
-```javascript
-// Instantiate a Presentation object that represents a PPT file
-var pres = new aspose.slides.Presentation();
+You can save a presentation to a stream by passing an output stream to the [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/) class’s `save` method. A presentation can be written to many stream types. In the example below, we create a new presentation and save it to a file stream.
+
+```js
+// Instantiate the Presentation class that represents a presentation file.
+var presentation = new aspose.slides.Presentation();
 try {
-    var shape = pres.getSlides().get_Item(0).getShapes().addAutoShape(aspose.slides.ShapeType.Rectangle, 200, 200, 200, 200);
-    // Add text to shape
-    shape.getTextFrame().setText("This demo shows how to Create PowerPoint file and save it to Stream.");
-    var os = java.newInstanceSync("java.io.FileOutputStream", "Save_As_Stream_out.pptx");
-    pres.save(os, aspose.slides.SaveFormat.Pptx);
-    os.close();
-} catch (e) {console.log(e);
-} finally {
-    if (pres != null) {
-        pres.dispose();
+    var fileStream = java.newInstanceSync("java.io.FileOutputStream", "Output.pptx");
+    try {
+        // Save the presentation to the stream.
+        presentation.save(fileStream, aspose.slides.SaveFormat.Pptx);
+    } finally {
+        fileStream.close();
     }
+} finally {
+    presentation.dispose();
 }
 ```
 
-## **Save Presentation with Predefined View Type**
-Aspose.Slides for Node.js via Java provides a facility to set the view type for the generated presentation when it is opened in PowerPoint through the [ViewProperties](https://reference.aspose.com/slides/nodejs-java/aspose.slides/ViewProperties) class. The [**setLastView**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/ViewProperties#setLastView-int-) property is used to set the view type by using the [**ViewType**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/ViewType) enumerator.
+## **Save Presentations with a Predefined View Type**
 
-```javascript
-// Opening the presentation file
-var pres = new aspose.slides.Presentation();
+Aspose.Slides lets you set the initial view that PowerPoint uses when the generated presentation opens through the [ViewProperties](https://reference.aspose.com/slides/nodejs-java/aspose.slides/viewproperties/) class. Use the [setLastView](https://reference.aspose.com/slides/nodejs-java/aspose.slides/viewproperties/#setLastView) method with a value from the [ViewType](https://reference.aspose.com/slides/nodejs-java/aspose.slides/viewtype/) enumeration.
+
+```js
+var presentation = new aspose.slides.Presentation();
 try {
-    // Setting view type
-    pres.getViewProperties().setLastView(aspose.slides.ViewType.SlideMasterView);
-    // Saving presentation
-    pres.save("newDemo.pptx", aspose.slides.SaveFormat.Pptx);
+    presentation.getViewProperties().setLastView(aspose.slides.ViewType.SlideMasterView);
+    presentation.save("SlideMasterView.pptx", aspose.slides.SaveFormat.Pptx);
 } finally {
-    if (pres != null) {
-        pres.dispose();
-    }
+    presentation.dispose();
 }
 ```
 
-## **Saving Presentations to Strict Office Open XML Format**
-Aspose.Slides allows you to save the presentation in Strict Office Open XML format. For that purpose, it provides the [**PptxOptions**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/pptxoptions) class where you can set the Conformance property while saving the presentation file. If you set its value as [**Conformance.Iso29500_2008_Strict**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Conformance#Iso29500_2008_Strict), then the output presentation file will be saved in Strict Open XML format.
+## **Save Presentations in the Strict Office Open XML Format**
 
-The following sample code creates a presentation and saves it in the Strict Office Open XML format. While calling the [**Save**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Presentation#save-java.lang.String-int-aspose.slides.ISaveOptions-) method for the presentation, the [**PptxOptions**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/pptxoptions) object is passed into it with the Conformance property set as [**Conformance.Iso29500_2008_Strict**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Conformance#Iso29500_2008_Strict).
+Aspose.Slides lets you save a presentation in the Strict Office Open XML format. Use the [PptxOptions](https://reference.aspose.com/slides/nodejs-java/aspose.slides/pptxoptions/) class and set its conformance property when saving. If you set [Conformance.Iso29500_2008_Strict](https://reference.aspose.com/slides/nodejs-java/aspose.slides/conformance/#Iso29500_2008_Strict), the output file is saved in the Strict Office Open XML format.
 
-```javascript
-// Instantiate a Presentation object that represents a PPT file
-var pres = new aspose.slides.Presentation();
+The example below creates a presentation and saves it in the Strict Office Open XML format.
+
+```js
+var options = new aspose.slides.PptxOptions();
+options.setConformance(aspose.slides.Conformance.Iso29500_2008_Strict);
+
+// Instantiate the Presentation class that represents a presentation file.
+var presentation = new aspose.slides.Presentation();
 try {
-    // Get the first slide
-    var slide = pres.getSlides().get_Item(0);
-    // Add an autoshape of type line
-    slide.getShapes().addAutoShape(aspose.slides.ShapeType.Line, 50, 150, 300, 0);
-    // Set Strict Office Open XML Format save options
-    var options = new aspose.slides.PptxOptions();
-    options.setConformance(aspose.slides.Conformance.Iso29500_2008_Strict);
-    // Save your presentation to a file
-    pres.save("demoPass.pptx", aspose.slides.SaveFormat.Pptx, options);
+    // Save the presentation in the Strict Office Open XML format.
+    presentation.save("StrictOfficeOpenXml.pptx", aspose.slides.SaveFormat.Pptx, options);
 } finally {
-    if (pres != null) {
-        pres.dispose();
-    }
+    presentation.dispose();
 }
 ```
 
-## **Saving Presentations to Office Open XML format in Zip64 mode**
+## **Save Presentations in Office Open XML Format in Zip64 Mode**
 
-An Office Open XML file is a ZIP-archive that has a 4 GB (2^32 bytes) limit on uncompressed size of a file, compressed size of a file, and total size of the archive, as well as a limit of 65,535 (2^16-1) files in the archive. ZIP64 format extensions increase the limits to 2^64.
+An Office Open XML file is a ZIP archive that imposes 4 GB (2^32 bytes) limits on the uncompressed size of any file, the compressed size of any file, and the total size of the archive, and it also limits the archive to 65,535 (2^16-1) files. ZIP64 format extensions raise these limits to 2^64.
 
-The new [**PptxOptions.Zip64Mode**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/zip64mode/) property allows you to choose when to use ZIP64 format extensions for the saved Office Open XML file.
+The [PptxOptions.setZip64Mode](https://reference.aspose.com/slides/nodejs-java/aspose.slides/pptxoptions/#getZip64Mode) method lets you choose when to use ZIP64 format extensions when saving an Office Open XML file.
 
-This property provides the following modes:
+This method can be used with the following modes:
 
-- [Zip64Mode.IfNecessary](https://reference.aspose.com/slides/nodejs-java/aspose.slides/zip64mode/#IfNecessary) means that ZIP64 format extensions will only be used if the presentation falls outside the above limitations. This is the default mode.
-- [Zip64Mode.Never](https://reference.aspose.com/slides/nodejs-java/aspose.slides/zip64mode/#Never) means that ZIP64 format extensions will not be used.
-- [Zip64Mode.Always](https://reference.aspose.com/slides/nodejs-java/aspose.slides/zip64mode/#Always) means that ZIP64 format extensions will always be used.
+- [IfNecessary](https://reference.aspose.com/slides/nodejs-java/aspose.slides/zip64mode/#IfNecessary) uses ZIP64 format extensions only if the presentation exceeds the limitations above. This is the default mode.
+- [Never](https://reference.aspose.com/slides/nodejs-java/aspose.slides/zip64mode/#Never) never uses ZIP64 format extensions.
+- [Always](https://reference.aspose.com/slides/nodejs-java/aspose.slides/zip64mode/#Always) always uses ZIP64 format extensions.
 
-The following code demonstrates how to save the presentation to PPTX format with ZIP64 format extensions:
+The following code demonstrates how to save a presentation as PPTX with ZIP64 format extensions enabled:
 
-```javascript
-var pres = new aspose.slides.Presentation("Sample.pptx");
+```js
+var pptxOptions = new aspose.slides.PptxOptions();
+pptxOptions.setZip64Mode(aspose.slides.Zip64Mode.Always);
+
+var presentation = new aspose.slides.Presentation("Sample.pptx");
 try {
-    var pptxOptions = new aspose.slides.PptxOptions();
-    pptxOptions.setZip64Mode(aspose.slides.Zip64Mode.Always);
-    pres.save("Sample-zip64.pptx", aspose.slides.SaveFormat.Pptx, pptxOptions);
+    presentation.save("OutputZip64.pptx", aspose.slides.SaveFormat.Pptx, pptxOptions);
 } finally {
-    if (pres != null) {
-        pres.dispose();
-    }
+    presentation.dispose();
 }
 ```
 
 {{% alert title="NOTE" color="warning" %}}
 
-Saving in the Zip64Mode.Never mode will throw a [PptxException](https://reference.aspose.com/slides/nodejs-java/aspose.slides/pptxexception/) if the presentation cannot be saved in ZIP32 format.
+When you save with [Zip64Mode.Never](https://reference.aspose.com/slides/nodejs-java/aspose.slides/zip64mode/#Never), a [PptxException](https://reference.aspose.com/slides/nodejs-java/aspose.slides/pptxexception/) is thrown if the presentation cannot be saved in ZIP32 format.
 
 {{% /alert %}}
 
-## **Save a Presentation without Refreshing the Thumbnail**
+## **Save Presentations without Refreshing the Thumbnail**
 
-The [**PptxOptions.setRefreshThumbnail**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/pptxoptions/#setRefreshThumbnail) method allows you to control the generation of the thumbnail when saving a presentation in PPTX format:
+The [PptxOptions.setRefreshThumbnail](https://reference.aspose.com/slides/nodejs-java/aspose.slides/pptxoptions/#setRefreshThumbnail) method controls thumbnail generation when saving a presentation to PPTX:
 
-- When the value **true** is passed, the presentation thumbnail will be refreshed while saving. This is the *default* value.
-- When the value **false** is passed, the current thumbnail will be saved as is. If the presentation doesn't have a thumbnail, no thumbnail will be generated.
+- If set to `true`, the thumbnail is refreshed during save. This is the default.
+- If set to `false`, the current thumbnail is preserved. If the presentation has no thumbnail, none is generated.
 
-In the code below, we saved the presentation to PPTX format without refreshing its thumbnail:
+In the code below, the presentation is saved to PPTX without refreshing its thumbnail.
 
 ```js
+var pptxOptions = new aspose.slides.PptxOptions();
+pptxOptions.setRefreshThumbnail(false);
+
 var presentation = new aspose.slides.Presentation("Sample.pptx");
 try {
-    var pptxOptions = new aspose.slides.PptxOptions();
-    pptxOptions.setRefreshThumbnail(false);
-
-    presentation.save("Sample_with_old_thumbnail.pptx", aspose.slides.SaveFormat.Pptx, pptxOptions);
+    presentation.save("Output.pptx", aspose.slides.SaveFormat.Pptx, pptxOptions);
 }
 finally {
     presentation.dispose();
@@ -154,36 +156,38 @@ finally {
 
 {{% alert title="Info" color="info" %}}
 
-This option allows you to save time when saving a presentation in PPTX format.
+This option helps reduce the time required to save a presentation in PPTX format.
 
 {{% /alert %}}
 
 ## **Save Progress Updates in Percentage**
-New [**ProgressCallback**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/ProgressCallback) class has been added to [**SaveOptions**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/SaveOptions) class and [**SaveOptions** ](https://reference.aspose.com/slides/nodejs-java/aspose.slides/SaveOptions)abstract class. [**ProgressCallback**](https://reference.aspose.com/slides/nodejs-java/aspose.slides/ProgressCallback) class represents a callback object for saving progress updates in percentage.  
 
-The following code snippets below show how to use [ProgressCallback](https://reference.aspose.com/slides/nodejs-java/aspose.slides/ProgressCallback) class:
+Save-progress reporting is configured via the [setProgressCallback](https://reference.aspose.com/slides/nodejs-java/aspose.slides/saveoptions/#setProgressCallback) method on [SaveOptions](https://reference.aspose.com/slides/nodejs-java/aspose.slides/saveoptions/) and its subclasses. Provide a Java proxy that implements the [IProgressCallback](https://reference.aspose.com/slides/java/com.aspose.slides/iprogresscallback/) interface; during export, the callback receives periodic percentage updates.
+
+The following code snippets show how to use `IProgressCallback`.
 
 ```javascript
-var pres = new aspose.slides.Presentation("ConvertToPDF.pptx");
+const ExportProgressHandler = java.newProxy("com.aspose.slides.IProgressCallback", {
+    reporting: function(progressValue) {
+        // Use the progress percentage value here.
+        const progress = Math.floor(progressValue);
+        console.log(`${progress}% of the file has been converted.`);
+    }
+});
+
+let saveOptions = new aspose.slides.PdfOptions();
+saveOptions.setProgressCallback(ExportProgressHandler);
+
+var presentation = new aspose.slides.Presentation("Sample.pptx");
 try {
-    let saveOptions = new aspose.slides.PdfOptions();
-    
-    const ExportProgressHandler = java.newProxy("com.aspose.slides.IProgressCallback", {
-        reporting: function(progressValue) {
-            const progress = Math.floor(progressValue);
-            console.log(`${progress}% file converted`);
-        }
-    });
-    
-    saveOptions.setProgressCallback(ExportProgressHandler);
-    pres.save("ConvertToPDF.pdf", aspose.slides.SaveFormat.Pdf, saveOptions);
+    presentation.save("Output.pdf", aspose.slides.SaveFormat.Pdf, saveOptions);
 } finally {
-    pres.dispose();
+    presentation.dispose();
 }
 ```
 
 {{% alert title="Info" color="info" %}}
 
-Using its own API, Aspose developed a [free PowerPoint Splitter app](https://products.aspose.app/slides/splitter) that allows users to split their presentations into multiple files. Essentially, the app saves selected slides from a given presentation as new PowerPoint (PPTX or PPT) files. 
+Aspose has developed a [free PowerPoint Splitter app](https://products.aspose.app/slides/splitter) using its own API. The app lets you split a presentation into multiple files by saving selected slides as new PPTX or PPT files.
 
 {{% /alert %}}

--- a/en/php-java/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/php-java/developer-guide/manage-presentation/save-presentation/_index.md
@@ -1,149 +1,152 @@
 ---
-title: Save Presentation
+title: Save Presentations in PHP
+linktitle: Save Presentations
 type: docs
 weight: 80
 url: /php-java/save-presentation/
+keywords:
+- save PowerPoint
+- save OpenDocument
+- save presentation
+- save slide
+- save PPT
+- save PPTX
+- save ODP
+- presentation to file
+- presentation to stream
+- predefined view type
+- Strict Office Open XML Format
+- Zip64 mode
+- refreshing thumbnail
+- saving progress
+- PHP
+- Aspose.Slides
+description: "Discover how to save presentations in PHP using Aspose.Slides—export to PowerPoint or OpenDocument while retaining layouts, fonts and effects."
 ---
 
 ## **Overview**
-{{% alert color="primary" %}} 
 
-[Opening Presentation](/slides/php-java/open-presentation/) described how to use the [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/Presentation) class to open a presentation. This article explains how to create and save presentations.
+[Open Presentations in PHP](/slides/php-java/open-presentation/) described how to use the [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/) class to open a presentation. This article explains how to create and save presentations. The [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/) class contains a presentation’s contents. Whether you’re creating a presentation from scratch or modifying an existing one, you’ll want to save it when you’re finished. With Aspose.Slides for PHP, you can save to a **file** or **stream**. This article explains the different ways to save a presentation.
 
-{{% /alert %}} 
+## **Save Presentations to Files**
 
-The [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/Presentation) class holds a presentation's content. Whether creating a presentation from scratch or modifying an existing one, when finished, you want to save the presentation. With Aspose.Slides for PHP via Java, it can be saved as a **file** or **stream**. This article explains how to save a presentation in different ways:
-
-## **Save Presentation to File**
-Save a presentation to file by calling the [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/Presentation) class [**Save**](https://reference.aspose.com/slides/php-java/aspose.slides/Presentation#save-java.lang.String-int-) method. Simply pass the file name and [**SaveFormat**](https://reference.aspose.com/slides/php-java/aspose.slides/SaveFormat) to the [**Save**](https://reference.aspose.com/slides/php-java/aspose.slides/Presentation#save-java.lang.String-int-) method.
-
-The examples that follow show how to save a presentation with Aspose.Slides for PHP via Java.
+Save a presentation to a file by calling the [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/) class’s `save` method. Pass the file name and save format to the method. The following example show how to save a presentation with Aspose.Slides.
 
 ```php
-  # Instantiate a Presentation object that represents a PPT file
-  $pres = new Presentation();
-  try {
-    # ...do some work here...
-    # Save your presentation to a file
-    $pres->save("demoPass.pptx", SaveFormat::Pptx);
-  } finally {
-    if (!java_is_null($pres)) {
-      $pres->dispose();
-    }
-  }
+// Instantiate the Presentation class that represents a presentation file.
+$presentation = new Presentation();
+try {
+    // Do some work here...
+
+    // Save the presentation to a file.
+    $presentation->save("Output.pptx", SaveFormat::Pptx);
+} finally {
+    $presentation->dispose();
+}
 ```
 
-## **Save Presentation to Stream**
-It is possible to save a presentation to a stream by passing an output stream to the [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/Presentation) class [**Save**](https://reference.aspose.com/slides/php-java/aspose.slides/Presentation#save-java.io.OutputStream-int-) method. There are many types of streams to which a presentation can be saved. In the below example we have created a new Presentation file, add text in shape and Save the presentation to the stream.
+## **Save Presentations to Streams**
+
+You can save a presentation to a stream by passing an output stream to the [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/) class’s `save` method. A presentation can be written to many stream types. In the example below, we create a new presentation and save it to a file stream.
 
 ```php
-  # Instantiate a Presentation object that represents a PPT file
-  $pres = new Presentation();
-  try {
-    $shape = $pres->getSlides()->get_Item(0)->getShapes()->addAutoShape(ShapeType::Rectangle, 200, 200, 200, 200);
-    # Add text to shape
-    $shape->getTextFrame()->setText("This demo shows how to Create PowerPoint file and save it to Stream.");
-    $os = new Java("java.io.FileOutputStream", "Save_As_Stream_out.pptx");
-    $pres->save($os, SaveFormat::Pptx);
-    $os->close();
-  } catch (JavaException $e) {
-  } finally {
-    if (!java_is_null($pres)) {
-      $pres->dispose();
-    }
-  }
+// Instantiate the Presentation class that represents a presentation file.
+$presentation = new Presentation();
+try {
+    $fileStream = new Java("java.io.FileOutputStream", "Output.pptx");
+    try {
+        // Save the presentation to the stream.
+        $presentation->save($fileStream, SaveFormat::Pptx);
+    } finally {
+    $fileStream->close();
+}
+} finally {
+    $presentation->dispose();
+}
 ```
 
-## **Save Presentation with Predefined View Type**
-Aspose.Slides for PHP via Java provides a facility to set the view type for the generated presentation when it is opened in PowerPoint through the [ViewProperties](https://reference.aspose.com/slides/php-java/aspose.slides/ViewProperties) class. The [**setLastView**](https://reference.aspose.com/slides/php-java/aspose.slides/ViewProperties#setLastView-int-) property is used to set the view type by using the [**ViewType**](https://reference.aspose.com/slides/php-java/aspose.slides/ViewType) enumerator.
+## **Save Presentations with a Predefined View Type**
+
+Aspose.Slides lets you set the initial view that PowerPoint uses when the generated presentation opens through the [ViewProperties](https://reference.aspose.com/slides/php-java/aspose.slides/viewproperties/) class. Use the [setLastView](https://reference.aspose.com/slides/php-java/aspose.slides/viewproperties/#setLastView) method with a value from the [ViewType](https://reference.aspose.com/slides/php-java/aspose.slides/viewtype/) enumeration.
 
 ```php
-  # Opening the presentation file
-  $pres = new Presentation();
-  try {
-    # Setting view type
-    $pres->getViewProperties()->setLastView(ViewType::SlideMasterView);
-    # Saving presentation
-    $pres->save("newDemo.pptx", SaveFormat::Pptx);
-  } finally {
-    if (!java_is_null($pres)) {
-      $pres->dispose();
-    }
-  }
+$presentation = new Presentation();
+try {
+    $presentation->getViewProperties()->setLastView(ViewType::SlideMasterView);
+    $presentation->save("SlideMasterView.pptx", SaveFormat::Pptx);
+} finally {
+    $presentation->dispose();
+}
 ```
 
-## **Saving Presentations to Strict Office Open XML Format**
-Aspose.Slides allows you to save the presentation in Strict Office Open XML format. For that purpose, it provides the [**PptxOptions**](https://reference.aspose.com/slides/php-java/aspose.slides/pptxoptions) class where you can set the Conformance property while saving the presentation file. If you set its value as [**Conformance.Iso29500_2008_Strict**](https://reference.aspose.com/slides/php-java/aspose.slides/Conformance#Iso29500_2008_Strict), then the output presentation file will be saved in Strict Open XML format.
+## **Save Presentations in the Strict Office Open XML Format**
 
-The following sample code creates a presentation and saves it in the Strict Office Open XML format. While calling the [**Save**](https://reference.aspose.com/slides/php-java/aspose.slides/Presentation#save-java.lang.String-int-com.aspose.slides.ISaveOptions-) method for the presentation, the [**PptxOptions**](https://reference.aspose.com/slides/php-java/aspose.slides/pptxoptions) object is passed into it with the Conformance property set as [**Conformance.Iso29500_2008_Strict**](https://reference.aspose.com/slides/php-java/aspose.slides/Conformance#Iso29500_2008_Strict).
+Aspose.Slides lets you save a presentation in the Strict Office Open XML format. Use the [PptxOptions](https://reference.aspose.com/slides/php-java/aspose.slides/pptxoptions/) class and set its conformance property when saving. If you set [Conformance.Iso29500_2008_Strict](https://reference.aspose.com/slides/php-java/aspose.slides/conformance/#Iso29500_2008_Strict), the output file is saved in the Strict Office Open XML format.
+
+The example below creates a presentation and saves it in the Strict Office Open XML format.
 
 ```php
-  # Instantiate a Presentation object that represents a PPT file
-  $pres = new Presentation();
-  try {
-    # Get the first slide
-    $slide = $pres->getSlides()->get_Item(0);
-    # Add an autoshape of type line
-    $slide->getShapes()->addAutoShape(ShapeType::Line, 50, 150, 300, 0);
-    #Set Strict Office Open XML Format save options
-    $options = new PptxOptions();
-    $options->setConformance(Conformance->Iso29500_2008_Strict);
-    # Save your presentation to a file
-    $pres->save("demoPass.pptx", SaveFormat::Pptx, $options);
-  } finally {
-    if (!java_is_null($pres)) {
-      $pres->dispose();
-    }
-  }
+$options = new PptxOptions();
+$options->setConformance(Conformance::Iso29500_2008_Strict);
+
+// Instantiate the Presentation class that represents a presentation file.
+$presentation = new Presentation();
+try {
+    // Save the presentation in the Strict Office Open XML format.
+    $presentation->save("StrictOfficeOpenXml.pptx", SaveFormat::Pptx, $options);
+} finally {
+    $presentation->dispose();
+}
 ```
 
-## **Saving Presentations to Office Open XML format in Zip64 mode**
-An Office Open XML file is a ZIP-archive that has a 4 GB (2^32 bytes) limit on uncompressed size of a file, compressed size of a file, and total size of the archive, as well as a limit of 65,535 (2^16-1) files in the archive. ZIP64 format extensions increase the limits to 2^64.
+## **Save Presentations in Office Open XML Format in Zip64 Mode**
 
-The new [**IPptxOptions.Zip64Mode**](https://reference.aspose.com/slides/php-java/aspose.slides/zip64mode/) property allows you to choose when to use ZIP64 format extensions for the saved Office Open XML file.
+An Office Open XML file is a ZIP archive that imposes 4 GB (2^32 bytes) limits on the uncompressed size of any file, the compressed size of any file, and the total size of the archive, and it also limits the archive to 65,535 (2^16-1) files. ZIP64 format extensions raise these limits to 2^64.
 
-This property provides the following modes:
+The [PptxOptions.setZip64Mode](https://reference.aspose.com/slides/php-java/aspose.slides/pptxoptions/#setZip64Mode) method lets you choose when to use ZIP64 format extensions when saving an Office Open XML file.
 
-- [Zip64Mode.IfNecessary](https://reference.aspose.com/slides/php-java/aspose.slides/zip64mode/#IfNecessary) means that ZIP64 format extensions will only be used if the presentation falls outside the above limitations. This is the default mode.
-- [Zip64Mode.Never](https://reference.aspose.com/slides/php-java/aspose.slides/zip64mode/#Never) means that ZIP64 format extensions will not be used. 
-- [Zip64Mode.Always](https://reference.aspose.com/slides/php-java/aspose.slides/zip64mode/#Always) means that ZIP64 format extensions will always be used.
+This method can be used with the following modes:
 
-The following code demonstrates how to save the presentation to PPTX format with ZIP64 format extensions:
+- [IfNecessary](https://reference.aspose.com/slides/php-java/aspose.slides/zip64mode/#IfNecessary) uses ZIP64 format extensions only if the presentation exceeds the limitations above. This is the default mode.
+- [Never](https://reference.aspose.com/slides/php-java/aspose.slides/zip64mode/#Never) never uses ZIP64 format extensions.
+- [Always](https://reference.aspose.com/slides/php-java/aspose.slides/zip64mode/#Always) always uses ZIP64 format extensions.
+
+The following code demonstrates how to save a presentation as PPTX with ZIP64 format extensions enabled:
 
 ```php
-  $pres = new Presentation("Sample.pptx");
-  try {
-    $pptxOptions = new PptxOptions();
-    $pptxOptions->setZip64Mode(Zip64Mode::Always);
-    
-    $pres->save("Sample-zip64.pptx", SaveFormat::Pptx, $pptxOptions);
-  } finally {
-    $pres->dispose();
-  }
+$pptxOptions = new PptxOptions();
+$pptxOptions->setZip64Mode(Zip64Mode::Always);
+
+$presentation = new Presentation("Sample.pptx");
+try {
+    $presentation->save("OutputZip64.pptx", SaveFormat::Pptx, $pptxOptions);
+} finally {
+    $presentation->dispose();
+}
 ```
 
 {{% alert title="NOTE" color="warning" %}}
 
-Saving in the Zip64Mode.Never mode will throw a [PptxException](https://reference.aspose.com/slides/php-java/aspose.slides/pptxexception/) if the presentation cannot be saved in ZIP32 format.
+When you save with [Zip64Mode.Never](https://reference.aspose.com/slides/php-java/aspose.slides/zip64mode/#Never), a [PptxException](https://reference.aspose.com/slides/php-java/aspose.slides/pptxexception/) is thrown if the presentation cannot be saved in ZIP32 format.
 
 {{% /alert %}}
 
-## **Save a Presentation without Refreshing the Thumbnail**
+## **Save Presentations without Refreshing the Thumbnail**
 
-The [**PptxOptions.setRefreshThumbnail**](https://reference.aspose.com/slides/php-java/aspose.slides/pptxoptions/#setRefreshThumbnail) method allows you to control the generation of the thumbnail when saving a presentation in PPTX format:
+The [PptxOptions.setRefreshThumbnail](https://reference.aspose.com/slides/php-java/aspose.slides/pptxoptions/#setRefreshThumbnail) method controls thumbnail generation when saving a presentation to PPTX:
 
-- When the value **true** is passed, the presentation thumbnail will be refreshed while saving. This is the *default* value.
-- When the value **false** is passed, the current thumbnail will be saved as is. If the presentation doesn't have a thumbnail, no thumbnail will be generated.
+- If set to `true`, the thumbnail is refreshed during save. This is the default.
+- If set to `false`, the current thumbnail is preserved. If the presentation has no thumbnail, none is generated.
 
-In the code below, we saved the presentation to PPTX format without refreshing its thumbnail:
+In the code below, the presentation is saved to PPTX without refreshing its thumbnail.
 
 ```php
+$pptxOptions = new PptxOptions();
+$pptxOptions->setRefreshThumbnail(false);
+
 $presentation = new Presentation("Sample.pptx");
 try {
-    $pptxOptions = new PptxOptions();
-    $pptxOptions->setRefreshThumbnail(false);
-
-    $presentation->save("Sample_with_old_thumbnail.pptx", SaveFormat::Pptx, $pptxOptions);
+    $presentation->save("Output.pptx", SaveFormat::Pptx, $pptxOptions);
 }
 finally {
     $presentation->dispose();
@@ -152,38 +155,40 @@ finally {
 
 {{% alert title="Info" color="info" %}}
 
-This option allows you to save time when saving a presentation in PPTX format.
+This option helps reduce the time required to save a presentation in PPTX format.
 
 {{% /alert %}}
 
 ## **Save Progress Updates in Percentage**
-New [**IProgressCallback**](https://reference.aspose.com/slides/php-java/aspose.slides/IProgressCallback) interface has been added to [**ISaveOptions**](https://reference.aspose.com/slides/php-java/aspose.slides/ISaveOptions) interface and [**SaveOptions** ](https://reference.aspose.com/slides/php-java/aspose.slides/SaveOptions)abstract class. [**IProgressCallback**](https://reference.aspose.com/slides/php-java/aspose.slides/IProgressCallback) interface represents a callback object for saving progress updates in percentage.  
 
-The following code snippets below show how to use [IProgressCallback](https://reference.aspose.com/slides/php-java/aspose.slides/IProgressCallback) interface:
+Save-progress reporting is configured via the [setProgressCallback](https://reference.aspose.com/slides/php-java/aspose.slides/saveoptions/#setProgressCallback) method on [SaveOptions](https://reference.aspose.com/slides/php-java/aspose.slides/saveoptions/) and its subclasses. Provide a Java proxy that implements the [IProgressCallback](https://reference.aspose.com/slides/java/com.aspose.slides/iprogresscallback/) interface; during export, the callback receives periodic percentage updates.
+
+The following code snippets show how to use `IProgressCallback`.
 
 ```php
-  class ExportProgressHandler {
+class ExportProgressHandler {
     function reporting($progressValue) {
-      # Use progress percentage value here
-      $progress = java("java.lang.Double")->valueOf($progressValue)->intValue();
-      echo($progress . "% file converted");
+        // Use the progress percentage value here.
+        $progress = java("java.lang.Double")->valueOf($progressValue)->intValue();
+        echo($progress . "% of the file has been converted.");
     }
-  }
+}
 
-  # Opening the presentation file
-  $pres = new Presentation("ConvertToPDF.pptx");
-  try {
-    $saveOptions = new PdfOptions();
-    $progressHandler = java_closure(new ExportProgressHandler(), null, java("com.aspose.slides.IProgressCallback"));
-    $saveOptions->setProgressCallback($progressHandler);
-    $pres->save("ConvertToPDF.pdf", SaveFormat::Pdf, $saveOptions);
-  } finally {
-    $pres->dispose();
-  }
+$progressHandler = java_closure(new ExportProgressHandler(), null, java("com.aspose.slides.IProgressCallback"));
+
+$saveOptions = new PdfOptions();
+$saveOptions->setProgressCallback($progressHandler);
+
+$presentation = new Presentation("Sample.pptx");
+try {
+    $presentation->save("Output.pdf", SaveFormat::Pdf, $saveOptions);
+} finally {
+    $presentation->dispose();
+}
 ```
 
 {{% alert title="Info" color="info" %}}
 
-Using its own API, Aspose developed a [free PowerPoint Splitter app](https://products.aspose.app/slides/splitter) that allows users to split their presentations into multiple files. Essentially, the app saves selected slides from a given presentation as new PowerPoint (PPTX or PPT) files. 
+Aspose has developed a [free PowerPoint Splitter app](https://products.aspose.app/slides/splitter) using its own API. The app lets you split a presentation into multiple files by saving selected slides as new PPTX or PPT files.
 
 {{% /alert %}}

--- a/en/python-net/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/python-net/developer-guide/manage-presentation/save-presentation/_index.md
@@ -6,14 +6,18 @@ weight: 80
 url: /python-net/save-presentation/
 keywords:
 - save PowerPoint
+- save OpenDocument
 - save presentation
+- save slide
 - save PPT
 - save PPTX
 - save ODP
-- save presentation to file
-- save presentation to stream
-- view type
-- strict Office Open XML format
+- presentation to file
+- presentation to stream
+- predefined view type
+- Strict Office Open XML Format
+- Zip64 mode
+- refreshing thumbnail
 - saving progress
 - Python
 - Aspose.Slides
@@ -61,13 +65,9 @@ Aspose.Slides for Python lets you set the initial view that PowerPoint uses when
 ```py
 import aspose.slides as slides
 
-# Instantiate the Presentation class that represents a presentation file.
 with slides.Presentation() as presentation:
-    
     presentation.view_properties.last_view = slides.ViewType.SLIDE_MASTER_VIEW
-
     presentation.save("slide_master_view.pptx", slides.export.SaveFormat.PPTX)
-
 ```
 
 ## **Save Presentations in the Strict Office Open XML Format**
@@ -88,6 +88,34 @@ with slides.Presentation() as presentation:
     presentation.save("strict_office_open_xml.pptx", slides.export.SaveFormat.PPTX, options)
 ```
 
+## **Save Presentations in Office Open XML Format in Zip64 Mode**
+
+An Office Open XML file is a ZIP archive that imposes 4 GB (2^32 bytes) limits on the uncompressed size of any file, the compressed size of any file, and the total size of the archive, and it also limits the archive to 65,535 (2^16-1) files. ZIP64 format extensions raise these limits to 2^64.
+
+The [PptxOptions.zip_64_mode](https://reference.aspose.com/slides/python-net/aspose.slides.export/pptxoptions/zip_64_mode/) property lets you choose when to use ZIP64 format extensions when saving an Office Open XML file.
+
+This property provides the following modes:
+
+- `IF_NECESSARY` uses ZIP64 format extensions only if the presentation exceeds the limitations above. This is the default mode.
+- `NEVER` never uses ZIP64 format extensions.
+- `ALWAYS` always uses ZIP64 format extensions.
+
+The following code demonstrates how to save a presentation as PPTX with ZIP64 format extensions enabled:
+
+```py
+pptx_options = slides.export.PptxOptions()
+pptx_options.zip_64_mode = slides.export.Zip64Mode.ALWAYS
+
+with slides.Presentation("sample.pptx") as presentation:
+    presentation.save("output_zip64.pptx", slides.export.SaveFormat.PPTX, pptx_options)
+```
+
+{{% alert title="NOTE" color="warning" %}}
+
+When you save with `Zip64Mode.NEVER`, a [PptxException](https://reference.aspose.com/slides/python-net/aspose.slides/pptxexception/) is thrown if the presentation cannot be saved in ZIP32 format.
+
+{{% /alert %}}
+
 ## **Save Presentations without Refreshing the Thumbnail**
 
 The [PptxOptions.refresh_thumbnail](https://reference.aspose.com/slides/python-net/aspose.slides.export/pptxoptions/refresh_thumbnail/) property controls thumbnail generation when saving a presentation to PPTX:
@@ -98,11 +126,12 @@ The [PptxOptions.refresh_thumbnail](https://reference.aspose.com/slides/python-n
 In the code below, the presentation is saved to PPTX without refreshing its thumbnail.
 
 ```py
+import aspose.slides as slides
+
+pptx_options = slides.export.PptxOptions()
+pptx_options.refresh_thumbnail = False
+
 with slides.Presentation("sample.pptx") as presentation:
-    
-    pptx_options = slides.export.PptxOptions()
-    pptx_options.refresh_thumbnail = False
-    
     presentation.save("output.pptx", slides.export.SaveFormat.PPTX, pptx_options)
 ```
 

--- a/en/python-net/developer-guide/manage-presentation/save-presentation/_index.md
+++ b/en/python-net/developer-guide/manage-presentation/save-presentation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Save Presentations in Python
-linktitle: Save Presentation
+linktitle: Save Presentations
 type: docs
 weight: 80
 url: /python-net/save-presentation/
@@ -31,7 +31,7 @@ Save a presentation to a file by calling the [Presentation](https://reference.as
 ```py
 import aspose.slides as slides
 
-# Instantiate the Presentation class that represents a PPT file.
+# Instantiate the Presentation class that represents a presentation file.
 with slides.Presentation() as presentation:
     
     # Do some work here...
@@ -47,14 +47,10 @@ You can save a presentation to a stream by passing an output stream to the [Pres
 ```py
 import aspose.slides as slides
 
-# Instantiate the Presentation class that represents a PPT file.
+# Instantiate the Presentation class that represents a presentation file.
 with slides.Presentation() as presentation:
-    slide = presentation.slides[0]
-
-    shape = slide.shapes.add_auto_shape(slides.ShapeType.RECTANGLE, 20, 20, 200, 200)
-
-    # Save the presentation to a stream.
     with open("output.pptx", "bw") as file_stream:
+        # Save the presentation to the stream.
         presentation.save(file_stream, slides.export.SaveFormat.PPTX)
 ```
 
@@ -65,7 +61,7 @@ Aspose.Slides for Python lets you set the initial view that PowerPoint uses when
 ```py
 import aspose.slides as slides
 
-# Instantiate the Presentation class that represents a PPT file.
+# Instantiate the Presentation class that represents a presentation file.
 with slides.Presentation() as presentation:
     
     presentation.view_properties.last_view = slides.ViewType.SLIDE_MASTER_VIEW
@@ -83,17 +79,11 @@ The example below creates a presentation and saves it in the Strict Office Open 
 ```py
 import aspose.slides as slides
 
+options = slides.export.PptxOptions()
+options.conformance = slides.export.Conformance.ISO29500_2008_STRICT
+
 # Instantiate the Presentation class that represents a presentation file.
 with slides.Presentation() as presentation:
-    # Get the first slide.
-    slide = presentation.slides[0]
-
-    # Add a line AutoShape.
-    slide.shapes.add_auto_shape(slides.ShapeType.LINE, 50, 150, 300, 0)
-
-    options = slides.export.PptxOptions()
-    options.conformance = slides.export.Conformance.ISO29500_2008_STRICT
-
     # Save the presentation in the Strict Office Open XML format.
     presentation.save("strict_office_open_xml.pptx", slides.export.SaveFormat.PPTX, options)
 ```


### PR DESCRIPTION
Updated the article "Save Presentations" for Aspose.Slides for .NET, Android via Java, C++, Java, Node.js via Java, PHP via Java, Python via .NET.