### PR TITLE
Update docs for forum topic 327157

### DIFF
--- a/en/java/developer-guide/presentation-content/powerpoint-table/manage-cells/_index.md
+++ b/en/java/developer-guide/presentation-content/powerpoint-table/manage-cells/_index.md
@@ -340,6 +340,10 @@ try {
 }
 ```
 
+## **Vertical Alignment After PDF to PPTX Conversion**
+
+When a presentation is created from a PDF using `presentation.slides.addFromPdf`, the vertical alignment of text inside table cells may shift upward toward the cell borders. This behavior can be observed in an Excel → PDF → PPTX conversion workflow. At present, Aspose.Slides for Java does not offer a setting to preserve the original vertical alignment of table cell text during this conversion.
+
 ## **FAQ**
 
 **Can I set different line thicknesses and styles for different sides of a single cell?**


### PR DESCRIPTION
Forum topic: [327157](https://forum.aspose.com/t/table-text-becomes-vertically-misaligned-after-excel-to-pdf-to-pptx-conversion/327157) - Table Text Becomes Vertically Misaligned After Excel-to-PDF-to-PPTX Conversion

Summary:
- Added a section describing vertical alignment shift after PDF‑to‑PPTX conversion
- Documented the current limitation of preserving text vertical alignment in tables

Updated documentation:
- Added section: Vertical Alignment After PDF to PPTX Conversion