### PR TITLE
Update docs for forum topic 327979

### DIFF
--- a/en/java/developer-guide/presentation-content/manage-blob/_index.md
+++ b/en/java/developer-guide/presentation-content/manage-blob/_index.md
@@ -201,6 +201,22 @@ When you use `TempFilesRootPath`, Aspose.Slides does not automatically create a 
 
 {{% /alert %}}
 
+**Increase JVM Heap for Large Presentations**  
+
+When processing very large files, the JVM heap must be large enough to hold the presentation object model. In a Spring Boot 3 application you can increase the heap size, for example:
+
+```bash
+java -Xms2g -Xmx8g -jar your-app.jar
+```
+
+Or set it via an environment variable:
+
+```bash
+export JAVA_TOOL_OPTIONS="-Xms2g -Xmx8g"
+```
+
+If you start the application with Maven/Gradle, add the options to `JAVA_OPTS` or `SPRING_BOOT_JAVA_OPTS`. Ensure the heap size is sufficient for the size of the source presentation, the template, and the output file.
+
 ## **FAQ**
 
 **What data in an Aspose.Slides presentation is treated as BLOB and controlled by BLOB options?**


### PR DESCRIPTION
Forum topic: 327979 - How to Manage Big Presentations Using Aspose.Slides for Java Library?

Summary:
- Add JVM heap guidance for handling very large presentations
- Provide Spring Boot 3 examples for setting JVM options via command line and environment variables

Changed sections:
- Memory and Large Presentations