### PR TITLE
Update docs for forum topic 328435

### DIFF
--- a/en/python-net/getting-started/system-requirements/_index.md
+++ b/en/python-net/getting-started/system-requirements/_index.md
@@ -80,6 +80,12 @@ Aspose.Slides for Python supports Windows (32-bit and 64-bit), macOS, and 64-bit
 - For Python 3.5–3.7: the `pymalloc` build of Python is required. The `--with-pymalloc` build option is enabled by default. Typically, the `pymalloc` build of Python is marked with an `m` suffix in the filename.
 - The `libpython` shared library. The `--enable-shared` Python build option is disabled by default, and some Python distributions do not include the `libpython` shared library. On some Linux platforms, you can install the `libpython` shared library using the package manager (for example, `sudo apt-get install libpython3.7`). A common issue is that the `libpython` library is installed in a nonstandard location for shared libraries. You can resolve this by using Python build options to set alternate library paths when compiling Python, or by creating a symbolic link to the `libpython` library file in the system’s standard shared library location. Typically, the `libpython` shared library filename is `libpythonX.Ym.so.1.0` for Python 3.5–3.7 or `libpythonX.Y.so.1.0` for Python 3.8 or later (for example, `libpython3.7m.so.1.0`, `libpython3.9.so.1.0`).
 
+## **Bundled .NET Runtime**
+
+Aspose.Slides for Python via .NET is shipped as a self-contained package that includes the .NET Core 3.1 runtime. .NET Core 3.1 reached end-of-life in December 2022, and is no longer supported. The runtime is bundled so that installing the .NET Runtime on the machine is not required.
+
+If you need to use a newer or supported .NET runtime, you can obtain a framework-dependent version of the package and install the desired .NET runtime separately.
+
 ## **FAQ**
 
 **Do I need Microsoft PowerPoint installed for conversions and rendering?**


### PR DESCRIPTION
Forum topic: [328435](https://forum.aspose.com/t/aspose-slides-for-python-via-net-net-core-3-1-eol/328435) - Aspose.Slides for Python via .NET: .NET Core 3.1 EOL

Summary:
- Add note about bundled .NET Core 3.1 runtime and its EOL status
- Mention framework‑dependent option for using a supported .NET runtime

Updated documentation:
- Added section: Bundled .NET Runtime