### PR TITLE
Update docs for forum topic 294894

### DIFF
--- a/en/net/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
+++ b/en/net/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
@@ -115,9 +115,9 @@ using (Presentation pres = new Presentation())
 }
 ```
 
-### **Detect Unsupported Embedded Workbook Formats**
+## **Detect Unsupported Embedded Workbook Formats**
 
-Aspose.Slides does not support the Excel binary workbook (.xlsb) format that can be embedded in some charts. Starting with version 26.4 you can use the `EmbeddedWorkbookType` property on `IChartData` together with the `WorkbookType` enumeration to detect unsupported formats and skip those charts.
+Aspose.Slides does not support the Excel binary workbook (.xlsb) format that can be embedded in some charts. You can use the `EmbeddedWorkbookType` property on `IChartData` together with the `WorkbookType` enumeration to detect unsupported formats and skip those charts.
 
 ```csharp
 using (var presentation = new Presentation("pres.pptx"))
@@ -137,25 +137,6 @@ using (var presentation = new Presentation("pres.pptx"))
 
         // Read or modify the chart workbook data here.
     }
-}
-```
-
-**Workaround:** Convert the workbook to a supported format (e.g., .xlsx) using Aspose.Cells and write it back to the chart.
-
-```csharp
-using (var presentation = new Presentation("Generate picture 2.0.pptx"))
-{
-    var chart = (IChart)presentation.Slides[0].Shapes[3];
-
-    using (var xlsbStream = chart.ChartData.ReadWorkbookStream())
-    using (var workbook = new Aspose.Cells.Workbook(xlsbStream))
-    using (var xlsxStream = new MemoryStream())
-    {
-        workbook.Save(xlsxStream, Aspose.Cells.SaveFormat.Xlsx);
-        chart.ChartData.WriteWorkbookStream(xlsxStream);
-    }
-
-    presentation.Save("output-xlsx.pptx", SaveFormat.Pptx);
 }
 ```
 

--- a/en/net/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
+++ b/en/net/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
@@ -115,6 +115,50 @@ using (Presentation pres = new Presentation())
 }
 ```
 
+### **Detect Unsupported Embedded Workbook Formats**
+
+Aspose.Slides does not support the Excel binary workbook (.xlsb) format that can be embedded in some charts. Starting with version 26.4 you can use the `EmbeddedWorkbookType` property on `IChartData` together with the `WorkbookType` enumeration to detect unsupported formats and skip those charts.
+
+```csharp
+using (var presentation = new Presentation("pres.pptx"))
+{
+    foreach (var shape in presentation.Slides[0].Shapes)
+    {
+        if (shape is not IChart chart) continue;
+
+        var chartData = chart.ChartData;
+
+        if (chartData.DataSourceType == ChartDataSourceType.InternalWorkbook &&
+            chartData.EmbeddedWorkbookType == WorkbookType.WorkbookBinaryMacro)
+        {
+            // Embedded workbook is in .xlsb format, which is not supported.
+            continue;
+        }
+
+        // Read or modify the chart workbook data here.
+    }
+}
+```
+
+**Workaround:** Convert the workbook to a supported format (e.g., .xlsx) using Aspose.Cells and write it back to the chart.
+
+```csharp
+using (var presentation = new Presentation("Generate picture 2.0.pptx"))
+{
+    var chart = (IChart)presentation.Slides[0].Shapes[3];
+
+    using (var xlsbStream = chart.ChartData.ReadWorkbookStream())
+    using (var workbook = new Aspose.Cells.Workbook(xlsbStream))
+    using (var xlsxStream = new MemoryStream())
+    {
+        workbook.Save(xlsxStream, Aspose.Cells.SaveFormat.Xlsx);
+        chart.ChartData.WriteWorkbookStream(xlsxStream);
+    }
+
+    presentation.Save("output-xlsx.pptx", SaveFormat.Pptx);
+}
+```
+
 ## **External Workbook**
 
 {{% alert color="primary" %}} 


### PR DESCRIPTION
Forum topic: 294894 - Aspose.Slides for .NET: Chart Data Is Not Read for Some Types of Charts

Summary:
- Added guidance on detecting unsupported .xlsb embedded workbooks using EmbeddedWorkbookType
- Provided a conversion workaround with Aspose.Cells

Changed sections:
- Specify the Data Source Type