### PR TITLE
Update docs for forum topic 327186

### DIFF
--- a/en/net/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
+++ b/en/net/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
@@ -84,11 +84,11 @@ using(Presentation pres = new Presentation())
 }
 ```
 
-### Limitations
+### **Limitations**
 
 Tags added via the `CustomData.Tags` collection are stored only within the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
 
-**Workaround**: You can store a custom identifier in the object's **Alt Text** (e.g., `shape.AlternativeText = "MyId"`). After exporting to PDF, the Alt Text may appear in the PDF tag structure, but this approach is not reliable for all object types or export scenarios.
+**Workaround**: You can store a custom identifier in the object's **Alt Text** (e.g., `shape.AlternativeText = "MyId"`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
 
 ## **FAQ**
 

--- a/en/net/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
+++ b/en/net/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
@@ -84,6 +84,12 @@ using(Presentation pres = new Presentation())
 }
 ```
 
+### Limitations
+
+Tags added via the `CustomData.Tags` collection are stored only within the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
+
+**Workaround**: You can store a custom identifier in the object's **Alt Text** (e.g., `shape.AlternativeText = "MyId"`). After exporting to PDF, the Alt Text may appear in the PDF tag structure, but this approach is not reliable for all object types or export scenarios.
+
 ## **FAQ**
 
 **Can I remove all tags from a presentation, slide, or shape in one operation?**


### PR DESCRIPTION
Forum topic: [327186](https://forum.aspose.com/t/custom-node-id-support-in-aspose-slides-for-net-preserved-in-pdf-tag-structure/327186) - Custom Node ID Support in Aspose.Slides for .NET (Preserved in PDF Tag Structure)

Summary:
- Added a Limitations section after Add Tags to Presentations
- Clarified that tags are not preserved in PDF export and suggested Alt Text workaround

Changed sections:
- Add Tags to Presentations