### PR TITLE
Update docs for forum topic 326803

### DIFF
--- a/en/net/getting-started/system-requirements/_index.md
+++ b/en/net/getting-started/system-requirements/_index.md
@@ -47,10 +47,6 @@ Because CentOS 7 ships with GLIBC 2.14 while Aspose.Slides for .NET 6 and .NET 7
 
 {{% /alert %}} 
 
-**Font rendering considerations on Linux**
-
-When a font version contains inconsistent name-table records, the Linux font loader may select an invalid record and fail to resolve the font. This results in missing text or substitution with a fallback square/sharp-corner font (e.g., the ChillRoundM v1.750 issue). Ensure that the font’s name-table entries are consistent across platforms or use an updated version of the font where the records have been corrected.
-
 ### **Mac**
 - Mac OS X
 

--- a/en/net/getting-started/system-requirements/_index.md
+++ b/en/net/getting-started/system-requirements/_index.md
@@ -47,6 +47,10 @@ Because CentOS 7 ships with GLIBC 2.14 while Aspose.Slides for .NET 6 and .NET 7
 
 {{% /alert %}} 
 
+**Font rendering considerations on Linux**
+
+When a font version contains inconsistent name-table records, the Linux font loader may select an invalid record and fail to resolve the font. This results in missing text or substitution with a fallback square/sharp-corner font (e.g., the ChillRoundM v1.750 issue). Ensure that the font’s name-table entries are consistent across platforms or use an updated version of the font where the records have been corrected.
+
 ### **Mac**
 - Mac OS X
 
@@ -131,3 +135,7 @@ No, PowerPoint is not required; Aspose.Slides is a standalone engine for [creati
 **Which fonts are needed for correct rendering?**
 
 In practice, the fonts used in the presentation or proper [substitutes](/slides/net/font-substitution/) must be available. To ensure consistent rendering on Linux/macOS, it is advisable to install common font packages.
+
+**Why does a custom font render as a fallback or missing text on Linux?**
+
+If the font file has inconsistent or corrupted name-table entries, the Linux font-matching stack (FreeType/fontconfig) may select an invalid record, causing the font to be unresolved. Using a font version with corrected name-table records or installing a consistent replacement resolves the issue.


### PR DESCRIPTION
Forum topic: [326803](https://forum.aspose.com/t/slide-getimage-renders-incorrectly-with-specific-font-chillroundm-v1-750-on-linux-ubuntu-docker-but-works-on-windows/326803) - Slide.GetImage() Renders Incorrectly with Specific Font ("ChillRoundM" v1.750) on Linux (Ubuntu/Docker), but Works on Windows

Summary:
- Added guidance on font name‑table inconsistencies causing Linux rendering issues
- Provided FAQ entry explaining fallback behavior for custom fonts on Linux

Changed sections:
- Supported Operating Systems > Linux
- FAQ