### PR TITLE
Update docs for forum topic 324047

### DIFF
--- a/en/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-pdf/_index.md
+++ b/en/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-pdf/_index.md
@@ -297,6 +297,8 @@ Aspose.Slides supports PDF conversion operations, allowing you to convert PDF fi
 
 > **Note:** When exporting to PDF/UA, Aspose.Slides treats complex graphics such as SmartArt, charts, and formulas as a single figure. Individual path elements are not preserved as separate content and may be marked as artifacts; alternative text is provided only for the whole figure.
 
+In versions prior to **26.5**, PDF/UA export may position formula path elements incorrectly and report an inaccurate BBox. This behavior was fixed starting with Aspose.Slides for .NET **26.5**. Update to version 26.5 or later to obtain correct formula placement and bounding-box information.
+
 ## **FAQ**
 
 **Can I convert multiple PowerPoint files to PDF in bulk?**


### PR DESCRIPTION
Forum topic: [324047](https://forum.aspose.com/t/powerpoint-to-pdf-ua-in-c-formula-path-element-has-incorrect-position-and-invalid-bbox/324047) - PowerPoint to PDF/UA in C#: Formula Path Element Has Incorrect Position and Invalid BBox

Summary:
- Add note that formula positioning and BBox issues are fixed in version 26.5
- Advise users to upgrade to 26.5 or later for correct PDF/UA output

Updated documentation:
- Updated section: Accessibility and Compliance Standards for PDF