### PR TITLE
Update docs for forum topic 324091

### DIFF
--- a/en/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-pdf/_index.md
+++ b/en/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-pdf/_index.md
@@ -295,6 +295,8 @@ Aspose.Slides supports PDF conversion operations, allowing you to convert PDF fi
 
 {{% /alert %}}
 
+> **Note:** When exporting to PDF/UA, Aspose.Slides treats complex graphics such as SmartArt, charts, and formulas as a single figure. Individual path elements are not preserved as separate content and may be marked as artifacts; alternative text is provided only for the whole figure.
+
 ## **FAQ**
 
 **Can I convert multiple PowerPoint files to PDF in bulk?**


### PR DESCRIPTION
Forum topic: [324091](https://forum.aspose.com/t/powerpoint-to-pdf-ua-in-c-parts-of-non-decorative-elements-are-incorrectly-tagged-as-artifacts/324091) - PowerPoint to PDF/UA in C#: Parts of Non-Decorative Elements Are Incorrectly Tagged As Artifacts

Summary:
- Add note about current artifact handling for complex graphics in PDF/UA export
- Clarify that only figure‑level alternative text is generated

Updated documentation:
- Updated section: Accessibility and Compliance Standards for PDF