### PR TITLE
Update docs for forum topic 327999

### DIFF
--- a/en/python-net/developer-guide/presentation-content/manage-blob/_index.md
+++ b/en/python-net/developer-guide/presentation-content/manage-blob/_index.md
@@ -164,21 +164,18 @@ When you use `temp_files_root_path`, Aspose.Slides does not automatically create
 
 ### **Dispose Presentation Objects to Release Memory**
 
-When processing large presentations, ensure that the `Presentation` instance is properly disposed so that the memory it occupied is released. The recommended way is to use the context manager (`with slides.Presentation(...) as pres:`) as shown in the examples above; it automatically closes the presentation and frees unmanaged resources when the block exits.
+When processing large presentations, ensure that the `Presentation` instance is properly disposed so that the memory it occupied is released. The recommended way is to use the context manager (`with slides.Presentation(...) as presentation:`) as shown in the examples above; it automatically closes the presentation and frees unmanaged resources when the block exits.
 
-If you create a presentation without a `with` block, explicitly call `pres.dispose()` (or `pres.__exit__(None, None, None)`) after you have finished using it, and remove any remaining references so that Python’s garbage collector can reclaim the memory.
+If you create a presentation without a `with` block, explicitly call `presentation.dispose()` after you have finished using it, and remove any remaining references so that Python’s garbage collector can reclaim the memory.
 
 ```py
 import aspose.slides as slides
 
-pres = slides.Presentation("large.pptx")
+presentation = slides.Presentation("large.pptx")
 # ...process the presentation...
-pres.save("large.pdf", slides.export.SaveFormat.PDF)
-# Explicitly release resources
-pres.dispose()
-# Optionally trigger garbage collection
-import gc
-gc.collect()
+presentation.save("large.pdf", slides.export.SaveFormat.PDF)
+# Explicitly release resources.
+presentation.dispose()
 ```
 
 ## **FAQ**

--- a/en/python-net/developer-guide/presentation-content/manage-blob/_index.md
+++ b/en/python-net/developer-guide/presentation-content/manage-blob/_index.md
@@ -162,6 +162,25 @@ When you use `temp_files_root_path`, Aspose.Slides does not automatically create
 
 {{% /alert %}}
 
+### **Dispose Presentation Objects to Release Memory**
+
+When processing large presentations, ensure that the `Presentation` instance is properly disposed so that the memory it occupied is released. The recommended way is to use the context manager (`with slides.Presentation(...) as pres:`) as shown in the examples above; it automatically closes the presentation and frees unmanaged resources when the block exits.
+
+If you create a presentation without a `with` block, explicitly call `pres.dispose()` (or `pres.__exit__(None, None, None)`) after you have finished using it, and remove any remaining references so that Python’s garbage collector can reclaim the memory.
+
+```py
+import aspose.slides as slides
+
+pres = slides.Presentation("large.pptx")
+# ...process the presentation...
+pres.save("large.pdf", slides.export.SaveFormat.PDF)
+# Explicitly release resources
+pres.dispose()
+# Optionally trigger garbage collection
+import gc
+gc.collect()
+```
+
 ## **FAQ**
 
 **What data in an Aspose.Slides presentation is treated as BLOB and controlled by BLOB options?**


### PR DESCRIPTION
Forum topic: 327999 - High Memory Usage in Aspose.Slides for Python on Azure Linux

Summary:
- Added a new subsection on disposing Presentation objects
- Provided code example for explicit disposal and garbage collection

Changed sections:
- Memory and Large Presentations