### PR TITLE
SLIDESDOC-645 Add the section "Load Presentation Without Embedded Binary Objects" to the articles for other platforms

### DIFF
--- a/en/androidjava/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/androidjava/developer-guide/manage-presentation/open-presentation/_index.md
@@ -1,103 +1,128 @@
 ---
-title: Open Presentation in Java
+title: Open a Presentation on Android
 linktitle: Open Presentation
 type: docs
 weight: 20
 url: /androidjava/open-presentation/
-keywords: "Open PowerPoint, PPTX, PPT, Open Presentation, Load Presentation, Java"
-description: "Open or load Presentation PPT, PPTX, ODP in Java"
+keywords:
+- open PowerPoint
+- open presentation
+- open PPTX
+- open PPT
+- open ODP
+- load presentation
+- load PPTX
+- load PPT
+- load ODP
+- protected presentation
+- large presentation
+- external resource
+- Android
+- Java
+- Aspose.Slides
+description: "Open PowerPoint (.pptx, .ppt) and OpenDocument (.odp) presentations effortlessly with Aspose.Slides for Android—fast, reliable, fully featured."
 ---
 
-Besides creating PowerPoint presentations from scratch, Aspose.Slides allows you to open existing presentations. After you load a presentation, you can get information about the presentation, edit the presentation (content on its slides), add new slides or remove existing ones, etc. 
+## **Overview**
 
-## Open Presentation
+Beyond creating PowerPoint presentations from scratch, Aspose.Slides also lets you open existing presentations. After loading a presentation, you can retrieve information about it, edit slide content, add new slides, remove existing ones, and more.
 
-To open an existing presentation, you simply have to instantiate the [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/presentation/) class and pass the file path (of the presentation you want to open) to its constructor.
+## **Open Presentations**
 
-This Java code shows you how to open a presentation and also find out the number of slides it contains: 
+To open an existing presentation, instantiate the [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/presentation/) class and pass the file path to its constructor.
+
+The following Java example shows how to open a presentation and get its slide count:
 
 ```java
-// Instantiates the Presentation class and passes the file path to its constructor
-Presentation pres = new Presentation("Presentation.pptx");
+// Instantiate the Presentation class and pass a file path to its constructor.
+Presentation presentation = new Presentation("Sample.pptx");
 try {
-    // Prints the total number of slides present in the presentation
-    System.out.println(pres.getSlides().size());
+    // Print the total number of slides in the presentation.
+    System.out.println(presentation.getSlides().size());
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
-## **Open Password Protected Presentation**
+## **Open Password-Protected Presentations**
 
-When you have to open a password-protected presentation, you can pass the password through the [Password](https://reference.aspose.com/slides/androidjava/com.aspose.slides/loadoptions/#getPassword--) property (from the [LoadOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/loadoptions/) class) to decrypt the presentation and load the presentation. This Java code demonstrates the operation:
-
-```java
- LoadOptions loadOptions = new LoadOptions();
- loadOptions.setPassword("YOUR_PASSWORD");
- Presentation pres = new Presentation("pres.pptx", loadOptions);
- try {
- // Do some work with the decrypted presentation
- } finally {
-     if (pres != null) pres.dispose();
- }
-```
-
-## Open Large Presentation
-
-Aspose.Slides provides options (the [BlobManagementOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/loadoptions/#setBlobManagementOptions-com.aspose.slides.IBlobManagementOptions-) property in particular) under the [LoadOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/LoadOptions) class to allow you to load large presentations.
-
-This Java demonstrates an operation in which a large presentation (say 2GB in size) is loaded:
+When you need to open a password-protected presentation, pass the password through the [setPassword](https://reference.aspose.com/slides/androidjava/com.aspose.slides/loadoptions/#setPassword-java.lang.String-) method of the [LoadOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/loadoptions/) class to decrypt and load it. The following Java code demonstrates this operation:
 
 ```java
 LoadOptions loadOptions = new LoadOptions();
+loadOptions.setPassword("YOUR_PASSWORD");
+
+Presentation presentation = new Presentation("Sample.pptx", loadOptions);
+try {
+    // Perform operations on the decrypted presentation.
+} finally {
+    presentation.dispose();
+}
+```
+
+## **Open Large Presentations**
+
+Aspose.Slides provides options—particularly the [setBlobManagementOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/loadoptions/#setBlobManagementOptions-com.aspose.slides.IBlobManagementOptions-) method in the [LoadOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/loadoptions/) class—to help you load large presentations.
+
+The following Java code demonstrates loading a large presentation (for example, 2 GB):
+
+```java
+final String filePath = "LargePresentation.pptx";
+
+LoadOptions loadOptions = new LoadOptions();
+// Choose the KeepLocked behavior—the presentation file will remain locked for the lifetime of
+// the Presentation instance, but it does not need to be loaded into memory or copied to a temporary file.
 loadOptions.getBlobManagementOptions().setPresentationLockingBehavior(PresentationLockingBehavior.KeepLocked);
 loadOptions.getBlobManagementOptions().setTemporaryFilesAllowed(true);
-loadOptions.getBlobManagementOptions().setMaxBlobsBytesInMemory(0L);
+loadOptions.getBlobManagementOptions().setMaxBlobsBytesInMemory(10 * 1024 * 1024); // 10 MB
 
-Presentation pres = new Presentation("veryLargePresentation.pptx", loadOptions);
+Presentation presentation = new Presentation(filePath, loadOptions);
 try {
-    // The large presentation has been loaded and can be used, but the memory consumption is still low.
-    // makes changes to the presentation.
-    pres.getSlides().get_Item(0).setName("Very large presentation");
+    // The large presentation has been loaded and can be used, while memory consumption remains low.
 
-    // The presentation will be saved to the other file. The memory consumption stays low during the operation
-    pres.save("veryLargePresentation-copy.pptx", SaveFormat.Pptx);
+    // Make changes to the presentation.
+    presentation.getSlides().get_Item(0).setName("Large presentation");
+
+    // Save the presentation to another file. Memory consumption remains low during this operation.
+    presentation.save("LargePresentation-copy.pptx", SaveFormat.Pptx);
+
+    // Don't do this! An I/O exception will be thrown because the file is locked until the presentation object is disposed.
+    Files.delete(Paths.get(filePath));
 } finally {
-    if(pres != null) pres.dispose();
+    presentation.dispose();
 }
+
+// It is OK to do it here. The source file is no longer locked by the presentation object.
+Files.delete(Paths.get(filePath));
 ```
 
 {{% alert color="info" title="Info" %}}
 
-To circumvent certain limitations when interacting with a stream, Aspose.Slides may copy the stream's content. Loading a large presentation through its stream will result in the copying of the presentation's contents and cause slow loading. Therefore, when you intend to load a large presentation, we strongly recommend that you use the presentation file path and not its stream.
+To work around certain limitations when working with streams, Aspose.Slides may copy a stream’s contents. Loading a large presentation from a stream causes the presentation to be copied and can slow loading. Therefore, when you need to load a large presentation, we strongly recommend using the presentation file path rather than a stream.
 
-When you want to create a presentation that contains large objects (video, audio, big images, etc.), you can use the [Blob facility](https://docs.aspose.com/slides/androidjava/manage-blob/) to reduce memory consumption.
+When creating a presentation that contains large objects (video, audio, high-resolution images, etc.), you can use [BLOB management](/slides/androidjava/manage-blob/) to reduce memory consumption.
 
-{{%/alert %}} 
+{{%/alert %}}
 
+## **Control External Resources**
 
-## Load Presentation
-
-Aspose.Slides provides [IResourceLoadingCallback](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iresourceloadingcallback/) with a single method to allow you to manage external resources. This Java code shows you how to use the `IResourceLoadingCallback` interface:
+Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iresourceloadingcallback/) interface that lets you manage external resources. The following Java code shows how to use the `IResourceLoadingCallback` interface:
 
 ```java
-LoadOptions opts = new LoadOptions();
-opts.setResourceLoadingCallback(new ImageLoadingHandler());
+LoadOptions loadOptions = new LoadOptions();
+loadOptions.setResourceLoadingCallback(new ImageLoadingHandler());
 
-Presentation pres = new Presentation("presentation.pptx", opts);
+Presentation presentation = new Presentation("presentation.pptx", loadOptions);
 ```
 
 ```java
