### PR TITLE
Update docs for forum topic 313231

### DIFF
--- a/en/net/developer-guide/manage-presentation/convert-presentation/export-to-html5/_index.md
+++ b/en/net/developer-guide/manage-presentation/convert-presentation/export-to-html5/_index.md
@@ -58,6 +58,10 @@ using (Presentation pres = new Presentation("pres.pptx"))
 }
 ```
 
+## **Performance Considerations**
+
+Conversion speed can vary between Aspose.Slides library versions. Some users have reported that version 25.5.0 may be slower for PPTX-to-HTML5 conversions compared with earlier versions such as 24.9.0. If you notice a significant slowdown after upgrading, consider testing with a previous version to confirm the impact.
+
 ## **Export PowerPoint to HTML**
 
 This C# demonstrates the standard PowerPoint to HTML process:


### PR DESCRIPTION
Forum topic: [313231](https://forum.aspose.com/t/aspose-slides-net6-crossplatform-latest-versions-are-slower-during-pptx-to-html5-conversions/313231) - Aspose.Slides/Net6.Crossplatform Latest Versions Are Slower During PPTX-to-HTML5 Conversions

Summary:
- Added a Performance Considerations note after Export PowerPoint to HTML5
- Documented observed version‑specific slowdown for PPTX‑to‑HTML5 conversion

Updated documentation:
- Added section: Performance Considerations