### PR TITLE
Update docs for forum topic 328017

### DIFF
--- a/en/java/developer-guide/presentation-content/powerpoint-charts/chart-entities/chart-series/_index.md
+++ b/en/java/developer-guide/presentation-content/powerpoint-charts/chart-entities/chart-series/_index.md
@@ -345,6 +345,27 @@ try {
 }
 ```
 
+## **Clear Chart Data Workbook for Empty Waterfall Charts**
+
+When all series and categories are removed from a Waterfall chart, saving the presentation throws an exception because the underlying chart data is missing. To keep the chart usable, clear the chart data workbook instead of removing series and categories.
+
+```java
+Presentation presentation = new Presentation();
+try {
+    ISlide slide = presentation.getSlides().get_Item(0);
+
+    IChart chart = slide.getShapes().addChart(ChartType.Waterfall, 80, 80, 800, 420);
+
+    // Clear the chart data workbook (index 0) instead of clearing series/categories
+    chart.getChartData().getChartDataWorkbook().clear(0);
+    chart.setLegend(false);
+
+    presentation.save("output.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
 ## **FAQ**
 
 **Is there a limit to how many series a single chart can contain?**


### PR DESCRIPTION
Forum topic: [328017](https://forum.aspose.com/t/exception-when-creating-waterfall-chart-with-no-data-points-in-java/328017) - Exception When Creating Waterfall Chart with No Data Points in Java

Summary:
- Added guidance for handling empty Waterfall charts
- Provided code to clear the chart data workbook instead of series/categories

Updated documentation:
- Added section: Clear Chart Data Workbook for Empty Waterfall Charts