-class ImageLoadingHandler implements IResourceLoadingCallback 
-{
-    public int resourceLoading(IResourceLoadingArgs args) 
-    {
-        if (args.getOriginalUri().endsWith(".jpg")) 
-        {
-            try // loads substitute image
-            {
-                byte[] imageBytes = Files.readAllBytes(new File("aspose-logo.jpg").toPath());
-                args.setData(imageBytes);
+class ImageLoadingHandler implements IResourceLoadingCallback {
+    public int resourceLoading(IResourceLoadingArgs args) {
+        if (args.getOriginalUri().endsWith(".jpg")) {
+            try {
+                // Load a substitute image.
+                byte[] imageData = Files.readAllBytes(new File("aspose-logo.jpg").toPath());
+                args.setData(imageData);
                 return ResourceLoadingAction.UserProvided;
             } catch (RuntimeException ex) {
                 return ResourceLoadingAction.Skip;
@@ -105,58 +130,36 @@ class ImageLoadingHandler implements IResourceLoadingCallback
                 ex.printStackTrace();
             }
         } else if (args.getOriginalUri().endsWith(".png")) {
-            // sets substitute url
+            // Set a substitute URL.
             args.setUri("http://www.google.com/images/logos/ps_logo2.png");
             return ResourceLoadingAction.Default;
         }
-        // skips all other images
+        // Skip all other images.
         return ResourceLoadingAction.Skip;
     }
 }
 ```
 
-## Load Presentation Without Embedded Binary Objects
+## **Load Presentations Without Embedded Binary Objects**
 
-The PowerPoint presentation can contain the following types of the embedded binary objects:
+A PowerPoint presentation can contain the following types of embedded binary objects:
 
-- VBA Project ([IPresentation.VbaProject](https://reference.aspose.com/slides/androidjava/com.aspose.slides/vbaproject/));
-- OLE Object embedded data ([IOleEmbeddedDataInfo.EmbeddedFileData](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ioleembeddeddatainfo/#getEmbeddedFileData--));
-- ActiveX Control binary data ([IControl.ActiveXControlBinary](https://reference.aspose.com/slides/androidjava/com.aspose.slides/icontrol/#getActiveXControlBinary--));
+- VBA project (accessible via [IPresentation.getVbaProject](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ipresentation/#getVbaProject--));
+- OLE object embedded data (accessible via [IOleEmbeddedDataInfo.getEmbeddedFileData](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ioleembeddeddatainfo/#getEmbeddedFileData--));
+- ActiveX control binary data (accessible via [IControl.getActiveXControlBinary](https://reference.aspose.com/slides/androidjava/com.aspose.slides/icontrol/#getActiveXControlBinary--)).
 
-Using the [ILoadOptions.DeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iloadoptions/#setDeleteEmbeddedBinaryObjects-boolean-) property, you can load the presentation without any embedded binary objects.
+Using the [ILoadOptions.DeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iloadoptions/#setDeleteEmbeddedBinaryObjects-boolean-) property, you can load a presentation without any embedded binary objects.
 
-This property can be useful for removing potentially malicious binary content.
-
-The code demonstrates how to load and save a presentation without any malware content:
+This property is useful for removing potentially malicious binary content. The following Java code demonstrates how to load a presentation without any embedded binary content:
 
 ```java
 LoadOptions loadOptions = new LoadOptions();
 loadOptions.setDeleteEmbeddedBinaryObjects(true);
 
-Presentation pres = new Presentation("malware.ppt", loadOptions);
+Presentation presentation = new Presentation("malware.ppt", loadOptions);
 try {
-    pres.save("clean.ppt", SaveFormat.Ppt);
+    // Perform operations on the presentation.
 } finally {
-    if (pres != null) pres.dispose();
-}
-```
-
-## Open and Save Presentation
-
-Steps to Open and Save Presentation:
-
-1. Create an instance of the [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation) class and pass the file you want to open.
-2. Save the presentation.  
-
-```java
-// Instantiates a Presentation object that represents a PPT file
-Presentation pres = new Presentation();
-try {
-    // ...do some work here...
-    
-    // Saves your presentation to a file
-    pres.save("demoPass.pptx", com.aspose.slides.SaveFormat.Pptx);
-} finally {
-    if(pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```

--- a/en/androidjava/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/androidjava/developer-guide/manage-presentation/open-presentation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Open a Presentation on Android
-linktitle: Open Presentation
+linktitle: Open Presentations
 type: docs
 weight: 20
 url: /androidjava/open-presentation/

--- a/en/androidjava/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/androidjava/developer-guide/manage-presentation/open-presentation/_index.md
@@ -88,7 +88,7 @@ try {
     presentation.save("LargePresentation-copy.pptx", SaveFormat.Pptx);
 
     // Don't do this! An I/O exception will be thrown because the file is locked until the presentation object is disposed.
-    Files.delete(Paths.get(filePath));
+    //Files.delete(Paths.get(filePath));
 } finally {
     presentation.dispose();
 }
@@ -122,7 +122,7 @@ class ImageLoadingHandler implements IResourceLoadingCallback {
         if (args.getOriginalUri().endsWith(".jpg")) {
             try {
                 // Load a substitute image.
-                byte[] imageData = Files.readAllBytes(new File("aspose-logo.jpg").toPath());
+                byte[] imageData = getImageBytes("aspose-logo.jpg"); // Use any method to get bytes
                 args.setData(imageData);
                 return ResourceLoadingAction.UserProvided;
             } catch (RuntimeException ex) {

--- a/en/androidjava/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/androidjava/developer-guide/manage-presentation/open-presentation/_index.md
@@ -113,7 +113,7 @@ Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.c
 LoadOptions loadOptions = new LoadOptions();
 loadOptions.setResourceLoadingCallback(new ImageLoadingHandler());
 
-Presentation presentation = new Presentation("presentation.pptx", loadOptions);
+Presentation presentation = new Presentation("Sample.pptx", loadOptions);
 ```
 
 ```java

--- a/en/androidjava/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/androidjava/developer-guide/manage-presentation/open-presentation/_index.md
@@ -17,6 +17,7 @@ keywords:
 - protected presentation
 - large presentation
 - external resource
+- binary object
 - Android
 - Java
 - Aspose.Slides
@@ -62,7 +63,7 @@ try {
 
 ## **Open Large Presentations**
 
-Aspose.Slides provides options—particularly the [setBlobManagementOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/loadoptions/#setBlobManagementOptions-com.aspose.slides.IBlobManagementOptions-) method in the [LoadOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/loadoptions/) class—to help you load large presentations.
+Aspose.Slides provides options—particularly the [getBlobManagementOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/loadoptions/#getBlobManagementOptions--) method in the [LoadOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/loadoptions/) class—to help you load large presentations.
 
 The following Java code demonstrates loading a large presentation (for example, 2 GB):
 
@@ -148,9 +149,9 @@ A PowerPoint presentation can contain the following types of embedded binary obj
 - OLE object embedded data (accessible via [IOleEmbeddedDataInfo.getEmbeddedFileData](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ioleembeddeddatainfo/#getEmbeddedFileData--));
 - ActiveX control binary data (accessible via [IControl.getActiveXControlBinary](https://reference.aspose.com/slides/androidjava/com.aspose.slides/icontrol/#getActiveXControlBinary--)).
 
-Using the [ILoadOptions.DeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iloadoptions/#setDeleteEmbeddedBinaryObjects-boolean-) property, you can load a presentation without any embedded binary objects.
+Using the [ILoadOptions.setDeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iloadoptions/#setDeleteEmbeddedBinaryObjects-boolean-) method, you can load a presentation without any embedded binary objects.
 
-This property is useful for removing potentially malicious binary content. The following Java code demonstrates how to load a presentation without any embedded binary content:
+This method is useful for removing potentially malicious binary content. The following Java code demonstrates how to load a presentation without any embedded binary content:
 
 ```java
 LoadOptions loadOptions = new LoadOptions();

--- a/en/cpp/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/cpp/developer-guide/manage-presentation/open-presentation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Open a Presentation in C++
-linktitle: Open Presentation
+linktitle: Open Presentations
 type: docs
 weight: 20
 url: /cpp/open-presentation/

--- a/en/cpp/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/cpp/developer-guide/manage-presentation/open-presentation/_index.md
@@ -149,11 +149,11 @@ auto presentation = MakeObject<Presentation>(u"Sample.pptx", loadOptions);
 
 A PowerPoint presentation can contain the following types of embedded binary objects:
 
-- VBA project (accessible via [IPresentation.get_VbaProject](https://reference.aspose.com/slides/cpp/aspose.slides/ipresentation/get_vbaproject/));
-- OLE object embedded data (accessible via [IOleEmbeddedDataInfo.get_EmbeddedFileData](https://reference.aspose.com/slides/cpp/aspose.slides/ioleembeddeddatainfo/get_embeddedfiledata/));
-- ActiveX control binary data (accessible via [IControl.get_ActiveXControlBinary](https://reference.aspose.com/slides/cpp/aspose.slides/icontrol/get_activexcontrolbinary/)).
+- VBA project (accessible via [IPresentation::get_VbaProject](https://reference.aspose.com/slides/cpp/aspose.slides/ipresentation/get_vbaproject/));
+- OLE object embedded data (accessible via [IOleEmbeddedDataInfo::get_EmbeddedFileData](https://reference.aspose.com/slides/cpp/aspose.slides/ioleembeddeddatainfo/get_embeddedfiledata/));
+- ActiveX control binary data (accessible via [IControl::get_ActiveXControlBinary](https://reference.aspose.com/slides/cpp/aspose.slides/icontrol/get_activexcontrolbinary/)).
 
-Using the [ILoadOptions.set_DeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/cpp/aspose.slides/iloadoptions/set_deleteembeddedbinaryobjects/) method, you can load a presentation without any embedded binary objects.
+Using the [ILoadOptions::set_DeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/cpp/aspose.slides/iloadoptions/set_deleteembeddedbinaryobjects/) method, you can load a presentation without any embedded binary objects.
 
 This method is useful for removing potentially malicious binary content. The following C++ code demonstrates how to load a presentation without any embedded binary content:
 

--- a/en/cpp/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/cpp/developer-guide/manage-presentation/open-presentation/_index.md
@@ -1,156 +1,169 @@
 ---
-title: Open Presentation - C++ PowerPoint API
+title: Open a Presentation in C++
 linktitle: Open Presentation
 type: docs
 weight: 20
 url: /cpp/open-presentation/
-keywords: "Open PowerPoint, PPTX, PPT, Open Presentation, Load Presentation, C++, CPP"
-description: "Open or load Presentation PPT, PPTX, ODP in C++"
+keywords:
+- open PowerPoint
+- open presentation
+- open PPTX
+- open PPT
+- open ODP
+- load presentation
+- load PPTX
+- load PPT
+- load ODP
+- protected presentation
+- large presentation
+- external resource
+- binary object
+- C++
+- Aspose.Slides
+description: "Open PowerPoint (.pptx, .ppt) and OpenDocument (.odp) presentations effortlessly with Aspose.Slides for C++—fast, reliable, fully featured."
 ---
 
-Besides creating PowerPoint presentations from scratch, Aspose.Slides allows you to open existing presentations. After you load a presentation, you can get information about the presentation, edit the presentation (content on its slides), add new slides or remove existing ones, etc. 
+## **Overview**
 
-## Open Presentation
+Beyond creating PowerPoint presentations from scratch, Aspose.Slides also lets you open existing presentations. After loading a presentation, you can retrieve information about it, edit slide content, add new slides, remove existing ones, and more.
 
-To open an existing presentation, you simply have to instantiate the [Presentation](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/) class and pass the file path (of the presentation you want to open) to its constructor. 
+## **Open Presentations**
 
-This C++ code shows you how to open a presentation and also find out the number of slides it contains: 
+To open an existing presentation, instantiate the [Presentation](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/) class and pass the file path to its constructor.
 
-```c++
-// The path to the documents directory.
-String dataDir = u"";
+The following C++ example shows how to open a presentation and get its slide count:
 
-// Instantiates the Presentation class and passes the file path to its constructor
-auto pres = System::MakeObject<Presentation>(dataDir + u"OpenPresentation.pptx");
+```cpp
+// Instantiate the Presentation class and pass a file path to its constructor.
+auto presentation = MakeObject<Presentation>(u"Sample.pptx");
 
-// Prints the total number of slides present in the presentation
-Console::WriteLine(Convert::ToString(pres->get_Slides()->get_Count()));
+// Print the total number of slides in the presentation.
+Console::WriteLine(presentation->get_Slides()->get_Count());
+
+presentation->Dispose();
 ```
 
-## **Open Password Protected Presentation**
+## **Open Password-Protected Presentations**
 
-When you have to open a password-protected presentation, you can pass the password through the [get_Password()](https://reference.aspose.com/slides/cpp/aspose.slides/loadoptions/get_password/) property (from the [LoadOptions](https://reference.aspose.com/slides/cpp/aspose.slides/loadoptions/) class) to decrypt the presentation and load the presentation. This C++ code demonstrates the operation:
+When you need to open a password-protected presentation, pass the password through the [set_Password](https://reference.aspose.com/slides/cpp/aspose.slides/loadoptions/set_password/) method of the [LoadOptions](https://reference.aspose.com/slides/cpp/aspose.slides/loadoptions/) class to decrypt and load it. The following C++ code demonstrates this operation:
 
-```c++
-System::SharedPtr<LoadOptions> loadOptions = System::MakeObject<LoadOptions>();
+```cpp
+auto loadOptions = MakeObject<LoadOptions>();
 loadOptions->set_Password(u"YOUR_PASSWORD");
-auto presentation = System::MakeObject<Presentation>(u"pres.pptx", loadOptions);
-// Do some work with the decrypted presentation
+
+auto presentation = MakeObject<Presentation>(u"Sample.pptx", loadOptions);
+    
+// Perform operations on the decrypted presentation.
+
+presentation->Dispose();
 ```
 
-## Open Large Presentation
+## **Open Large Presentations**
 
-Aspose.Slides provides options (the [BlobManagementOptions](https://reference.aspose.com/slides/cpp/aspose.slides/loadoptions/set_blobmanagementoptions/) property in particular) under the [LoadOptions](https://reference.aspose.com/slides/cpp/aspose.slides/loadoptions/) class to allow you to load large presentations. 
+Aspose.Slides provides options—particularly the [get_BlobManagementOptions](https://reference.aspose.com/slides/cpp/aspose.slides/loadoptions/get_blobmanagementoptions/) method in the [LoadOptions](https://reference.aspose.com/slides/cpp/aspose.slides/loadoptions/) class—to help you load large presentations.
 
-This C++ demonstrates an operation in which a large presentation (say 2GB in size) is loaded:
+The following C++ code demonstrates loading a large presentation (for example, 2 GB):
 
-```c++
-String pathToVeryLargePresentationFile = u"veryLargePresentation.pptx";
+```cpp
+auto filePath = u"LargePresentation.pptx";
 
-{
-    SharedPtr<LoadOptions> loadOptions = System::MakeObject<LoadOptions>();
-    // let's choose the KeepLocked behavior - the "veryLargePresentation.pptx" will be locked for
-    // the Presentation's instance lifetime, but we don't need to load it into memory or copy into
-    // the temporary file
-    loadOptions->get_BlobManagementOptions()->set_PresentationLockingBehavior(PresentationLockingBehavior::KeepLocked);
+auto loadOptions = MakeObject<LoadOptions>();
+// Choose the KeepLocked behavior—the presentation file will remain locked for the lifetime of
+// the Presentation instance, but it does not need to be loaded into memory or copied to a temporary file.
+loadOptions->get_BlobManagementOptions()->set_PresentationLockingBehavior(PresentationLockingBehavior::KeepLocked);
+loadOptions->get_BlobManagementOptions()->set_IsTemporaryFilesAllowed(true);
+loadOptions->get_BlobManagementOptions()->set_MaxBlobsBytesInMemory(10 * 1024 * 1024); // 10 MB
 
-    auto pres = System::MakeObject<Presentation>(pathToVeryLargePresentationFile, loadOptions);
+auto presentation = MakeObject<Presentation>(filePath, loadOptions);
 
-    // The large presentation has been loaded and can be used, but the memory consumption is still low.
+// The large presentation has been loaded and can be used, while memory consumption remains low.
 
-    // Makes changes to the presentation.
-    pres->get_Slides()->idx_get(0)->set_Name(u"Very large presentation");
+// Make changes to the presentation.
+presentation->get_Slide(0)->set_Name(u"Large presentation");
 
-    // The presentation will be saved to the other file. The memory consumption stays low during the operation
-    pres->Save(u"veryLargePresentation-copy.pptx", SaveFormat::Pptx);
+// Save the presentation to another file. Memory consumption remains low during this operation.
+presentation->Save(u"LargePresentation-copy.pptx", SaveFormat::Pptx);
 
-    // can't do that! IO exception will be thrown because the file is locked while pres objects will
-    // not be disposed
-    File::Delete(pathToVeryLargePresentationFile);
-}
+// Don't do this! An I/O exception will be thrown because the file is locked until the presentation object is disposed.
+File::Delete(filePath);
 
-// It is ok to do it here. The source file is not locked by the pres object
-File::Delete(pathToVeryLargePresentationFile);
+presentation->Dispose();
+
+// It is OK to do it here. The source file is no longer locked by the presentation object.
+File::Delete(filePath);
 ```
 
 {{% alert color="info" title="Info" %}}
 
-To circumvent certain limitations when interacting with streams, Aspose.Slides may copy the stream's content. Loading a large presentation through its stream will result in the copying of the presentation's contents and cause slow loading. Therefore, when you intend to load a large presentation, we strongly recommend that you use the presentation file path and not its stream.
+To work around certain limitations when working with streams, Aspose.Slides may copy a stream’s contents. Loading a large presentation from a stream causes the presentation to be copied and can slow loading. Therefore, when you need to load a large presentation, we strongly recommend using the presentation file path rather than a stream.
 
-When you want to create a presentation that contains large objects (video, audio, big images, etc.), you can use the [Blob facility](https://docs.aspose.com/slides/cpp/manage-blob/) to reduce memory consumption.
+When creating a presentation that contains large objects (video, audio, high-resolution images, etc.), you can use [BLOB management](/slides/cpp/manage-blob/) to reduce memory consumption.
 
-{{%/alert %}} 
+{{%/alert %}}
 
+## **Control External Resources**
 
-## Load Presentation
+Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.com/slides/cpp/aspose.slides/iresourceloadingcallback/) interface that lets you manage external resources. The following C++ code shows how to use the `IResourceLoadingCallback` interface:
 
-Aspose.Slides provides [IResourceLoadingCallback](https://reference.aspose.com/slides/cpp/aspose.slides/iresourceloadingcallback/) with a single method to allow you to manage external resources. This C++ code shows you how to use the `IResourceLoadingCallback` interface:
+```cpp
+auto loadOptions = MakeObject<LoadOptions>();
+loadOptions->set_ResourceLoadingCallback(MakeObject<ImageLoadingHandler>());
 
-```c++
-// The path to the documents directory.
-System::String dataDir = GetDataPath();
-
-auto opts = System::MakeObject<LoadOptions>();
-opts->set_ResourceLoadingCallback(System::MakeObject<ImageLoadingHandler>(dataDir));
-auto presentation = System::MakeObject<Presentation>(dataDir + u"presentation.pptx", opts);
+auto presentation = MakeObject<Presentation>(u"presentation.pptx", loadOptions);
 ```
 
-```c++
+```cpp
 class ImageLoadingHandler : public IResourceLoadingCallback
 {
 public:
-    ImageLoadingHandler(String dataDir)
-        : m_dataDir(dataDir)
-    {
-    }
-
     ResourceLoadingAction ResourceLoading(SharedPtr<IResourceLoadingArgs> args) override
     {
         if (args->get_OriginalUri().EndsWith(u".jpg"))
         {
             try
             {
-                System::ArrayPtr<uint8_t> imageBytes = File::ReadAllBytes(Path::Combine(m_dataDir, u"aspose-logo.jpg"));
-                args->SetData(imageBytes);
+                // Load a substitute image.
+                auto imageData = File::ReadAllBytes(u"aspose-logo.jpg");
+                args->SetData(imageData);
                 return ResourceLoadingAction::UserProvided;
             }
-            catch (System::Exception&)
+            catch (Exception&)
             {
                 return ResourceLoadingAction::Skip;
             }
         }
-
-        if (args->get_OriginalUri().EndsWith(u".png"))
+        else if (args->get_OriginalUri().EndsWith(u".png"))
         {
-            // Sets substitute url
+            // Set a substitute URL.
             args->set_Uri(u"http://www.google.com/images/logos/ps_logo2.png");
             return ResourceLoadingAction::Default;
         }
 
-        // Skips all other images
+        // Skip all other images.
         return ResourceLoadingAction::Skip;
     }
-    
-private:
-    String m_dataDir;
 };
 ```
 
-<h2>Open and Save Presentation</h2>
+## **Load Presentations Without Embedded Binary Objects**
 
-<a name="cplusplus-open-save-presentation"><strong>Steps: Open and Save Presentation in C++</strong></a>
+A PowerPoint presentation can contain the following types of embedded binary objects:
 
-1. Create an instance of the [Presentation](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/) class and pass the file you want to open. 
+- VBA project (accessible via [IPresentation.get_VbaProject](https://reference.aspose.com/slides/cpp/aspose.slides/ipresentation/get_vbaproject/));
+- OLE object embedded data (accessible via [IOleEmbeddedDataInfo.get_EmbeddedFileData](https://reference.aspose.com/slides/cpp/aspose.slides/ioleembeddeddatainfo/get_embeddedfiledata/));
+- ActiveX control binary data (accessible via [IControl.get_ActiveXControlBinary](https://reference.aspose.com/slides/cpp/aspose.slides/icontrol/get_activexcontrolbinary/)).
 
-2. Save the presentation. 
+Using the [ILoadOptions.set_DeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/cpp/aspose.slides/iloadoptions/set_deleteembeddedbinaryobjects/) method, you can load a presentation without any embedded binary objects.
 
-   ```c++
-   	const String outPath = u"../out/SaveToFile_out.ppt";
-   	
-   	SharedPtr<Presentation> pres = MakeObject<Presentation>();
-   
-   	// pres->get_ProtectionManager()->Encrypt(u"pass");
-   	// ...do some work here..
-   
-   	pres->Save(outPath, Aspose::Slides::Export::SaveFormat::Pptx);
-   ```
+This method is useful for removing potentially malicious binary content. The following C++ code demonstrates how to load a presentation without any embedded binary content:
+
+```cpp
+auto loadOptions = MakeObject<LoadOptions>();
+loadOptions->set_DeleteEmbeddedBinaryObjects(true);
+
+auto presentation = MakeObject<Presentation>(u"malware.ppt", loadOptions);
+
+// Perform operations on the presentation.
+
+presentation->Dispose();
+```

--- a/en/cpp/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/cpp/developer-guide/manage-presentation/open-presentation/_index.md
@@ -106,13 +106,6 @@ When creating a presentation that contains large objects (video, audio, high-res
 Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.com/slides/cpp/aspose.slides/iresourceloadingcallback/) interface that lets you manage external resources. The following C++ code shows how to use the `IResourceLoadingCallback` interface:
 
 ```cpp
-auto loadOptions = MakeObject<LoadOptions>();
-loadOptions->set_ResourceLoadingCallback(MakeObject<ImageLoadingHandler>());
-
-auto presentation = MakeObject<Presentation>(u"presentation.pptx", loadOptions);
-```
-
-```cpp
 class ImageLoadingHandler : public IResourceLoadingCallback
 {
 public:
@@ -143,6 +136,13 @@ public:
         return ResourceLoadingAction::Skip;
     }
 };
+```
+
+```cpp
+auto loadOptions = MakeObject<LoadOptions>();
+loadOptions->set_ResourceLoadingCallback(MakeObject<ImageLoadingHandler>());
+
+auto presentation = MakeObject<Presentation>(u"Sample.pptx", loadOptions);
 ```
 
 ## **Load Presentations Without Embedded Binary Objects**

--- a/en/java/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/java/developer-guide/manage-presentation/open-presentation/_index.md
@@ -1,103 +1,128 @@
 ---
-title: Open Presentation in Java
+title: Open a Presentation in Java
 linktitle: Open Presentation
 type: docs
 weight: 20
 url: /java/open-presentation/
-keywords: "Open PowerPoint, PPTX, PPT, Open Presentation, Load Presentation, Java"
-description: "Open or load Presentation PPT, PPTX, ODP in Java"
+keywords:
+- open PowerPoint
+- open presentation
+- open PPTX
+- open PPT
+- open ODP
+- load presentation
+- load PPTX
+- load PPT
+- load ODP
+- protected presentation
+- large presentation
+- external resource
+- binary object
+- Java
+- Aspose.Slides
+description: "Open PowerPoint (.pptx, .ppt) and OpenDocument (.odp) presentations effortlessly with Aspose.Slides for Java—fast, reliable, fully featured."
 ---
 
-Besides creating PowerPoint presentations from scratch, Aspose.Slides allows you to open existing presentations. After you load a presentation, you can get information about the presentation, edit the presentation (content on its slides), add new slides or remove existing ones, etc. 
+## **Overview**
 
-## Open Presentation
+Beyond creating PowerPoint presentations from scratch, Aspose.Slides also lets you open existing presentations. After loading a presentation, you can retrieve information about it, edit slide content, add new slides, remove existing ones, and more.
 
-To open an existing presentation, you simply have to instantiate the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation/) class and pass the file path (of the presentation you want to open) to its constructor. 
+## **Open Presentations**
 
-This Java code shows you how to open a presentation and also find out the number of slides it contains: 
+To open an existing presentation, instantiate the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation/) class and pass the file path to its constructor.
+
+The following Java example shows how to open a presentation and get its slide count:
 
 ```java
-// Instantiates the Presentation class and passes the file path to its constructor
-Presentation pres = new Presentation("Presentation.pptx");
+// Instantiate the Presentation class and pass a file path to its constructor.
+Presentation presentation = new Presentation("Sample.pptx");
 try {
-    // Prints the total number of slides present in the presentation
-    System.out.println(pres.getSlides().size());
+    // Print the total number of slides in the presentation.
+    System.out.println(presentation.getSlides().size());
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
-## **Open Password Protected Presentation**
+## **Open Password-Protected Presentations**
 
-When you have to open a password-protected presentation, you can pass the password through the [Password](https://reference.aspose.com/slides/java/com.aspose.slides/loadoptions/#getPassword--) property (from the [LoadOptions](https://reference.aspose.com/slides/java/com.aspose.slides/loadoptions/) class) to decrypt the presentation and load the presentation. This Java code demonstrates the operation:
-
-```java
- LoadOptions loadOptions = new LoadOptions();
- loadOptions.setPassword("YOUR_PASSWORD");
- Presentation pres = new Presentation("pres.pptx", loadOptions);
- try {
- // Do some work with the decrypted presentation
- } finally {
-     if (pres != null) pres.dispose();
- }
-```
-
-## Open Large Presentation
-
-Aspose.Slides provides options (the [BlobManagementOptions](https://reference.aspose.com/slides/java/com.aspose.slides/loadoptions/#setBlobManagementOptions-com.aspose.slides.IBlobManagementOptions-) property in particular) under the [LoadOptions](https://reference.aspose.com/slides/java/com.aspose.slides/LoadOptions) class to allow you to load large presentations. 
-
-This Java demonstrates an operation in which a large presentation (say 2GB in size) is loaded:
+When you need to open a password-protected presentation, pass the password through the [setPassword](https://reference.aspose.com/slides/java/com.aspose.slides/loadoptions/#setPassword-java.lang.String-) method of the [LoadOptions](https://reference.aspose.com/slides/java/com.aspose.slides/loadoptions/) class to decrypt and load it. The following Java code demonstrates this operation:
 
 ```java
 LoadOptions loadOptions = new LoadOptions();
+loadOptions.setPassword("YOUR_PASSWORD");
+
+Presentation presentation = new Presentation("Sample.pptx", loadOptions);
+try {
+    // Perform operations on the decrypted presentation.
+} finally {
+    presentation.dispose();
+}
+```
+
+## **Open Large Presentations**
+
+Aspose.Slides provides options—particularly the [getBlobManagementOptions](https://reference.aspose.com/slides/java/com.aspose.slides/loadoptions/#getBlobManagementOptions--) method in the [LoadOptions](https://reference.aspose.com/slides/java/com.aspose.slides/loadoptions/) class—to help you load large presentations.
+
+The following Java code demonstrates loading a large presentation (for example, 2 GB):
+
+```java
+final String filePath = "LargePresentation.pptx";
+
+LoadOptions loadOptions = new LoadOptions();
+// Choose the KeepLocked behavior—the presentation file will remain locked for the lifetime of
+// the Presentation instance, but it does not need to be loaded into memory or copied to a temporary file.
 loadOptions.getBlobManagementOptions().setPresentationLockingBehavior(PresentationLockingBehavior.KeepLocked);
 loadOptions.getBlobManagementOptions().setTemporaryFilesAllowed(true);
-loadOptions.getBlobManagementOptions().setMaxBlobsBytesInMemory(0L);
+loadOptions.getBlobManagementOptions().setMaxBlobsBytesInMemory(10 * 1024 * 1024); // 10 MB
 
-Presentation pres = new Presentation("veryLargePresentation.pptx", loadOptions);
+Presentation presentation = new Presentation(filePath, loadOptions);
 try {
-    // The large presentation has been loaded and can be used, but the memory consumption is still low.
-    // makes changes to the presentation.
-    pres.getSlides().get_Item(0).setName("Very large presentation");
+    // The large presentation has been loaded and can be used, while memory consumption remains low.
 
-    // The presentation will be saved to the other file. The memory consumption stays low during the operation
-    pres.save("veryLargePresentation-copy.pptx", SaveFormat.Pptx);
+    // Make changes to the presentation.
+    presentation.getSlides().get_Item(0).setName("Large presentation");
+
+    // Save the presentation to another file. Memory consumption remains low during this operation.
+    presentation.save("LargePresentation-copy.pptx", SaveFormat.Pptx);
+
+    // Don't do this! An I/O exception will be thrown because the file is locked until the presentation object is disposed.
+    Files.delete(Paths.get(filePath));
 } finally {
-    if(pres != null) pres.dispose();
+    presentation.dispose();
 }
+
+// It is OK to do it here. The source file is no longer locked by the presentation object.
+Files.delete(Paths.get(filePath));
 ```
 
 {{% alert color="info" title="Info" %}}
 
-To circumvent certain limitations when interacting with a stream, Aspose.Slides may copy the stream's content. Loading a large presentation through its stream will result in the copying of the presentation's contents and cause slow loading. Therefore, when you intend to load a large presentation, we strongly recommend that you use the presentation file path and not its stream.
+To work around certain limitations when working with streams, Aspose.Slides may copy a stream’s contents. Loading a large presentation from a stream causes the presentation to be copied and can slow loading. Therefore, when you need to load a large presentation, we strongly recommend using the presentation file path rather than a stream.
 
-When you want to create a presentation that contains large objects (video, audio, big images, etc.), you can use the [Blob facility](https://docs.aspose.com/slides/java/manage-blob/) to reduce memory consumption.
+When creating a presentation that contains large objects (video, audio, high-resolution images, etc.), you can use [BLOB management](/slides/java/manage-blob/) to reduce memory consumption.
 
 {{%/alert %}} 
 
+## **Control External Resources**
 
-## Load Presentation
-
-Aspose.Slides provides [IResourceLoadingCallback](https://reference.aspose.com/slides/java/com.aspose.slides/iresourceloadingcallback/) with a single method to allow you to manage external resources. This Java code shows you how to use the `IResourceLoadingCallback` interface:
+Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.com/slides/java/com.aspose.slides/iresourceloadingcallback/) interface that lets you manage external resources. The following Java code shows how to use the `IResourceLoadingCallback` interface:
 
 ```java
-LoadOptions opts = new LoadOptions();
-opts.setResourceLoadingCallback(new ImageLoadingHandler());
+LoadOptions loadOptions = new LoadOptions();
+loadOptions.setResourceLoadingCallback(new ImageLoadingHandler());
 
-Presentation pres = new Presentation("presentation.pptx", opts);
+Presentation presentation = new Presentation("presentation.pptx", loadOptions);
 ```
 
 ```java
-class ImageLoadingHandler implements IResourceLoadingCallback 
-{
-    public int resourceLoading(IResourceLoadingArgs args) 
-    {
-        if (args.getOriginalUri().endsWith(".jpg")) 
-        {
-            try // loads substitute image
-            {
-                byte[] imageBytes = Files.readAllBytes(new File("aspose-logo.jpg").toPath());
-                args.setData(imageBytes);
+class ImageLoadingHandler implements IResourceLoadingCallback {
+    public int resourceLoading(IResourceLoadingArgs args) {
+        if (args.getOriginalUri().endsWith(".jpg")) {
+            try {
+                // Load a substitute image.
+                byte[] imageData = Files.readAllBytes(new File("aspose-logo.jpg").toPath());
+                args.setData(imageData);
                 return ResourceLoadingAction.UserProvided;
             } catch (RuntimeException ex) {
                 return ResourceLoadingAction.Skip;
@@ -105,58 +130,36 @@ class ImageLoadingHandler implements IResourceLoadingCallback
                 ex.printStackTrace();
             }
         } else if (args.getOriginalUri().endsWith(".png")) {
-            // sets substitute url
+            // Set a substitute URL.
             args.setUri("http://www.google.com/images/logos/ps_logo2.png");
             return ResourceLoadingAction.Default;
         }
-        // skips all other images
+        // Skip all other images.
         return ResourceLoadingAction.Skip;
     }
 }
 ```
 
-## Load Presentation Without Embedded Binary Objects
+## **Load Presentations Without Embedded Binary Objects**
 
-The PowerPoint presentation can contain the following types of the embedded binary objects:
+A PowerPoint presentation can contain the following types of embedded binary objects:
 
-- VBA Project ([IPresentation.VbaProject](https://reference.aspose.com/slides/java/com.aspose.slides/vbaproject/));
-- OLE Object embedded data ([IOleEmbeddedDataInfo.EmbeddedFileData](https://reference.aspose.com/slides/java/com.aspose.slides/ioleembeddeddatainfo/#getEmbeddedFileData--));
-- ActiveX Control binary data ([IControl.ActiveXControlBinary](https://reference.aspose.com/slides/java/com.aspose.slides/icontrol/#getActiveXControlBinary--));
+- VBA project (accessible via [IPresentation.getVbaProject](https://reference.aspose.com/slides/java/com.aspose.slides/ipresentation/#getVbaProject--));
+- OLE object embedded data (accessible via [IOleEmbeddedDataInfo.getEmbeddedFileData](https://reference.aspose.com/slides/java/com.aspose.slides/ioleembeddeddatainfo/#getEmbeddedFileData--));
+- ActiveX control binary data (accessible via [IControl.getActiveXControlBinary](https://reference.aspose.com/slides/java/com.aspose.slides/icontrol/#getActiveXControlBinary--)).
 
-Using the [ILoadOptions.DeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/java/com.aspose.slides/iloadoptions/#setDeleteEmbeddedBinaryObjects-boolean-) property, you can load the presentation without any embedded binary objects.
+Using the [ILoadOptions.setDeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/java/com.aspose.slides/iloadoptions/#setDeleteEmbeddedBinaryObjects-boolean-) method, you can load a presentation without any embedded binary objects.
 
-This property can be useful for removing potentially malicious binary content.
-
-The code demonstrates how to load and save a presentation without any malware content:
+This method is useful for removing potentially malicious binary content. The following Java code demonstrates how to load a presentation without any embedded binary content:
 
 ```java
 LoadOptions loadOptions = new LoadOptions();
 loadOptions.setDeleteEmbeddedBinaryObjects(true);
 
-Presentation pres = new Presentation("malware.ppt", loadOptions);
+Presentation presentation = new Presentation("malware.ppt", loadOptions);
 try {
-    pres.save("clean.ppt", SaveFormat.Ppt);
+    // Perform operations on the presentation.
 } finally {
-    if (pres != null) pres.dispose();
-}
-```
-
-## Open and Save Presentation
-
-Steps to Open and Save Presentation:
-
-1. Create an instance of the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation) class and pass the file you want to open. 
-2. Save the presentation.  
-
-```java
-// Instantiates a Presentation object that represents a PPT file
-Presentation pres = new Presentation();
-try {
-    // ...do some work here...
-    
-    // Saves your presentation to a file
-    pres.save("demoPass.pptx", com.aspose.slides.SaveFormat.Pptx);
-} finally {
-    if(pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```

--- a/en/java/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/java/developer-guide/manage-presentation/open-presentation/_index.md
@@ -112,7 +112,7 @@ Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.c
 LoadOptions loadOptions = new LoadOptions();
 loadOptions.setResourceLoadingCallback(new ImageLoadingHandler());
 
-Presentation presentation = new Presentation("presentation.pptx", loadOptions);
+Presentation presentation = new Presentation("Sample.pptx", loadOptions);
 ```
 
 ```java

--- a/en/java/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/java/developer-guide/manage-presentation/open-presentation/_index.md
@@ -87,7 +87,7 @@ try {
     presentation.save("LargePresentation-copy.pptx", SaveFormat.Pptx);
 
     // Don't do this! An I/O exception will be thrown because the file is locked until the presentation object is disposed.
-    Files.delete(Paths.get(filePath));
+    //Files.delete(Paths.get(filePath));
 } finally {
     presentation.dispose();
 }

--- a/en/java/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/java/developer-guide/manage-presentation/open-presentation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Open a Presentation in Java
-linktitle: Open Presentation
+linktitle: Open Presentations
 type: docs
 weight: 20
 url: /java/open-presentation/

--- a/en/net/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/net/developer-guide/manage-presentation/open-presentation/_index.md
@@ -44,7 +44,7 @@ using (Presentation presentation = new Presentation("Sample.pptx"))
 
 ## **Open Password-Protected Presentations**
 
-When you need to open a password-protected presentation, pass the password through the `Password` property of the [LoadOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/) class to decrypt and load it. The following C# code demonstrates this operation:
+When you need to open a password-protected presentation, pass the password through the [Password](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/password/) property of the [LoadOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/) class to decrypt and load it. The following C# code demonstrates this operation:
 
 ```cs
 LoadOptions loadOptions = new LoadOptions {Password = "YOUR_PASSWORD"};
@@ -58,17 +58,20 @@ using (Presentation presentation = new Presentation("Sample.pptx", loadOptions))
 
 Aspose.Slides provides options—particularly the [BlobManagementOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/blobmanagementoptions/) property in the [LoadOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/) class—to help you load large presentations.
 
-This C# code demonstrates loading a large presentation (for example, 2 GB):
+The following C# code demonstrates loading a large presentation (for example, 2 GB):
 
 ```cs
 const string filePath = "LargePresentation.pptx";
 
 LoadOptions loadOptions = new LoadOptions
 {
-    BlobManagementOptions = {
+    BlobManagementOptions = 
+    {
         // Choose the KeepLocked behavior—the presentation file will remain locked for the lifetime of 
         // the Presentation instance, but it does not need to be loaded into memory or copied to a temporary file.
         PresentationLockingBehavior = PresentationLockingBehavior.KeepLocked,
+        IsTemporaryFilesAllowed = true,
+        MaxBlobsBytesInMemory = 10 * 1024 * 1024 // 10 MB
     }
 };
 
@@ -145,9 +148,9 @@ public class ImageLoadingHandler : IResourceLoadingCallback
 
 A PowerPoint presentation can contain the following types of embedded binary objects:
 
-- VBA project ([IPresentation.VbaProject](https://reference.aspose.com/slides/net/aspose.slides/ipresentation/vbaproject/));
-- OLE object embedded data ([IOleEmbeddedDataInfo.EmbeddedFileData](https://reference.aspose.com/slides/net/aspose.slides/ioleembeddeddatainfo/embeddedfiledata/));
-- ActiveX control binary data ([IControl.ActiveXControlBinary](https://reference.aspose.com/slides/net/aspose.slides/icontrol/activexcontrolbinary/)).
+- VBA project (accessible via [IPresentation.VbaProject](https://reference.aspose.com/slides/net/aspose.slides/ipresentation/vbaproject/));
+- OLE object embedded data (accessible via [IOleEmbeddedDataInfo.EmbeddedFileData](https://reference.aspose.com/slides/net/aspose.slides/ioleembeddeddatainfo/embeddedfiledata/));
+- ActiveX control binary data (accessible via [IControl.ActiveXControlBinary](https://reference.aspose.com/slides/net/aspose.slides/icontrol/activexcontrolbinary/)).
 
 Using the [ILoadOptions.DeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/net/aspose.slides/iloadoptions/deleteembeddedbinaryobjects/) property, you can load a presentation without any embedded binary objects.
 
@@ -161,6 +164,6 @@ LoadOptions loadOptions = new LoadOptions()
 
 using (Presentation presentation = new Presentation("malware.ppt", loadOptions))
 {
-    // ...
+    // Perform operations on the presentation.
 }
 ```

--- a/en/net/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/net/developer-guide/manage-presentation/open-presentation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Open a Presentation in C#
-linktitle: Open Presentation
+linktitle: Open Presentations
 type: docs
 weight: 20
 url: /net/open-presentation/

--- a/en/net/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/net/developer-guide/manage-presentation/open-presentation/_index.md
@@ -110,7 +110,7 @@ Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.c
 LoadOptions loadOptions = new LoadOptions();
 loadOptions.ResourceLoadingCallback = new ImageLoadingHandler();
 
-Presentation presentation = new Presentation("presentation.pptx", loadOptions);
+Presentation presentation = new Presentation("Sample.pptx", loadOptions);
 ```
 
 ```cs

--- a/en/net/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/net/developer-guide/manage-presentation/open-presentation/_index.md
@@ -17,6 +17,7 @@ keywords:
 - protected presentation
 - large presentation
 - external resource
+- binary object
 - .NET
 - C#
 - Aspose.Slides
@@ -122,7 +123,7 @@ public class ImageLoadingHandler : IResourceLoadingCallback
             try
             {
                 // Load a substitute image.
-                byte[] imageData = File.ReadAllBytes("c:\\aspose-logo.jpg");
+                byte[] imageData = File.ReadAllBytes("aspose-logo.jpg");
                 args.SetData(imageData);
                 return ResourceLoadingAction.UserProvided;
             }

--- a/en/net/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/net/developer-guide/manage-presentation/open-presentation/_index.md
@@ -1,108 +1,126 @@
 ---
-title: Open Presentation in C#
+title: Open a Presentation in C#
 linktitle: Open Presentation
 type: docs
 weight: 20
 url: /net/open-presentation/
-keywords: "Open PowerPoint, PPTX, PPT, Open Presentation, Load Presentation, C#, Csharp, .NET"
-description: "Open or load Presentation PPT, PPTX, ODP in C# or .NET"
+keywords:
+- open PowerPoint
+- open presentation
+- open PPTX
+- open PPT
+- open ODP
+- load presentation
+- load PPTX
+- load PPT
+- load ODP
+- protected presentation
+- large presentation
+- external resource
+- .NET
+- C#
+- Aspose.Slides
+description: "Open PowerPoint (.pptx, .ppt) and OpenDocument (.odp) presentations effortlessly with Aspose.Slides for .NET—fast, reliable, fully featured."
 ---
 
-Besides creating PowerPoint presentations from scratch, Aspose.Slides allows you to open existing presentations. After you load a presentation, you can get information about the presentation, edit the presentation (content on its slides), add new slides or remove existing ones, etc. 
+## **Overview**
 
-## Open Presentation
+Beyond creating PowerPoint presentations from scratch, Aspose.Slides also lets you open existing presentations. After loading a presentation, you can retrieve information about it, edit slide content, add new slides, remove existing ones, and more.
 
-To open an existing presentation, you simply have to instantiate the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class and pass the file path (to the presentation you want to open) to its constructor. 
+## **Open Presentations**
 
-This C# code shows you how to open a presentation and also find out the number of slides it contains: 
+To open an existing presentation, instantiate the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class and pass the file path to its constructor.
 
-```c#
-// Instantiates the Presentation class and passes the file path to its constructor
-Presentation pres = new Presentation("OpenPresentation.pptx");
+The following C# example shows how to open a presentation and get its slide count:
 
-// Prints the total number of slides present in the presentation
-System.Console.WriteLine(pres.Slides.Count.ToString());
+```cs
+// Instantiate the Presentation class and pass a file path to its constructor.
+using (Presentation presentation = new Presentation("Sample.pptx"))
+{
+    // Print the total number of slides in the presentation.
+    System.Console.WriteLine(presentation.Slides.Count);
+}
 ```
 
-## **Open Password-Protected Presentation**
+## **Open Password-Protected Presentations**
 
-When you have to open a password-protected presentation, you can pass the password through the [Password](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/password/) property (from the [LoadOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/) class) to decrypt the presentation and load the presentation. This C# code demonstrates the operation:
+When you need to open a password-protected presentation, pass the password through the `Password` property of the [LoadOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/) class to decrypt and load it. The following C# code demonstrates this operation:
 
-```c#
-	LoadOptions loadOptions = new LoadOptions {Password = "YOUR_PASSWORD"};
-	using (Presentation presentation = new Presentation("pres.pptx", loadOptions))
-	{
-	  // Do some work with the decrypted presentation
-	}
+```cs
+LoadOptions loadOptions = new LoadOptions {Password = "YOUR_PASSWORD"};
+using (Presentation presentation = new Presentation("Sample.pptx", loadOptions))
+{
+    // Perform operations on the decrypted presentation.
+}
 ```
 
-## Open Large Presentation
+## **Open Large Presentations**
 
-Aspose.Slides provides options (the [BlobManagementOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/blobmanagementoptions/) property in particular) under the [LoadOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/) class to allow you to load large presentations. 
+Aspose.Slides provides options—particularly the [BlobManagementOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/blobmanagementoptions/) property in the [LoadOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/) class—to help you load large presentations.
 
-This C# demonstrates an operation in which a large presentation (say 2GB in size) is loaded:
+This C# code demonstrates loading a large presentation (for example, 2 GB):
 
-```c#
-const string pathToVeryLargePresentationFile = "veryLargePresentation.pptx";
+```cs
+const string filePath = "LargePresentation.pptx";
 
 LoadOptions loadOptions = new LoadOptions
 {
     BlobManagementOptions = {
-        // Let's choose the KeepLocked behavior - the "veryLargePresentation.pptx" will be locked for
-        // the Presentation's instance lifetime, but we don't need to load it into memory or copy into
-        // the temporary file
+        // Choose the KeepLocked behavior—the presentation file will remain locked for the lifetime of 
+        // the Presentation instance, but it does not need to be loaded into memory or copied to a temporary file.
         PresentationLockingBehavior = PresentationLockingBehavior.KeepLocked,
     }
 };
 
-using (Presentation pres = new Presentation(pathToVeryLargePresentationFile, loadOptions))
+using (Presentation presentation = new Presentation(filePath, loadOptions))
 {
-    // The large presentation has been loaded and can be used, but the memory consumption is still low.
+    // The large presentation has been loaded and can be used, while memory consumption remains low.
 
-    // Makes changes to the presentation.
-    pres.Slides[0].Name = "Very large presentation";
+    // Make changes to the presentation.
+    presentation.Slides[0].Name = "Large presentation";
 
-    // The presentation will be saved to the other file. The memory consumption stays low during the operation
-    pres.Save("veryLargePresentation-copy.pptx", SaveFormat.Pptx);
+    // Save the presentation to another file. Memory consumption remains low during this operation.
+    presentation.Save("LargePresentation-copy.pptx", SaveFormat.Pptx);
 
-    // can't do that! IO exception will be thrown, because the file is locked while pres objects will
-    // not be disposed
-    File.Delete(pathToVeryLargePresentationFile);
+    // Don't do this! An I/O exception will be thrown because the file is locked until the presentation object is disposed.
+    File.Delete(filePath);
 }
 
-// It is ok to do it here, the source file is not locked by pres object
-File.Delete(pathToVeryLargePresentationFile);
+// It is OK to do it here. The source file is no longer locked by the presentation object.
+File.Delete(filePath);
 ```
 
 {{% alert color="info" title="Info" %}}
 
-To circumvent certain limitations when interacting with streams, Aspose.Slides may copy the stream's content. Loading a large presentation through its stream will result in the copying of the presentation's contents and cause slow loading. Therefore, when you intend to load a large presentation, we strongly recommend that you use the presentation file path and not its stream.
+To work around certain limitations when working with streams, Aspose.Slides may copy a stream’s contents. Loading a large presentation from a stream causes the presentation to be copied and can slow loading. Therefore, when you need to load a large presentation, we strongly recommend using the presentation file path rather than a stream.
 
-When you want to create a presentation that contains large objects (video, audio, big images, etc.), you can use the [Blob facility](https://docs.aspose.com/slides/net/manage-blob/) to reduce memory consumption.
+When creating a presentation that contains large objects (video, audio, high-resolution images, etc.), you can use [BLOB management](/slides/net/manage-blob/) to reduce memory consumption.
 
-{{%/alert %}} 
+{{%/alert %}}
 
+## **Control External Resources**
 
-## Load Presentation
-Aspose.Slides provides [IResourceLoadingCallback](https://reference.aspose.com/slides/net/aspose.slides/iresourceloadingcallback/) with a single method to allow you to manage external resources. This C# code shows you how to use the `IResourceLoadingCallback` interface:
+Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.com/slides/net/aspose.slides/iresourceloadingcallback/) interface that lets you manage external resources. The following C# code shows how to use the `IResourceLoadingCallback` interface:
 
-```c#
-LoadOptions opts = new LoadOptions();
-opts.ResourceLoadingCallback = new ImageLoadingHandler();
-Presentation presentation = new Presentation("presentation.pptx", opts);
+```cs
+LoadOptions loadOptions = new LoadOptions();
+loadOptions.ResourceLoadingCallback = new ImageLoadingHandler();
+
+Presentation presentation = new Presentation("presentation.pptx", loadOptions);
 ```
 
-```c#
+```cs
 public class ImageLoadingHandler : IResourceLoadingCallback
 {
     public ResourceLoadingAction ResourceLoading(IResourceLoadingArgs args)
     {
         if (args.OriginalUri.EndsWith(".jpg"))
         {
-            try // Loads substitute image
+            try
             {
-                byte[] imageBytes = File.ReadAllBytes("c:\\aspose-logo.jpg");
-                args.SetData(imageBytes);
+                // Load a substitute image.
+                byte[] imageData = File.ReadAllBytes("c:\\aspose-logo.jpg");
+                args.SetData(imageData);
                 return ResourceLoadingAction.UserProvided;
             }
             catch (Exception)
@@ -112,53 +130,37 @@ public class ImageLoadingHandler : IResourceLoadingCallback
         }
         else if (args.OriginalUri.EndsWith(".png"))
         {
-            // Sets substitute url
+            // Set a substitute URL.
             args.Uri = "http://www.google.com/images/logos/ps_logo2.png";
             return ResourceLoadingAction.Default;
         }
 
-        // Skips all other images
+        // Skip all other images.
         return ResourceLoadingAction.Skip;
     }
 }
 ```
 
-## Load Presentation Without Embedded Binary Objects
+## **Load Presentations Without Embedded Binary Objects**
 
-The PowerPoint presentation can contain the following types of the embedded binary objects:
+A PowerPoint presentation can contain the following types of embedded binary objects:
 
-- VBA Project ([IPresentation.VbaProject](https://reference.aspose.com/slides/net/aspose.slides/ipresentation/vbaproject/));
-- OLE Object embedded data ([IOleEmbeddedDataInfo.EmbeddedFileData](https://reference.aspose.com/slides/net/aspose.slides/ioleembeddeddatainfo/embeddedfiledata/));
-- ActiveX Control binary data ([IControl.ActiveXControlBinary](https://reference.aspose.com/slides/net/aspose.slides/icontrol/activexcontrolbinary/));
+- VBA project ([IPresentation.VbaProject](https://reference.aspose.com/slides/net/aspose.slides/ipresentation/vbaproject/));
+- OLE object embedded data ([IOleEmbeddedDataInfo.EmbeddedFileData](https://reference.aspose.com/slides/net/aspose.slides/ioleembeddeddatainfo/embeddedfiledata/));
+- ActiveX control binary data ([IControl.ActiveXControlBinary](https://reference.aspose.com/slides/net/aspose.slides/icontrol/activexcontrolbinary/)).
 
-Using the [ILoadOptions.DeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/net/aspose.slides/iloadoptions/deleteembeddedbinaryobjects/) property, you can load the presentation without any embedded binary objects.
+Using the [ILoadOptions.DeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/net/aspose.slides/iloadoptions/deleteembeddedbinaryobjects/) property, you can load a presentation without any embedded binary objects.
 
-This property can be useful for removing potentially malicious binary content.
+This property is useful for removing potentially malicious binary content. The following C# code demonstrates how to load a presentation without any embedded binary content:
 
-The C# code demonstrates how to load and save a presentation without any malware content:
-
-```c#
+```cs
 LoadOptions loadOptions = new LoadOptions()
 {
 	DeleteEmbeddedBinaryObjects = true
 }
 
-using (var pres = new Presentation("malware.ppt", loadOptions))
+using (Presentation presentation = new Presentation("malware.ppt", loadOptions))
 {
-    pres.Save("clean.ppt", SaveFormat.Ppt);
+    // ...
 }
-```
-
-<h2>Open and Save Presentation</h2>
-
-<a name="csharp-open-save-presentation"><strong>Steps: Open and Save Presentation in C#</strong></a>
-
-1. Create an instance of the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class and pass the file you want to open. 
-2. Save the Presentation.
-
-```c#
-// Loads any supported presentation e.g ppt, pptx, odp
-Presentation presentation = new Presentation("Sample.odp");
-
-presentation.Save("OutputPresenation.pptx", SaveFormat.Pptx);
 ```

--- a/en/nodejs-java/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/nodejs-java/developer-guide/manage-presentation/open-presentation/_index.md
@@ -1,168 +1,164 @@
 ---
-title: Open Presentation in JavaScript
-linktitle: Open Presentation
+title: Open a Presentation in JavaScript
+linktitle: Open Presentations
 type: docs
 weight: 20
 url: /nodejs-java/open-presentation/
-keywords: "Open PowerPoint, PPTX, PPT, Open Presentation, Load Presentation, Java"
-description: "Open or load Presentation PPT, PPTX, ODP in JavaScript"
+keywords:
+- open PowerPoint
+- open presentation
+- open PPTX
+- open PPT
+- open ODP
+- load presentation
+- load PPTX
+- load PPT
+- load ODP
+- protected presentation
+- large presentation
+- external resource
+- binary object
+- Node.js
+- JavaScript
+- Aspose.Slides
+description: "Open PowerPoint (.pptx, .ppt) and OpenDocument (.odp) presentations effortlessly with Aspose.Slides for Node.js—fast, reliable, fully featured."
 ---
 
-Besides creating PowerPoint presentations from scratch, Aspose.Slides allows you to open existing presentations. After you load a presentation, you can get information about the presentation, edit the presentation (content on its slides), add new slides or remove existing ones, etc. 
+## **Overview**
 
-## Open Presentation
+Beyond creating PowerPoint presentations from scratch, Aspose.Slides also lets you open existing presentations. After loading a presentation, you can retrieve information about it, edit slide content, add new slides, remove existing ones, and more.
 
-To open an existing presentation, you simply have to instantiate the [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/) class and pass the file path (of the presentation you want to open) to its constructor.
+## **Open Presentations**
 
-This JavaScript code shows you how to open a presentation and also find out the number of slides it contains:
+To open an existing presentation, instantiate the [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/) class and pass the file path to its constructor.
 
-```javascript
-// Instantiates the Presentation class and passes the file path to its constructor
-var pres = new aspose.slides.Presentation("Presentation.pptx");
+The following JavaScript example shows how to open a presentation and get its slide count:
+
+```js
+// Instantiate the Presentation class and pass a file path to its constructor.
+let presentation = new aspose.slides.Presentation("Sample.pptx");
 try {
-    // Prints the total number of slides present in the presentation
-    console.log(pres.getSlides().size());
+    // Print the total number of slides in the presentation.
+    console.log(presentation.getSlides().size());
 } finally {
-    if (pres != null) {
-        pres.dispose();
-    }
+    presentation.dispose();
 }
 ```
 
-## **Open Password Protected Presentation**
+## **Open Password-Protected Presentations**
 
-When you have to open a password-protected presentation, you can pass the password through the [getPassword](https://reference.aspose.com/slides/nodejs-java/aspose.slides/loadoptions/#getPassword--) method (from the [LoadOptions](https://reference.aspose.com/slides/nodejs-java/aspose.slides/loadoptions/) class) to decrypt the presentation and load the presentation. This JavaScript code demonstrates the operation:
+When you need to open a password-protected presentation, pass the password through the [setPassword](https://reference.aspose.com/slides/nodejs-java/aspose.slides/loadoptions/#setPassword) method of the [LoadOptions](https://reference.aspose.com/slides/nodejs-java/aspose.slides/loadoptions/) class to decrypt and load it. The following JavaScript code demonstrates this operation:
 
-```javascript
-var loadOptions = new aspose.slides.LoadOptions();
+```js
+let loadOptions = new aspose.slides.LoadOptions();
 loadOptions.setPassword("YOUR_PASSWORD");
-var pres = new aspose.slides.Presentation("pres.pptx", loadOptions);
+
+let presentation = new aspose.slides.Presentation("Sample.pptx", loadOptions);
 try {
-    // Do some work with the decrypted presentation
+    // Perform operations on the decrypted presentation.
 } finally {
-    if (pres != null) {
-        pres.dispose();
-    }
+    presentation.dispose();
 }
 ```
 
-## Open Large Presentation
+## **Open Large Presentations**
 
-Aspose.Slides provides options (the [getBlobManagementOptions](https://reference.aspose.com/slides/nodejs-java/aspose.slides/loadoptions/#setBlobManagementOptions-aspose.slides.IBlobManagementOptions-) method in particular) under the [LoadOptions](https://reference.aspose.com/slides/nodejs-java/aspose.slides/LoadOptions) class to allow you to load large presentations.
+Aspose.Slides provides options—particularly the [getBlobManagementOptions](https://reference.aspose.com/slides/nodejs-java/aspose.slides/loadoptions/#getBlobManagementOptions) method in the [LoadOptions](https://reference.aspose.com/slides/nodejs-java/aspose.slides/loadoptions/) class—to help you load large presentations.
 
-This JavaScript demonstrates an operation in which a large presentation (say 2GB in size) is loaded:
+The following JavaScript code demonstrates loading a large presentation (for example, 2 GB):
 
-```javascript
-var loadOptions = new aspose.slides.LoadOptions();
+```js
+const filePath = "LargePresentation.pptx";
+
+let loadOptions = new aspose.slides.LoadOptions();
+// Choose the KeepLocked behavior—the presentation file will remain locked for the lifetime of
+// the Presentation instance, but it does not need to be loaded into memory or copied to a temporary file.
 loadOptions.getBlobManagementOptions().setPresentationLockingBehavior(aspose.slides.PresentationLockingBehavior.KeepLocked);
 loadOptions.getBlobManagementOptions().setTemporaryFilesAllowed(true);
-loadOptions.getBlobManagementOptions().setMaxBlobsBytesInMemory(0);
-var pres = new aspose.slides.Presentation("veryLargePresentation.pptx", loadOptions);
+loadOptions.getBlobManagementOptions().setMaxBlobsBytesInMemory(10 * 1024 * 1024); // 10 MB
+
+let presentation = new aspose.slides.Presentation(filePath, loadOptions);
 try {
-    // The large presentation has been loaded and can be used, but the memory consumption is still low.
-    // makes changes to the presentation.
-    pres.getSlides().get_Item(0).setName("Very large presentation");
-    // The presentation will be saved to the other file. The memory consumption stays low during the operation
-    pres.save("veryLargePresentation-copy.pptx", aspose.slides.SaveFormat.Pptx);
+    // The large presentation has been loaded and can be used, while memory consumption remains low.
+    
+    // Make changes to the presentation.
+    presentation.getSlides().get_Item(0).setName("Large presentation");
+
+    // Save the presentation to another file. Memory consumption remains low during this operation.
+    presentation.save("LargePresentation-copy.pptx", aspose.slides.SaveFormat.Pptx);
+
+    // Don't do this! An I/O exception will be thrown because the file is locked until the presentation object is disposed.
+    fs.rmSync(filePath);
 } finally {
-    if (pres != null) {
-        pres.dispose();
-    }
+    presentation.dispose();
 }
+
+// It is OK to do it here. The source file is no longer locked by the presentation object.
+fs.rmSync(filePath);
 ```
 
 {{% alert color="info" title="Info" %}}
 
-To circumvent certain limitations when interacting with a stream, Aspose.Slides may copy the stream's content. Loading a large presentation through its stream will result in the copying of the presentation's contents and cause slow loading. Therefore, when you intend to load a large presentation, we strongly recommend that you use the presentation file path and not its stream.
+To work around certain limitations when working with streams, Aspose.Slides may copy a stream’s contents. Loading a large presentation from a stream causes the presentation to be copied and can slow loading. Therefore, when you need to load a large presentation, we strongly recommend using the presentation file path rather than a stream.
 
-When you want to create a presentation that contains large objects (video, audio, big images, etc.), you can use the [Blob facility](https://docs.aspose.com/slides/nodejs-java/manage-blob/) to reduce memory consumption.
+When creating a presentation that contains large objects (video, audio, high-resolution images, etc.), you can use [BLOB management](/slides/nodejs-java/manage-blob/) to reduce memory consumption.
 
-{{%/alert %}} 
+{{%/alert %}}
 
+## **Control External Resources**
 
-## Load Presentation
+Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.com/slides/java/com.aspose.slides/iresourceloadingcallback/) interface that lets you manage external resources. The following JavaScript code shows how to use the `IResourceLoadingCallback` interface:
 
-Aspose.Slides provides [ResourceLoadingCallback](https://reference.aspose.com/slides/nodejs-java/aspose.slides/resourceloadingcallback/) with a single method to allow you to manage external resources. This JavaScript code shows you how to use the `IResourceLoadingCallback` class:
-
-```javascript
-var opts = new aspose.slides.LoadOptions();
-opts.setResourceLoadingCallback(java.newInstanceSync("ImageLoadingHandler"));
-var pres = new aspose.slides.Presentation("presentation.pptx", opts);
-```
-
-You will need to implement ImageLoadingHandler in Java, compile it, and add it to the module location \aspose.slides.via.java\lib\.
-```java
-class ImageLoadingHandler implements IResourceLoadingCallback
-{
-    public int resourceLoading(IResourceLoadingArgs args)
-    {
-        if (args.getOriginalUri().endsWith(".jpg"))
-        {
-            try // loads substitute image
-            {
-                byte[] imageBytes = Files.readAllBytes(new File("aspose-logo.jpg").toPath());
-                    args.setData(imageBytes);
-                return ResourceLoadingAction.UserProvided;
-            } catch (RuntimeException ex) {
-                return ResourceLoadingAction.Skip;
-            }  catch (IOException ex) {
-                ex.printStackTrace();
-                }
-            } else if (args.getOriginalUri().endsWith(".png")) {
-                // sets substitute url
-                args.setUri("http://www.google.com/images/logos/ps_logo2.png");
-            return ResourceLoadingAction.Default;
+```js
+const ImageLoadingHandler = java.newProxy("com.aspose.slides.IResourceLoadingCallback", {
+  args: function (args) {
+        if (args.getOriginalUri().endsWith(".jpg")) {
+            try {
+                // Load a substitute image.
+                const imageData = fs.readFileSync("aspose-logo.jpg");
+                args.setData(imageData);
+                return aspose.slides.ResourceLoadingAction.UserProvided;
+            } catch {
+                return aspose.slides.ResourceLoadingAction.Skip;
             }
-            // skips all other images
-        return ResourceLoadingAction.Skip;
+        } else if (args.getOriginalUri().endsWith(".png")) {
+            // Set a substitute URL.
+            args.setUri("http://www.google.com/images/logos/ps_logo2.png");
+            return aspose.slides.ResourceLoadingAction.Default;
         }
-    }
+        // Skip all other images.
+        return ResourceLoadingAction.Skip;
+      }
+});
 ```
 
-## Load Presentation Without Embedded Binary Objects
+```js
+let loadOptions = new aspose.slides.LoadOptions();
+loadOptions.setResourceLoadingCallback(ImageLoadingHandler);
 
-The PowerPoint presentation can contain the following types of the embedded binary objects:
+let presentation = new aspose.slides.Presentation("presentation.pptx", loadOptions);
+```
 
-- VBA Project ([Presentation.VbaProject](https://reference.aspose.com/slides/nodejs-java/aspose.slides/vbaproject/));
-- OLE Object embedded data ([OleEmbeddedDataInfo.getEmbeddedFileData](https://reference.aspose.com/slides/nodejs-java/aspose.slides/oleembeddeddatainfo/#getEmbeddedFileData--));
-- ActiveX Control binary data ([Control.getActiveXControlBinary](https://reference.aspose.com/slides/nodejs-java/aspose.slides/control/#getActiveXControlBinary--));
+## **Load Presentations Without Embedded Binary Objects**
 
-Using the [LoadOptions.setDeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/nodejs-java/aspose.slides/loadoptions/#setDeleteEmbeddedBinaryObjects-boolean-) property, you can load the presentation without any embedded binary objects.
+A PowerPoint presentation can contain the following types of embedded binary objects:
 
-This property can be useful for removing potentially malicious binary content.
+- VBA project (accessible via [Presentation.getVbaProject](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/#getVbaProject));
+- OLE object embedded data (accessible via [OleEmbeddedDataInfo.getEmbeddedFileData](https://reference.aspose.com/slides/nodejs-java/aspose.slides/oleembeddeddatainfo/#getEmbeddedFileData));
+- ActiveX control binary data (accessible via [Control.getActiveXControlBinary](https://reference.aspose.com/slides/nodejs-java/aspose.slides/control/#getActiveXControlBinary)).
 
-The code demonstrates how to load and save a presentation without any malware content:
+Using the [LoadOptions.setDeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/nodejs-java/aspose.slides/loadoptions/#setDeleteEmbeddedBinaryObjects) method, you can load a presentation without any embedded binary objects.
 
-```javascript
-var loadOptions = new aspose.slides.LoadOptions();
+This method is useful for removing potentially malicious binary content. The following JavaScript code demonstrates how to load a presentation without any embedded binary content:
+
+```js
+let loadOptions = new aspose.slides.LoadOptions();
 loadOptions.setDeleteEmbeddedBinaryObjects(true);
-var pres = new aspose.slides.Presentation("malware.ppt", loadOptions);
+
+let presentation = new aspose.slides.Presentation("malware.ppt", loadOptions);
 try {
-    pres.save("clean.ppt", aspose.slides.SaveFormat.Ppt);
+    // Perform operations on the presentation.
 } finally {
-    if (pres != null) {
-        pres.dispose();
-    }
-}
-```
-
-## Open and Save Presentation
-
-Steps to Open and Save Presentation:
-
-1. Create an instance of the [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Presentation) class and pass the file you want to open.
-2. Save the presentation.  
-
-```javascript
-// Instantiates a Presentation object that represents a PPT file
-var pres = new aspose.slides.Presentation();
-try {
-    // ...do some work here...
-    // Saves your presentation to a file
-    pres.save("demoPass.pptx", aspose.slides.SaveFormat.Pptx);
-} finally {
-    if (pres != null) {
-        pres.dispose();
-    }
+    presentation.dispose();
 }
 ```

--- a/en/nodejs-java/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/nodejs-java/developer-guide/manage-presentation/open-presentation/_index.md
@@ -136,7 +136,7 @@ const ImageLoadingHandler = java.newProxy("com.aspose.slides.IResourceLoadingCal
 let loadOptions = new aspose.slides.LoadOptions();
 loadOptions.setResourceLoadingCallback(ImageLoadingHandler);
 
-let presentation = new aspose.slides.Presentation("presentation.pptx", loadOptions);
+let presentation = new aspose.slides.Presentation("Sample.pptx", loadOptions);
 ```
 
 ## **Load Presentations Without Embedded Binary Objects**

--- a/en/nodejs-java/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/nodejs-java/developer-guide/manage-presentation/open-presentation/_index.md
@@ -88,13 +88,13 @@ try {
     presentation.save("LargePresentation-copy.pptx", aspose.slides.SaveFormat.Pptx);
 
     // Don't do this! An I/O exception will be thrown because the file is locked until the presentation object is disposed.
-    fs.rmSync(filePath);
+    //fs.unlinkSync(filePath);
 } finally {
     presentation.dispose();
 }
 
 // It is OK to do it here. The source file is no longer locked by the presentation object.
-fs.rmSync(filePath);
+fs.unlinkSync(filePath);
 ```
 
 {{% alert color="info" title="Info" %}}
@@ -111,7 +111,7 @@ Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.c
 
 ```js
 const ImageLoadingHandler = java.newProxy("com.aspose.slides.IResourceLoadingCallback", {
-  args: function (args) {
+  resourceLoading: function(args) {
         if (args.getOriginalUri().endsWith(".jpg")) {
             try {
                 // Load a substitute image.
@@ -127,7 +127,7 @@ const ImageLoadingHandler = java.newProxy("com.aspose.slides.IResourceLoadingCal
             return aspose.slides.ResourceLoadingAction.Default;
         }
         // Skip all other images.
-        return ResourceLoadingAction.Skip;
+        return aspose.slides.ResourceLoadingAction.Skip;
       }
 });
 ```

--- a/en/php-java/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/php-java/developer-guide/manage-presentation/open-presentation/_index.md
@@ -1,168 +1,162 @@
 ---
-title: Open Presentation
-linktitle: Open Presentation
+title: Open a Presentation in PHP
+linktitle: Open Presentations
 type: docs
 weight: 20
 url: /php-java/open-presentation/
-keywords: "Open PowerPoint, PPTX, PPT, Open Presentation, Load Presentation, Java"
-description: "Open or load Presentation PPT, PPTX, ODP "
+keywords:
+- open PowerPoint
+- open presentation
+- open PPTX
+- open PPT
+- open ODP
+- load presentation
+- load PPTX
+- load PPT
+- load ODP
+- protected presentation
+- large presentation
+- external resource
+- binary object
+- PHP
+- Aspose.Slides
+description: "Open PowerPoint (.pptx, .ppt) and OpenDocument (.odp) presentations effortlessly with Aspose.Slides for PHP—fast, reliable, fully featured."
 ---
 
-Besides creating PowerPoint presentations from scratch, Aspose.Slides allows you to open existing presentations. After you load a presentation, you can get information about the presentation, edit the presentation (content on its slides), add new slides or remove existing ones, etc. 
+## **Overview**
 
-## Open Presentation
+Beyond creating PowerPoint presentations from scratch, Aspose.Slides also lets you open existing presentations. After loading a presentation, you can retrieve information about it, edit slide content, add new slides, remove existing ones, and more.
 
-To open an existing presentation, you simply have to instantiate the [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/) class and pass the file path (of the presentation you want to open) to its constructor.
+## **Open Presentations**
 
-This PHP code shows you how to open a presentation and also find out the number of slides it contains:
+To open an existing presentation, instantiate the [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/) class and pass the file path to its constructor.
+
+The following PHP example shows how to open a presentation and get its slide count:
 
 ```php
-  # Instantiates the Presentation class and passes the file path to its constructor
-  $pres = new Presentation("Presentation.pptx");
-  try {
-    # Prints the total number of slides present in the presentation
-    echo($pres->getSlides()->size());
-  } finally {
-    if (!java_is_null($pres)) {
-      $pres->dispose();
-    }
-  }
+// Instantiate the Presentation class and pass a file path to its constructor.
+$presentation = new Presentation("Sample.pptx");
+try {
+    // Print the total number of slides in the presentation.
+    echo($presentation->getSlides()->size());
+} finally {
+    $presentation->dispose();
+}
 ```
 
-## **Open Password Protected Presentation**
+## **Open Password-Protected Presentations**
 
-When you have to open a password-protected presentation, you can pass the password through the [Password](https://reference.aspose.com/slides/php-java/aspose.slides/loadoptions/#getPassword--) property (from the [LoadOptions](https://reference.aspose.com/slides/php-java/aspose.slides/loadoptions/) class) to decrypt the presentation and load the presentation. This PHP code demonstrates the operation:
+When you need to open a password-protected presentation, pass the password through the [setPassword](https://reference.aspose.com/slides/php-java/aspose.slides/loadoptions/#setPassword) method of the [LoadOptions](https://reference.aspose.com/slides/php-java/aspose.slides/loadoptions/) class to decrypt and load it. The following PHP code demonstrates this operation:
 
 ```php
-  $loadOptions = new LoadOptions();
-  $loadOptions->setPassword("YOUR_PASSWORD");
-  $pres = new Presentation("pres.pptx", $loadOptions);
-  try {
-    # Do some work with the decrypted presentation
-  } finally {
-    if (!java_is_null($pres)) {
-      $pres->dispose();
-    }
-  }
+$loadOptions = new LoadOptions();
+$loadOptions->setPassword("YOUR_PASSWORD");
+
+$presentation = new Presentation("Sample.pptx", $loadOptions);
+try {
+    // Perform operations on the decrypted presentation.
+} finally {
+    $presentation->dispose();
+}
 ```
 
-## Open Large Presentation
+## **Open Large Presentations**
 
-Aspose.Slides provides options (the [BlobManagementOptions](https://reference.aspose.com/slides/php-java/aspose.slides/loadoptions/#setBlobManagementOptions-com.aspose.slides.IBlobManagementOptions-) property in particular) under the [LoadOptions](https://reference.aspose.com/slides/php-java/aspose.slides/LoadOptions) class to allow you to load large presentations.
+Aspose.Slides provides options—particularly the [getBlobManagementOptions](https://reference.aspose.com/slides/php-java/aspose.slides/loadoptions/#getBlobManagementOptions) method in the [LoadOptions](https://reference.aspose.com/slides/php-java/aspose.slides/loadoptions/) class—to help you load large presentations.
 
-This Java demonstrates an operation in which a large presentation (say 2GB in size) is loaded:
+The following PHP code demonstrates loading a large presentation (for example, 2 GB):
 
 ```php
-  $loadOptions = new LoadOptions();
-  $loadOptions->getBlobManagementOptions()->setPresentationLockingBehavior(PresentationLockingBehavior->KeepLocked);
-  $loadOptions->getBlobManagementOptions()->setTemporaryFilesAllowed(true);
-  $loadOptions->getBlobManagementOptions()->setMaxBlobsBytesInMemory(0);
-  $pres = new Presentation("veryLargePresentation.pptx", $loadOptions);
-  try {
-    # The large presentation has been loaded and can be used, but the memory consumption is still low.
-    # makes changes to the presentation.
-    $pres->getSlides()->get_Item(0)->setName("Very large presentation");
-    # The presentation will be saved to the other file. The memory consumption stays low during the operation
-    $pres->save("veryLargePresentation-copy.pptx", SaveFormat::Pptx);
-  } finally {
-    if (!java_is_null($pres)) {
-      $pres->dispose();
-    }
-  }
+$filePath = "LargePresentation.pptx";
+
+$loadOptions = new LoadOptions();
+// Choose the KeepLocked behavior—the presentation file will remain locked for the lifetime of
+// the Presentation instance, but it does not need to be loaded into memory or copied to a temporary file.
+$loadOptions->getBlobManagementOptions()->setPresentationLockingBehavior(PresentationLockingBehavior::KeepLocked);
+$loadOptions->getBlobManagementOptions()->setTemporaryFilesAllowed(true);
+$loadOptions->getBlobManagementOptions()->setMaxBlobsBytesInMemory(10 * 1024 * 1024); // 10 MB
+
+$presentation = new Presentation($filePath, $loadOptions);
+try {
+    // The large presentation has been loaded and can be used, while memory consumption remains low.
+
+    // Make changes to the presentation.
+    $presentation->getSlides()->get_Item(0)->setName("Very large presentation");
+
+    // Save the presentation to another file. Memory consumption remains low during this operation.
+    $presentation->save("LargePresentation-copy.pptx", SaveFormat::Pptx);
+} finally {
+    $presentation->dispose();
+}
 ```
 
 {{% alert color="info" title="Info" %}}
 
-To circumvent certain limitations when interacting with a stream, Aspose.Slides may copy the stream's content. Loading a large presentation through its stream will result in the copying of the presentation's contents and cause slow loading. Therefore, when you intend to load a large presentation, we strongly recommend that you use the presentation file path and not its stream.
+To work around certain limitations when working with streams, Aspose.Slides may copy a stream’s contents. Loading a large presentation from a stream causes the presentation to be copied and can slow loading. Therefore, when you need to load a large presentation, we strongly recommend using the presentation file path rather than a stream.
 
-When you want to create a presentation that contains large objects (video, audio, big images, etc.), you can use the [Blob facility](https://docs.aspose.com/slides/php-java/manage-blob/) to reduce memory consumption.
+When creating a presentation that contains large objects (video, audio, high-resolution images, etc.), you can use [BLOB management](/slides/php-java/manage-blob/) to reduce memory consumption.
 
-{{%/alert %}} 
+{{%/alert %}}
 
+## **Control External Resources**
 
-## Load Presentation
-
-Aspose.Slides provides [IResourceLoadingCallback](https://reference.aspose.com/slides/php-java/aspose.slides/iresourceloadingcallback/) with a single method to allow you to manage external resources. This PHP code shows you how to use the `IResourceLoadingCallback` interface:
+Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.com/slides/java/com.aspose.slides/iresourceloadingcallback/) interface that lets you manage external resources. The following PHP code shows how to use the `IResourceLoadingCallback` interface:
 
 ```php
-
 class ImageLoadingHandler {
     function resourceLoading($args) {
-      if (java_values($args->getOriginalUri()->endsWith(".jpg"))) {
-        # loads substitute image
-        $file = new Java("java.io.File", "aspose-logo.jpg");
-        $Array = new JavaClass("java.lang.reflect.Array");
-        $Byte = new JavaClass("java.lang.Byte");
-        $imageBytes = $Array->newInstance($Byte, $Array->getLength($file));
-        try {
-            $dis = new Java("java.io.DataInputStream", new Java("java.io.FileInputStream", $file));
-            $dis->readFully($imageBytes);
-        } finally {
-            if (!java_is_null($dis)) $dis->close();
+        if (java_values($args->getOriginalUri()->endsWith(".jpg"))) {
+            // Load a substitute image.
+            $imageFile = new Java("java.io.File", "aspose-logo.jpg");
+            $Array = new JavaClass("java.lang.reflect.Array");
+            $Byte = new JavaClass("java.lang.Byte");
+            $imageData = $Array->newInstance($Byte, $Array->getLength($imageFile));
+            try {
+                $dis = new Java("java.io.DataInputStream", new Java("java.io.FileInputStream", $imageFile));
+                $dis->readFully($imageData);
+            } finally {
+                if (!java_is_null($dis)) $dis->close();
+            }
+            $args->setData($imageData);
+            return ResourceLoadingAction::UserProvided;
+        } else if (java_values($args->getOriginalUri()->endsWith(".png"))) {
+            // Set a substitute URL.
+            $args->setUri("http://www.google.com/images/logos/ps_logo2.png");
+            return ResourceLoadingAction::Default;
         }
-          $args->setData($imageBytes);
-          return ResourceLoadingAction::UserProvided;
-      } else if (java_values($args->getOriginalUri()->endsWith(".png"))) {
-        # sets substitute url
-        $args->setUri("http://www.google.com/images/logos/ps_logo2.png");
-        return ResourceLoadingAction::Default;
-      }
-      # skips all other images
-      return ResourceLoadingAction::Skip;
+        // Skip all other images.
+        return ResourceLoadingAction::Skip;
     }
-  }
+}
 
-  $opts = new LoadOptions();
-  $loadingHandler = java_closure(new ImageLoadingHandler(), null, java("com.aspose.slides.IResourceLoadingCallback"));
-  $opts->setResourceLoadingCallback($loadingHandler);
-  $pres = new Presentation("presentation.pptx", $opts);
+$loadingHandler = java_closure(new ImageLoadingHandler(), null, java("com.aspose.slides.IResourceLoadingCallback"));
+
+$loadOptions = new LoadOptions();
+$loadOptions->setResourceLoadingCallback($loadingHandler);
+
+$presentation = new Presentation("Sample.pptx", $loadOptions);
 ```
 
-## Load Presentation Without Embedded Binary Objects
+## **Load Presentations Without Embedded Binary Objects**
 
-The PowerPoint presentation can contain the following types of the embedded binary objects:
+A PowerPoint presentation can contain the following types of embedded binary objects:
 
-- VBA Project ([IPresentation.VbaProject](https://reference.aspose.com/slides/java/com.aspose.slides/vbaproject/));
-- OLE Object embedded data ([IOleEmbeddedDataInfo.EmbeddedFileData](https://reference.aspose.com/slides/java/com.aspose.slides/ioleembeddeddatainfo/#getEmbeddedFileData--));
-- ActiveX Control binary data ([IControl.ActiveXControlBinary](https://reference.aspose.com/slides/java/com.aspose.slides/icontrol/#getActiveXControlBinary--));
+- VBA project (accessible via [Presentation.getVbaProject](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/#getVbaProject));
+- OLE object embedded data (accessible via [OleEmbeddedDataInfo.getEmbeddedFileData](https://reference.aspose.com/slides/php-java/aspose.slides/oleembeddeddatainfo/#getEmbeddedFileData));
+- ActiveX control binary data (accessible via [Control.getActiveXControlBinary](https://reference.aspose.com/slides/php-java/aspose.slides/control/#getActiveXControlBinary)).
 
-Using the [ILoadOptions.DeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/java/com.aspose.slides/iloadoptions/#setDeleteEmbeddedBinaryObjects-boolean-) property, you can load the presentation without any embedded binary objects.
+Using the [LoadOptions.setDeleteEmbeddedBinaryObjects](https://reference.aspose.com/slides/php-java/aspose.slides/loadoptions/#setDeleteEmbeddedBinaryObjects) method, you can load a presentation without any embedded binary objects.
 
-This property can be useful for removing potentially malicious binary content.
-
-The code demonstrates how to load and save a presentation without any malware content:
-
-```java
-  $loadOptions = new LoadOptions();
-  $loadOptions->setDeleteEmbeddedBinaryObjects(true);
-
-  $pres = new Presentation("malware.ppt", $loadOptions);
-  try {
-    $pres->save("clean.ppt", SaveFormat::Ppt);
-  } finally {
-    if (!java_is_null(pres)) { 
-      $pres->dispose();
-    }
-  }
-```
-
-## Open and Save Presentation
-
-Steps to Open and Save Presentation:
-
-1. Create an instance of the [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/Presentation) class and pass the file you want to open.
-2. Save the presentation.  
+This method is useful for removing potentially malicious binary content. The following PHP code demonstrates how to load a presentation without any embedded binary content:
 
 ```php
-  # Instantiates a Presentation object that represents a PPT file
-  $pres = new Presentation();
-  try {
-    # ...do some work here...
-    # Saves your presentation to a file
-    $pres->save("demoPass.pptx", SaveFormat::Pptx);
-  } finally {
-    if (!java_is_null($pres)) {
-      $pres->dispose();
-    }
-  }
+$loadOptions = new LoadOptions();
+$loadOptions->setDeleteEmbeddedBinaryObjects(true);
+
+$presentation = new Presentation("malware.ppt", $loadOptions);
+try {
+    // Perform operations on the presentation.
+} finally {
+    $presentation->dispose();
+}
 ```

--- a/en/php-java/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/php-java/developer-guide/manage-presentation/open-presentation/_index.md
@@ -85,9 +85,14 @@ try {
 
     // Save the presentation to another file. Memory consumption remains low during this operation.
     $presentation->save("LargePresentation-copy.pptx", SaveFormat::Pptx);
+	
+	// Don't do this! An I/O exception will be thrown because the file is locked until the presentation object is disposed.
+	//unlink($filePath);
 } finally {
     $presentation->dispose();
 }
+// It is OK to do it here. The source file is no longer locked by the presentation object.
+unlink($filePath);
 ```
 
 {{% alert color="info" title="Info" %}}
@@ -107,17 +112,9 @@ class ImageLoadingHandler {
     function resourceLoading($args) {
         if (java_values($args->getOriginalUri()->endsWith(".jpg"))) {
             // Load a substitute image.
-            $imageFile = new Java("java.io.File", "aspose-logo.jpg");
-            $Array = new JavaClass("java.lang.reflect.Array");
-            $Byte = new JavaClass("java.lang.Byte");
-            $imageData = $Array->newInstance($Byte, $Array->getLength($imageFile));
-            try {
-                $dis = new Java("java.io.DataInputStream", new Java("java.io.FileInputStream", $imageFile));
-                $dis->readFully($imageData);
-            } finally {
-                if (!java_is_null($dis)) $dis->close();
-            }
-            $args->setData($imageData);
+			$bytes = file_get_contents("aspose-logo.jpg");
+			$javaByteArray = java_values($bytes);
+            $args->setData($javaByteArray);
             return ResourceLoadingAction::UserProvided;
         } else if (java_values($args->getOriginalUri()->endsWith(".png"))) {
             // Set a substitute URL.

--- a/en/python-net/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/python-net/developer-guide/manage-presentation/open-presentation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Open a Presentation in Python
-linktitle: Open Presentation
+linktitle: Open Presentations
 type: docs
 weight: 20
 url: /python-net/open-presentation/
@@ -17,6 +17,7 @@ keywords:
 - protected presentation
 - large presentation
 - external resource
+- binary object
 - Python
 - Aspose.Slides
 description: "Open PowerPoint (.pptx, .ppt) and OpenDocument (.odp) presentations effortlessly with Aspose.Slides for Python via .NET—fast, reliable, fully featured."
@@ -43,7 +44,7 @@ with slides.Presentation("sample.pptx") as presentation:
 
 ## **Open Password-Protected Presentations**
 
-When you need to open a password-protected presentation, pass the password through the `password` property of the [LoadOptions](https://reference.aspose.com/slides/python-net/aspose.slides/loadoptions/) class to decrypt and load it. The following Python code demonstrates this operation:
+When you need to open a password-protected presentation, pass the password through the [password](https://reference.aspose.com/slides/python-net/aspose.slides/loadoptions/password/) property of the [LoadOptions](https://reference.aspose.com/slides/python-net/aspose.slides/loadoptions/) class to decrypt and load it. The following Python code demonstrates this operation:
 
 ```python
 import aspose.slides as slides
@@ -52,12 +53,12 @@ load_options = slides.LoadOptions()
 load_options.password = "YOUR_PASSWORD"
 
 with slides.Presentation("sample.pptx", load_options) as presentation:
-    # ...
+    # Perform operations on the decrypted presentation.
 ```
 
 ## **Open Large Presentations**
 
-Aspose.Slides provides options—particularly the `blob_management_options` property in the [LoadOptions](https://reference.aspose.com/slides/python-net/aspose.slides/loadoptions/) class—to help you load large presentations.
+Aspose.Slides provides options—particularly the [blob_management_options](https://reference.aspose.com/slides/python-net/aspose.slides/loadoptions/blob_management_options/) property in the [LoadOptions](https://reference.aspose.com/slides/python-net/aspose.slides/loadoptions/) class—to help you load large presentations.
 
 This Python code demonstrates loading a large presentation (for example, 2 GB):
 
@@ -65,38 +66,65 @@ This Python code demonstrates loading a large presentation (for example, 2 GB):
 import aspose.slides as slides
 import os
 
-load_options = slides.LoadOptions()
-load_options.blob_management_options = slides.BlobManagementOptions()
-load_options.blob_management_options.presentation_locking_behavior = slides.PresentationLockingBehavior.KEEP_LOCKED
+file_path = "LargePresentation.pptx"
 
-with slides.Presentation("sample.pptx", load_options) as presentation:
+load_options = slides.LoadOptions()
+# Choose the KeepLocked behavior—the presentation file will remain locked for the lifetime of 
+# the Presentation instance, but it does not need to be loaded into memory or copied to a temporary file.
+load_options.blob_management_options.presentation_locking_behavior = slides.PresentationLockingBehavior.KEEP_LOCKED
+load_options.blob_management_options.is_temporary_files_allowed = True
+load_options.blob_management_options.max_blobs_bytes_in_memory = 10 * 1024 * 1024  # 10 MB
+
+with slides.Presentation(file_path, load_options) as presentation:
     # The large presentation has been loaded and can be used, while memory consumption remains low.
 
     # Make changes to the presentation.
-    presentation.slides[0].name = "Very large presentation"
+    presentation.slides[0].name = "Large presentation"
 
     # Save the presentation to another file. Memory consumption remains low during this operation.
-    presentation.save("veryLargePresentation-copy.pptx", slides.export.SaveFormat.PPTX)
+    presentation.save("LargePresentation-copy.pptx", slides.export.SaveFormat.PPTX)
 
     # Don't do this! An I/O exception will be thrown because the file is locked until the presentation object is disposed.
-    os.remove("sample.pptx")
+    os.remove(file_path)
 
 # It is OK to do it here. The source file is no longer locked by the presentation object.
-os.remove("sample.pptx")
+os.remove(file_path)
 ```
 
 {{% alert color="info" title="Info" %}}
 
 To work around certain limitations when working with streams, Aspose.Slides may copy a stream’s contents. Loading a large presentation from a stream causes the presentation to be copied and can slow loading. Therefore, when you need to load a large presentation, we strongly recommend using the presentation file path rather than a stream.
 
-When creating a presentation that contains large objects (video, audio, high-resolution images, etc.), you can use the [Blob facility](https://docs.aspose.com/slides/python-net/manage-blob/) to reduce memory consumption.
+When creating a presentation that contains large objects (video, audio, high-resolution images, etc.), you can use [BLOB management](/slides/python-net/manage-blob/) to reduce memory consumption.
 
 {{%/alert %}}
 
 ## **Control External Resources**
 
-Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.com/slides/python-net/aspose.slides/iresourceloadingcallback/) interface with a single method that lets you manage external resources. The following Python code shows how to use the `IResourceLoadingCallback` interface:
+Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.com/slides/python-net/aspose.slides/iresourceloadingcallback/) interface that lets you manage external resources. The following Python code shows how to use the `IResourceLoadingCallback` interface:
 
 ```python
 # [TODO[not_supported_yet]: python implementation of .NET interfaces]
+```
+
+## **Load Presentations Without Embedded Binary Objects**
+
+A PowerPoint presentation can contain the following types of embedded binary objects:
+
+- VBA project (accessible via [Presentation.vba_project](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/vba_project/));
+- OLE object embedded data (accessible via [OleEmbeddedDataInfo.embedded_file_data](https://reference.aspose.com/slides/python-net/aspose.slides/ioleembeddeddatainfo/embedded_file_data/));
+- ActiveX control binary data (accessible via [Control.active_x_control_binary](https://reference.aspose.com/slides/python-net/aspose.slides/control/active_x_control_binary/)).
+
+Using the [LoadOptions.delete_embedded_binary_objects](https://reference.aspose.com/slides/python-net/aspose.slides/loadoptions/delete_embedded_binary_objects/) property, you can load a presentation without any embedded binary objects.
+
+This property is useful for removing potentially malicious binary content. The following Python code demonstrates how to load a presentation without any embedded binary content:
+
+```py
+import aspose.slides as slides
+
+load_options = slides.LoadOptions()
+load_options.delete_embedded_binary_objects = True
+
+with slides.Presentation("malware.ppt", load_options) as presentation:
+    # Perform operations on the presentation.
 ```

--- a/en/python-net/developer-guide/manage-presentation/open-presentation/_index.md
+++ b/en/python-net/developer-guide/manage-presentation/open-presentation/_index.md
@@ -16,6 +16,7 @@ keywords:
 - load ODP
 - protected presentation
 - large presentation
+- external resource
 - Python
 - Aspose.Slides
 description: "Open PowerPoint (.pptx, .ppt) and OpenDocument (.odp) presentations effortlessly with Aspose.Slides for Python via .NET—fast, reliable, fully featured."
@@ -29,7 +30,7 @@ Beyond creating PowerPoint presentations from scratch, Aspose.Slides also lets y
 
 To open an existing presentation, instantiate the [Presentation](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/) class and pass the file path to its constructor.
 
-This Python example shows how to open a presentation and get its slide count:
+The following Python example shows how to open a presentation and get its slide count:
 
 ```python
 import aspose.slides as slides
@@ -40,7 +41,7 @@ with slides.Presentation("sample.pptx") as presentation:
     print(presentation.slides.length)
 ```
 
-## **Open Password Protected Presentations**
+## **Open Password-Protected Presentations**
 
 When you need to open a password-protected presentation, pass the password through the `password` property of the [LoadOptions](https://reference.aspose.com/slides/python-net/aspose.slides/loadoptions/) class to decrypt and load it. The following Python code demonstrates this operation:
 
@@ -48,7 +49,7 @@ When you need to open a password-protected presentation, pass the password throu
 import aspose.slides as slides
 
 load_options = slides.LoadOptions()
-load_options.password = "PASSWORD"
+load_options.password = "YOUR_PASSWORD"
 
 with slides.Presentation("sample.pptx", load_options) as presentation:
     # ...
@@ -92,29 +93,10 @@ When creating a presentation that contains large objects (video, audio, high-res
 
 {{%/alert %}}
 
-## **Load Presentations**
+## **Control External Resources**
 
 Aspose.Slides provides the [IResourceLoadingCallback](https://reference.aspose.com/slides/python-net/aspose.slides/iresourceloadingcallback/) interface with a single method that lets you manage external resources. The following Python code shows how to use the `IResourceLoadingCallback` interface:
 
 ```python
 # [TODO[not_supported_yet]: python implementation of .NET interfaces]
-```
-
-## **Open and Save Presentations**
-
-Follow these steps to open and save a presentation in Python:
-
-1. Create an instance of the [Presentation](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/) class and pass the path of the file you want to open to its constructor.
-2. Save the presentation.
-
-```python
-import aspose.slides as slides
-
-# Instantiate the Presentation class that represents a PPT file.
-with slides.Presentation("sample.ppt") as presentation:
-    
-    #...do some work here...
-
-    # Save the presentation to a file.
-    presentation.save("output.pptx", slides.export.SaveFormat.PPTX)
 ```


### PR DESCRIPTION
Added the section "Load Presentations Without Embedded Binary Objects" according to the changes made in https://github.com/aspose-slides/Aspose.Slides-Documentation/pull/629.
Updated the article "Open a Presentation" for .NET, Android via Java, C++, Java, Node.js via Java, PHP via Java, and Python via .NET.