### PR TITLE
SLIDESDOC-781 Rewrite the article "Enhance Image Processing with the Modern API"

### DIFF
--- a/en/androidjava/developer-guide/modern-api/_index.md
+++ b/en/androidjava/developer-guide/modern-api/_index.md
@@ -5,7 +5,7 @@ type: docs
 weight: 237
 url: /androidjava/modern-api/
 keywords:
-- System.Drawing
+- android.graphics
 - modern API
 - drawing
 - slide thumbnail
@@ -24,25 +24,27 @@ description: "Modernize slide image processing by replacing deprecated imaging A
 
 ## **Introduction**
 
-Historically, Aspose Slides has a dependency on java.awt and has in the public API the following classes from there:
+Historically, Aspose Slides has a dependency on android.graphics and has in the public API the following classes from there:
 - [Canvas](https://developer.android.com/reference/android/graphics/Canvas)
 - [Bitmap](https://developer.android.com/reference/android/graphics/Bitmap)
 
 As of version 24.4, this public API is declared deprecated.
 
-In order to get rid of dependencies on these classes, we added the so-called "Modern API" - i.e. the API that should be used instead of the deprecated one, whose signatures contain dependencies on Bitmap. Canvas is declared deprecated and its support is removed from the public Slides API.
+In order to get rid of dependencies on these classes, we added the so-called "Modern API" - i.e. the API that should be used instead of the deprecated one, whose signatures contain dependencies on [Bitmap](https://developer.android.com/reference/android/graphics/Bitmap). [Canvas](https://developer.android.com/reference/android/graphics/Canvas) is declared deprecated and its support is removed from the public Slides API.
 
-Removal of the deprecated public API with dependencies on System.Drawing will be in release 24.8.
+In current versions, treat the public API that depends on android.graphics types as legacy/deprecated. Use the Modern API for new code and when migrating existing image-processing workflows.
 
 ## **Modern API**
 
 Added the following classes and enums to the public API:
 
-- IImage - represents the raster or vector image.
-- ImageFormat - represents the file format of the image.
-- Images - methods to instantiate and work with the IImage interface.
+- [IImage](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iimage/) - represents the raster or vector image.
+- [ImageFormat](https://reference.aspose.com/slides/androidjava/com.aspose.slides/imageformat/) - represents the file format of the image.
+- [Images](https://reference.aspose.com/slides/androidjava/com.aspose.slides/images/) - methods to instantiate and work with the [IImage](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iimage/) interface.
 
-Please note that IImage is disposable (it implements the IDisposable interface and its use should be wrapped in using or dispose-it in another convenient way).
+Please note that [IImage](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iimage/) is disposable and its use should be followed by a `dispose()` call or another convenient disposal pattern.
+
+Use `getImage` to render a single slide or shape. Use `getImages` to render several presentation slides. Use [Images](https://reference.aspose.com/slides/androidjava/com.aspose.slides/images/) methods to load images, `addImage` with [IImage](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iimage/) to add them to a presentation, and `replaceImage` with [IImage](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iimage/) to update an existing presentation image.
 
 A typical scenario of using the new API may look as follows:
 
@@ -77,9 +79,9 @@ try {
 
 ## **Replacing Old Code with Modern API**
 
-In general, you will need to replace the call to the old method using ImageIO with the new one.
+In general, you will need to replace calls that use [Bitmap](https://developer.android.com/reference/android/graphics/Bitmap) with the new methods that use [IImage](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iimage/).
 
-Old:
+Legacy/deprecated API:
 ``` java
 Presentation pres = new Presentation();
 try {
@@ -103,7 +105,7 @@ try {
     if (pres != null) pres.dispose();
 }
 ```
-New:
+Modern API:
 ``` java
 Presentation pres = new Presentation();
 try {
@@ -120,7 +122,7 @@ try {
 
 ### **Getting a Slide Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` java
 Presentation pres = new Presentation("pres.pptx");
@@ -164,7 +166,7 @@ try {
 
 ### **Getting a Shape Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` java
 Presentation pres = new Presentation("pres.pptx");
@@ -208,7 +210,7 @@ try {
 
 ### **Getting a Presentation Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` java
 Presentation pres = new Presentation("pres.pptx");
@@ -266,7 +268,7 @@ try {
 
 ### **Adding a Picture to a Presentation**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` java
 Presentation pres = new Presentation();
@@ -301,7 +303,7 @@ try {
 }
 ```
 
-## **Methods to Be Removed and Their Replacement in Modern API**
+## **Deprecated Methods and Their Replacement in Modern API**
 
 ### **Presentation**
 | Method Signature                               | Replacement Method Signature                             |
@@ -329,9 +331,9 @@ try {
 | public final Bitmap getThumbnail(IRenderingOptions options, Size imageSize) | public final IImage getImage(IRenderingOptions options, Size imageSize) |
 | public final Bitmap getThumbnail(IRenderingOptions options, float scaleX, float scaleY) | public final IImage getImage(IRenderingOptions options, float scaleX, float scaleY) |
 | public final Bitmap getThumbnail(ITiffOptions options) | public final IImage getImage(ITiffOptions options) |
-| public final void renderToGraphics(IRenderingOptions options, Canvas graphics) | Will be deleted completely  |
-| public final void renderToGraphics(IRenderingOptions options, Canvas graphics, Size renderingSize) | Will be deleted completely  |
-| public final void renderToGraphics(IRenderingOptions options, Canvas graphics, float scaleX, float scaleY) | Will be deleted completely  |
+| public final void renderToGraphics(IRenderingOptions options, Canvas graphics) | No Modern API replacement  |
+| public final void renderToGraphics(IRenderingOptions options, Canvas graphics, Size renderingSize) | No Modern API replacement  |
+| public final void renderToGraphics(IRenderingOptions options, Canvas graphics, float scaleX, float scaleY) | No Modern API replacement  |
 
 ### **Output**
 | Method Signature                                                | Replacement Method Signature                                |
@@ -360,11 +362,11 @@ try {
 | public final Bitmap getTileImage(Integer background, Integer foreground) | public final IImage getTileIImage(Integer background, Integer foreground) |
 
 
-## **API Support for Canvas Will Be Discontinued**
+## **API Support for Canvas**
 
-Methods with [Canvas](https://developer.android.com/reference/android/graphics/Canvas) are declared deprecated and their support will be removed from the public API.
+Methods with [Canvas](https://developer.android.com/reference/android/graphics/Canvas) are declared deprecated and have no direct Modern API replacement.
 
-The part of the API that uses it will be removed:
+Use the Modern API image-rendering methods instead of the API that renders to [Canvas](https://developer.android.com/reference/android/graphics/Canvas):
 
 [Slide](https://reference.aspose.com/slides/androidjava/com.aspose.slides/slide/)
 
@@ -376,9 +378,9 @@ The part of the API that uses it will be removed:
 
 **Why was android.graphics.Canvas dropped?**
 
-Support for `Canvas` is being removed from the public API to unify work with rendering and images, eliminate ties to platform-specific dependencies, and switch to a cross-platform approach with [IImage](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iimage/). All rendering methods to `Canvas` will be removed.
+Support for [Canvas](https://developer.android.com/reference/android/graphics/Canvas) is deprecated in the public API to unify work with rendering and images, eliminate ties to platform-specific dependencies, and switch to a cross-platform approach with [IImage](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iimage/). Use `getImage` or `getImages` instead of rendering to [Canvas](https://developer.android.com/reference/android/graphics/Canvas).
 
-**What is the practical benefit of IImage compared to BufferedImage?**
+**What is the practical benefit of [IImage](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iimage/) compared to [Bitmap](https://developer.android.com/reference/android/graphics/Bitmap)?**
 
 [IImage](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iimage/) unifies working with both raster and vector images and simplifies saving to various formats via [ImageFormat](https://reference.aspose.com/slides/androidjava/com.aspose.slides/imageformat/).
 

--- a/en/cpp/developer-guide/modern-api/_index.md
+++ b/en/cpp/developer-guide/modern-api/_index.md
@@ -30,17 +30,19 @@ Currently, the Aspose.Slides for C++ library has dependencies in its public API 
 
 As of version 24.4, this public API is declared deprecated.
 
-In order to get rid of dependencies on System::Drawing in the public API, we added the so-called "Modern API". Methods with System::Drawing::Image and System::Drawing::Bitmap are declared deprecated and will be replaced with the corresponding methods from the Modern API. Methods with System::Graphics are declared deprecated and their support will be removed from the public API.
+In order to get rid of dependencies on System::Drawing in the public API, we added the so-called "Modern API". Methods with [System::Drawing::Image](https://reference.aspose.com/slides/cpp/system.drawing/image/) and [System::Drawing::Bitmap](https://reference.aspose.com/slides/cpp/system.drawing/bitmap/) are declared deprecated and should be replaced with the corresponding methods from the Modern API. Methods with [System::Drawing::Graphics](https://reference.aspose.com/slides/cpp/system.drawing/graphics/) are declared deprecated and have no direct Modern API replacement.
 
-Removal of the deprecated public API with dependencies on System::Drawing will be in release 24.8.
+In current versions, treat the public API that depends on System::Drawing types as legacy/deprecated. Use the Modern API for new code and when migrating existing image-processing workflows.
 
 ## **Modern API**
 
 Added the following classes and enums to the public API:
 
-- Aspose::Slides::IImage - represents the raster or vector image.
-- Aspose::Slides::ImageFormat - represents the file format of the image.
-- Aspose::Slides::Images - methods to instantiate and work with the IImage interface.
+- [Aspose::Slides::IImage](https://reference.aspose.com/slides/cpp/aspose.slides/iimage/) - represents the raster or vector image.
+- [Aspose::Slides::ImageFormat](https://reference.aspose.com/slides/cpp/aspose.slides/imageformat/) - represents the file format of the image.
+- [Aspose::Slides::Images](https://reference.aspose.com/slides/cpp/aspose.slides/images/) - methods to instantiate and work with the [IImage](https://reference.aspose.com/slides/cpp/aspose.slides/iimage/) interface.
+
+Use `GetImage` to render a single slide or shape. Use `GetImages` to render several presentation slides. Use [Images](https://reference.aspose.com/slides/cpp/aspose.slides/images/) methods to load images, `AddImage` with [IImage](https://reference.aspose.com/slides/cpp/aspose.slides/iimage/) to add them to a presentation, and `ReplaceImage` with [IImage](https://reference.aspose.com/slides/cpp/aspose.slides/iimage/) to update an existing presentation image.
 
 A typical scenario of using the new API may look as follows:
 
@@ -65,11 +67,11 @@ slideImage->Save(u"slide1.jpeg", Aspose::Slides::ImageFormat::Jpeg);
 
 ## **Replacing Old Code with Modern API**
 
-For ease of transition, the interface of the new IImage repeats the separate signatures of the Image and Bitmap classes. In general, you will just need to replace the call to the old method using System::Drawing with the new one.
+For ease of transition, the interface of the new [IImage](https://reference.aspose.com/slides/cpp/aspose.slides/iimage/) repeats the separate signatures of the [System::Drawing::Image](https://reference.aspose.com/slides/cpp/system.drawing/image/) and [System::Drawing::Bitmap](https://reference.aspose.com/slides/cpp/system.drawing/bitmap/) classes. In general, you will just need to replace the call to the old method using System::Drawing with the new one.
 
 ### **Getting a Slide Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` cpp
 System::SharedPtr<Presentation> pres = System::MakeObject<Presentation>(u"pres.pptx");
@@ -87,7 +89,7 @@ pres->get_Slide(0)->GetImage()->Save(u"slide1.png");
 
 ### **Getting a Shape Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` cpp
 System::SharedPtr<Presentation> pres = System::MakeObject<Presentation>(u"pres.pptx");
@@ -105,7 +107,7 @@ pres->get_Slide(0)->get_Shape(0)->GetImage()->Save(u"shape.png");
 
 ### **Getting a Presentation Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` cpp
 System::SharedPtr<Presentation> pres = System::MakeObject<Presentation>(u"pres.pptx");
@@ -135,7 +137,7 @@ for (int32_t index = 0; index < images->get_Length(); index++)
 
 ### **Adding a Picture to a Presentation**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` cpp
 System::SharedPtr<Presentation> pres = System::MakeObject<Presentation>();
@@ -159,7 +161,7 @@ System::SharedPtr<IPPImage> ppImage = pres->get_Images()->AddImage(image);
 pres->get_Slide(0)->get_Shapes()->AddPictureFrame(Aspose::Slides::ShapeType::Rectangle, 10.0f, 10.0f, 100.0f, 100.0f, ppImage);
 ```
 
-## **Methods/Properties to Be Removed and Their Replacement in Modern API**
+## **Deprecated Methods/Properties and Their Replacement in Modern API**
 
 ### **Presentation Class**
 |Method Signature|Replacement Method Signature|
@@ -170,8 +172,8 @@ pres->get_Slide(0)->get_Shapes()->AddPictureFrame(Aspose::Slides::ShapeType::Rec
 |GetThumbnails(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::ArrayPtr&lt;int32_t&gt; slides, float scaleX, float scaleY)|GetImages(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::ArrayPtr&lt;int32_t&gt; slides, float scaleX, float scaleY)|
 |GetThumbnails(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::Drawing::Size imageSize)|GetImages(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::Drawing::Size imageSize)|
 |GetThumbnails(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::ArrayPtr&lt;int32_t&gt; slides, System::Drawing::Size imageSize)|GetImages(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::ArrayPtr&lt;int32_t&gt; slides, System::Drawing::Size imageSize)|
-|Save(System::String fname, System::ArrayPtr&lt;int32_t&gt; slides, Export::SaveFormat format)|Will be deleted completely|
-|Save(System::String fname, System::ArrayPtr&lt;int32_t&gt; slides, Export::SaveFormat format, System::SharedPtr&lt;Export::ISaveOptions&gt; options)|Will be deleted completely|
+|Save(System::String fname, System::ArrayPtr&lt;int32_t&gt; slides, Export::SaveFormat format)|No Modern API replacement|
+|Save(System::String fname, System::ArrayPtr&lt;int32_t&gt; slides, Export::SaveFormat format, System::SharedPtr&lt;Export::ISaveOptions&gt; options)|No Modern API replacement|
 
 ### **Slide Class**
 |Method Signature|Replacement Method Signature|
@@ -183,9 +185,9 @@ pres->get_Slide(0)->get_Shapes()->AddPictureFrame(Aspose::Slides::ShapeType::Rec
 |GetThumbnail(System::SharedPtr&lt;Export::IRenderingOptions&gt; options)|GetImage(System::SharedPtr&lt;Export::IRenderingOptions&gt; options)|
 |GetThumbnail(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, float scaleX, float scaleY)|GetImage(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, float scaleX, float scaleY)|
 |GetThumbnail(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::Drawing::Size imageSize)|GetImage(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::Drawing::Size imageSize)|
-|RenderToGraphics(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::SharedPtr&lt;System::Drawing::Graphics&gt; graphics)|Will be deleted completely|
-|RenderToGraphics(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::SharedPtr&lt;System::Drawing::Graphics&gt; graphics, float scaleX, float scaleY)|Will be deleted completely|
-|RenderToGraphics(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::SharedPtr&lt;System::Drawing::Graphics&gt; graphics, System::Drawing::Size renderingSize)|Will be deleted completely|
+|RenderToGraphics(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::SharedPtr&lt;System::Drawing::Graphics&gt; graphics)|No Modern API replacement|
+|RenderToGraphics(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::SharedPtr&lt;System::Drawing::Graphics&gt; graphics, float scaleX, float scaleY)|No Modern API replacement|
+|RenderToGraphics(System::SharedPtr&lt;Export::IRenderingOptions&gt; options, System::SharedPtr&lt;System::Drawing::Graphics&gt; graphics, System::Drawing::Size renderingSize)|No Modern API replacement|
 
 ### **Shape Class**
 |Method Signature|Replacement Method Signature|
@@ -215,22 +217,22 @@ pres->get_Slide(0)->get_Shapes()->AddPictureFrame(Aspose::Slides::ShapeType::Rec
 | :- | :- |
 |GetTileImage(System::Drawing::Color background, System::Drawing::Color foreground)|GetTileIImage(System::Drawing::Color background, System::Drawing::Color foreground)|
 
-## **API Support for System::Drawing::Graphics Will Be Discontinued**
+## **API Support for System::Drawing::Graphics**
 
-Methods with [System::Drawing::Graphics](https://reference.aspose.com/slides/cpp/system.drawing/graphics/) are declared deprecated and their support will be removed from the public API.
+Methods with [System::Drawing::Graphics](https://reference.aspose.com/slides/cpp/system.drawing/graphics/) are declared deprecated and have no direct Modern API replacement.
 
-The part of the API that uses it will be removed:
+Use the Modern API image-rendering methods instead of the API that renders to [System::Drawing::Graphics](https://reference.aspose.com/slides/cpp/system.drawing/graphics/):
 - [Slide::RenderToGraphics(System::SharedPtr&lt;Export::IRenderingOptions&gt;, System::SharedPtr&lt;System::Drawing::Graphics&gt;)](https://reference.aspose.com/slides/cpp/aspose.slides/slide/rendertographics/#sliderendertographicssystemsharedptrexportirenderingoptions-systemsharedptrsystemdrawinggraphics-method)
 - [Slide::RenderToGraphics(System::SharedPtr&lt;Export::IRenderingOptions&gt;, System::SharedPtr&lt;System::Drawing::Graphics&gt;, float, float)](https://reference.aspose.com/slides/cpp/aspose.slides/slide/rendertographics/#sliderendertographicssystemsharedptrexportirenderingoptions-systemsharedptrsystemdrawinggraphics-float-float-method)
 - [Slide::RenderToGraphics(System::SharedPtr&lt;Export::IRenderingOptions&gt;, System::SharedPtr&lt;System::Drawing::Graphics&gt;, System::Drawing::Size)](https://reference.aspose.com/slides/cpp/aspose.slides/slide/rendertographics/#sliderendertographicssystemsharedptrexportirenderingoptions-systemsharedptrsystemdrawinggraphics-systemdrawingsize-method)
 
 ## **FAQ**
 
-**Why was System::Drawing::Graphics dropped?**
+**Why was [System::Drawing::Graphics](https://reference.aspose.com/slides/cpp/system.drawing/graphics/) dropped?**
 
-Support for `Graphics` is being removed from the public API to unify work with rendering and images, eliminate ties to platform-specific dependencies, and switch to a cross-platform approach with [IImage](https://reference.aspose.com/slides/cpp/aspose.slides/iimage/). All rendering methods to `Graphics` will be removed.
+Support for [System::Drawing::Graphics](https://reference.aspose.com/slides/cpp/system.drawing/graphics/) is deprecated in the public API to unify work with rendering and images, eliminate ties to platform-specific dependencies, and switch to a cross-platform approach with [IImage](https://reference.aspose.com/slides/cpp/aspose.slides/iimage/). Use `GetImage` or `GetImages` instead of rendering to [System::Drawing::Graphics](https://reference.aspose.com/slides/cpp/system.drawing/graphics/).
 
-**What is the practical benefit of IImage compared to Image/Bitmap?**
+**What is the practical benefit of [IImage](https://reference.aspose.com/slides/cpp/aspose.slides/iimage/) compared to [System::Drawing::Image](https://reference.aspose.com/slides/cpp/system.drawing/image/)/[System::Drawing::Bitmap](https://reference.aspose.com/slides/cpp/system.drawing/bitmap/)?**
 
 [IImage](https://reference.aspose.com/slides/cpp/aspose.slides/iimage/) unifies working with both raster and vector images, simplifies saving to various formats via [ImageFormat](https://reference.aspose.com/slides/cpp/aspose.slides/imageformat/), reduces dependence on `System::Drawing`, and makes code more portable across environments.
 

--- a/en/java/developer-guide/modern-api/_index.md
+++ b/en/java/developer-guide/modern-api/_index.md
@@ -28,19 +28,21 @@ Historically, Aspose Slides has a dependency on java.awt and has in the public A
 
 As of version 24.4, this public API is declared deprecated.
 
-In order to get rid of dependencies on these classes, we added the so-called "Modern API" - i.e. the API that should be used instead of the deprecated one, whose signatures contain dependencies on BufferedImage. Graphics2D is declared deprecated and its support is removed from the public Slides API.
+In order to get rid of dependencies on these classes, we added the so-called "Modern API" - i.e. the API that should be used instead of the deprecated one, whose signatures contain dependencies on [BufferedImage](https://docs.oracle.com/javase/8/docs/api/java/awt/image/BufferedImage.html). [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) is declared deprecated and its support is removed from the public Slides API.
 
-Removal of the deprecated public API with dependencies on System.Drawing will be in release 24.8.
+In current versions, treat the public API that depends on java.awt types as legacy/deprecated. Use the Modern API for new code and when migrating existing image-processing workflows.
 
 ## **Modern API**
 
 Added the following classes and enums to the public API:
 
-- IImage - represents the raster or vector image.
-- ImageFormat - represents the file format of the image.
-- Images - methods to instantiate and work with the IImage interface.
+- [IImage](https://reference.aspose.com/slides/java/com.aspose.slides/iimage/) - represents the raster or vector image.
+- [ImageFormat](https://reference.aspose.com/slides/java/com.aspose.slides/imageformat/) - represents the file format of the image.
+- [Images](https://reference.aspose.com/slides/java/com.aspose.slides/images/) - methods to instantiate and work with the [IImage](https://reference.aspose.com/slides/java/com.aspose.slides/iimage/) interface.
 
-Please note that IImage is disposable (it implements the IDisposable interface and its use should be wrapped in using or dispose-it in another convenient way).
+Please note that [IImage](https://reference.aspose.com/slides/java/com.aspose.slides/iimage/) is disposable and its use should be followed by a `dispose()` call or another convenient disposal pattern.
+
+Use `getImage` to render a single slide or shape. Use `getImages` to render several presentation slides. Use [Images](https://reference.aspose.com/slides/java/com.aspose.slides/images/) methods to load images, `addImage` with [IImage](https://reference.aspose.com/slides/java/com.aspose.slides/iimage/) to add them to a presentation, and `replaceImage` with [IImage](https://reference.aspose.com/slides/java/com.aspose.slides/iimage/) to update an existing presentation image.
 
 A typical scenario of using the new API may look as follows:
 
@@ -75,9 +77,9 @@ try {
 
 ## **Replacing Old Code with Modern API**
 
-In general, you will need to replace the call to the old method using ImageIO with the new one.
+In general, you will need to replace calls that use [BufferedImage](https://docs.oracle.com/javase/8/docs/api/java/awt/image/BufferedImage.html) and ImageIO with the new methods that use [IImage](https://reference.aspose.com/slides/java/com.aspose.slides/iimage/).
 
-Old:
+Legacy/deprecated API:
 ``` java
 BufferedImage slideImage = pres.getSlides().get_Item(0).getThumbnail(new Dimension(1920, 1080));
 try {
@@ -86,7 +88,7 @@ try {
     e.printStackTrace();
 }
 ```
-New:
+Modern API:
 ``` java
 IImage slideImage = pres.getSlides().get_Item(0).getImage(new Dimension(1920, 1080));
 try {
@@ -98,7 +100,7 @@ try {
 
 ### **Getting a Slide Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` java
 Presentation pres = new Presentation("pres.pptx");
@@ -132,7 +134,7 @@ try {
 
 ### **Getting a Shape Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` java
 Presentation pres = new Presentation("pres.pptx");
@@ -166,7 +168,7 @@ try {
 
 ### **Getting a Presentation Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` java
 Presentation pres = new Presentation("pres.pptx");
@@ -217,7 +219,7 @@ try {
 
 ### **Adding a Picture to a Presentation**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` java
 Presentation pres = new Presentation();
@@ -255,7 +257,7 @@ try {
 }
 ```
 
-## **Methods to Be Removed and Their Replacement in Modern API**
+## **Deprecated Methods and Their Replacement in Modern API**
 
 ### **Presentation**
 | Method Signature                               | Replacement Method Signature                             |
@@ -283,9 +285,9 @@ try {
 | public final BufferedImage getThumbnail(IRenderingOptions options, Dimension imageSize) | public final IImage getImage(IRenderingOptions options, Dimension imageSize) |
 | public final BufferedImage getThumbnail(ITiffOptions options) | public final IImage getImage(ITiffOptions options) |
 | public final BufferedImage getThumbnail(Dimension imageSize) | public final IImage getImage(Dimension imageSize) |
-| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics) | Will be deleted completely  |
-| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, float scaleX, float scaleY) | Will be deleted completely  |
-| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, Dimension renderingSize) | Will be deleted completely  |
+| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics) | No Modern API replacement  |
+| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, float scaleX, float scaleY) | No Modern API replacement  |
+| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, Dimension renderingSize) | No Modern API replacement  |
 
 ### **Output**
 | Method Signature                                                | Replacement Method Signature                                |
@@ -314,11 +316,11 @@ try {
 | public final java.awt.image.BufferedImage getTileImage(Color background, Color foreground) | public final IImage getTileIImage(Color background, Color foreground) |
 
 
-## **API Support for Graphics2D Will Be Discontinued**
+## **API Support for Graphics2D**
 
-Methods with [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) are declared deprecated and their support will be removed from the public API.
+Methods with [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) are declared deprecated and have no direct Modern API replacement.
 
-The part of the API that uses it will be removed:
+Use the Modern API image-rendering methods instead of the API that renders to [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html):
 
 [Slide](https://reference.aspose.com/slides/java/com.aspose.slides/slide/)
 
@@ -328,11 +330,11 @@ The part of the API that uses it will be removed:
 
 ## **FAQ**
 
-**Why was java.awt.Graphics2D dropped?**
+**Why was [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) dropped?**
 
-Support for `Graphics2D` is being removed from the public API to unify work with rendering and images, eliminate ties to platform-specific dependencies, and switch to a cross-platform approach with [IImage](https://reference.aspose.com/slides/java/com.aspose.slides/iimage/). All rendering methods to `Graphics2D` will be removed.
+Support for [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) is deprecated in the public API to unify work with rendering and images, eliminate ties to platform-specific dependencies, and switch to a cross-platform approach with [IImage](https://reference.aspose.com/slides/java/com.aspose.slides/iimage/). Use `getImage` or `getImages` instead of rendering to [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html).
 
-**What is the practical benefit of IImage compared to BufferedImage?**
+**What is the practical benefit of [IImage](https://reference.aspose.com/slides/java/com.aspose.slides/iimage/) compared to [BufferedImage](https://docs.oracle.com/javase/8/docs/api/java/awt/image/BufferedImage.html)?**
 
 [IImage](https://reference.aspose.com/slides/java/com.aspose.slides/iimage/) unifies working with both raster and vector images and simplifies saving to various formats via [ImageFormat](https://reference.aspose.com/slides/java/com.aspose.slides/imageformat/).
 

--- a/en/net/developer-guide/modern-api/_index.md
+++ b/en/net/developer-guide/modern-api/_index.md
@@ -32,26 +32,28 @@ Historically, Aspose Slides has a dependency on System.Drawing and has in the pu
 
 As of version 24.4, this public API is declared deprecated.
 
-Since System.Drawing support in versions .NET6 and above is removed for non-Windows versions ([breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only)), Slides has implemented a two library version approach:
+Since System.Drawing support in versions .NET6 and above is removed for non-Windows versions ([breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only)), Slides has implemented a two-package approach:
 - [Aspose.Slides.NET](https://www.nuget.org/packages/Aspose.Slides.NET) - support for .NET6+ for Windows, .NETStandard for Windows/Linux/MacOS, .NETFramework 2+ (Windows).
   - has a dependence on [System.Drawing.Common](https://www.nuget.org/packages/System.Drawing.Common/).
 - [Aspose.Slides.NET6.CrossPlatform](https://www.nuget.org/packages/Aspose.Slides.NET6.CrossPlatform) - Windows/Linux/MacOS version without dependencies.
 
-The inconvenience of [Aspose.Slides.NET6.CrossPlatform](https://www.nuget.org/packages/Aspose.Slides.NET6.CrossPlatform) is that it implements its own version of System.Drawing in the same namespace (to support backward compatibility with the public API). Thus, when Aspose.Slides.NET6.CrossPlatform and System.Drawing from .NETFramrwork or System.Drawing.Common package are used at the same time, a name conflict occurs unless alias is used.
+The inconvenience of [Aspose.Slides.NET6.CrossPlatform](https://www.nuget.org/packages/Aspose.Slides.NET6.CrossPlatform) is that it implements its own version of System.Drawing in the same namespace (to support backward compatibility with the public API). Thus, when Aspose.Slides.NET6.CrossPlatform and System.Drawing from .NET Framework or System.Drawing.Common package are used at the same time, a name conflict occurs unless alias is used.
 
-In order to get rid of dependencies on System.Drawing in the main Aspose.Slides.NET package, we added the so-called "Modern API" - i.e. the API that should be used instead of the deprecated one, whose signatures contain dependencies on the following types from System.Drawing: Image and Bitmap. PrinterSettings and Graphics are declared deprecated and their support is removed from the public Slides API.
+In order to get rid of dependencies on System.Drawing in the main Aspose.Slides.NET package, we added the so-called "Modern API" - i.e. the API that should be used instead of the deprecated one, whose signatures contain dependencies on the following types from System.Drawing: [Image](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.image) and [Bitmap](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.bitmap). [PrinterSettings](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.printing.printersettings) and [Graphics](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.graphics) are declared deprecated and their support is removed from the public Slides API.
 
-Removal of the deprecated public API with dependencies on System.Drawing will be in release 24.8.
+In current versions, treat the public API that depends on System.Drawing as legacy/deprecated. Use the Modern API for new code and when migrating existing image-processing workflows.
 
 ## **Modern API**
 
 Added the following classes and enums to the public API:
 
-- Aspose.Slides.IImage - represents the raster or vector image.
-- Aspose.Slides.ImageFormat - represents the file format of the image.
-- Aspose.Slides.Images - methods to instantiate and work with the IImage interface.
+- [Aspose.Slides.IImage](https://reference.aspose.com/slides/net/aspose.slides/iimage/) - represents the raster or vector image.
+- [Aspose.Slides.ImageFormat](https://reference.aspose.com/slides/net/aspose.slides/imageformat/) - represents the file format of the image.
+- [Aspose.Slides.Images](https://reference.aspose.com/slides/net/aspose.slides/images/) - methods to instantiate and work with the [IImage](https://reference.aspose.com/slides/net/aspose.slides/iimage/) interface.
 
-Please note that IImage is disposable (it implements the IDisposable interface and its use should be wrapped in using or dispose-it in another convenient way).
+Please note that [IImage](https://reference.aspose.com/slides/net/aspose.slides/iimage/) is disposable (it implements the [IDisposable](https://learn.microsoft.com/en-us/dotnet/api/system.idisposable) interface and its use should be wrapped in using or disposed in another convenient way).
+
+Use `GetImage` to render a single slide or shape. Use `GetImages` to render several presentation slides. Use [Images](https://reference.aspose.com/slides/net/aspose.slides/images/) methods to load images, `AddImage` with [IImage](https://reference.aspose.com/slides/net/aspose.slides/iimage/) to add them to a presentation, and `ReplaceImage` with [IImage](https://reference.aspose.com/slides/net/aspose.slides/iimage/) to update an existing presentation image.
 
 A typical scenario of using the new API may look as follows:
 
@@ -80,11 +82,11 @@ using (Presentation pres = new Presentation())
 
 ## **Replacing Old Code with Modern API**
 
-For ease of transition, the interface of the new IImage repeats the separate signatures of the Image and Bitmap classes. In general, you will just need to replace the call to the old method using System.Drawing with the new one.
+For ease of transition, the interface of the new [IImage](https://reference.aspose.com/slides/net/aspose.slides/iimage/) repeats the separate signatures of the [Image](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.image) and [Bitmap](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.bitmap) classes. In general, you will just need to replace the call to the old method using System.Drawing with the new one.
 
 ### **Getting a Slide Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` csharp
 using (Presentation pres = new Presentation("pres.pptx"))
@@ -104,7 +106,7 @@ using (Presentation pres = new Presentation("pres.pptx"))
 
 ### **Getting a Shape Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` csharp
 using (Presentation pres = new Presentation("pres.pptx"))
@@ -124,7 +126,7 @@ using (Presentation pres = new Presentation("pres.pptx"))
 
 ### **Getting a Presentation Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` csharp
 using (Presentation pres = new Presentation("pres.pptx"))
@@ -174,7 +176,7 @@ using (Presentation pres = new Presentation("pres.pptx"))
 
 ### **Adding a Picture to a Presentation**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` csharp
 using (Presentation pres = new Presentation())
@@ -203,7 +205,7 @@ using (Presentation pres = new Presentation())
     pres.Slides[0].Shapes.AddPictureFrame(ShapeType.Rectangle, 10, 10, 100, 100, ppImage);
 }
 ```
-## **Methods/Properties to Be Removed and Their Replacement in Modern API**
+## **Deprecated Methods/Properties and Their Replacement in Modern API**
 
 ### **Presentation**
 | Method Signature                               | Replacement Method Signature                             |
@@ -212,14 +214,14 @@ using (Presentation pres = new Presentation())
 | public Bitmap[] GetThumbnails(IRenderingOptions options, int[] slides) | [GetImages(IRenderingOptions options, int[] slides)](https://reference.aspose.com/slides/net/aspose.slides/presentation/getimages#getimages_1)   |
 | public Bitmap[] GetThumbnails(IRenderingOptions options, float scaleX, float scaleY) | [GetImages(IRenderingOptions options, float scaleX, float scaleY)](https://reference.aspose.com/slides/net/aspose.slides/presentation/getimages#getimages_4) |
 | public Bitmap[] GetThumbnails(IRenderingOptions options, int[] slides, float scaleX, float scaleY) | [GetImages(IRenderingOptions options, int[] slides, float scaleX, float scaleY)](https://reference.aspose.com/slides/net/aspose.slides/presentation/getimages#getimages_2) |
-| public Bitmap[] GetThumbnails(IRenderingOptions options, Size imageSize) | [GetImages(IRenderingOptions options, Size imageSize)]() |
+| public Bitmap[] GetThumbnails(IRenderingOptions options, Size imageSize) | [GetImages(IRenderingOptions options, Size imageSize)](https://reference.aspose.com/slides/net/aspose.slides/presentation/getimages) |
 | public Bitmap[] GetThumbnails(IRenderingOptions options, int[] slides, Size imageSize) | [GetImages(IRenderingOptions options, int[] slides, Size imageSize)](https://reference.aspose.com/slides/net/aspose.slides/presentation/getimages#getimages_3) |
-| public void Save(string fname, SaveFormat format, HttpResponse response, bool showInline) | Will be deleted completely |
-| public void Save(string fname, SaveFormat format, ISaveOptions options, HttpResponse response, bool showInline) | Will be deleted completely |
-| public void Print()                           | Will be deleted completely                               |
-| public void Print(PrinterSettings printerSettings) | Will be deleted completely                            |
-| public void Print(string printerName)         | Will be deleted completely                               |
-| public void Print(PrinterSettings printerSettings, string presName) | Will be deleted completely                          |
+| public void Save(string fname, SaveFormat format, HttpResponse response, bool showInline) | No Modern API replacement |
+| public void Save(string fname, SaveFormat format, ISaveOptions options, HttpResponse response, bool showInline) | No Modern API replacement |
+| public void Print()                           | No Modern API replacement                               |
+| public void Print(PrinterSettings printerSettings) | No Modern API replacement                            |
+| public void Print(string printerName)         | No Modern API replacement                               |
+| public void Print(PrinterSettings printerSettings, string presName) | No Modern API replacement                          |
 
 ### **Shape**
 | Method Signature                                                      | Replacement Method Signature                                       |
@@ -237,9 +239,9 @@ using (Presentation pres = new Presentation())
 | public Bitmap GetThumbnail(ITiffOptions options)                    | [GetImage(ITiffOptions options)](https://reference.aspose.com/slides/net/aspose.slides/slide/getimage#getimage_4)                                      |
 | public Bitmap GetThumbnail(IRenderingOptions options, float scaleX, float scaleY) | [GetImage(IRenderingOptions options, float scaleX, float scaleY)](https://reference.aspose.com/slides/net/aspose.slides/slide/getimage#getimage_2) |
 | public Bitmap GetThumbnail(IRenderingOptions options, Size imageSize) | [GetImage(IRenderingOptions options, Size imageSize)](https://reference.aspose.com/slides/net/aspose.slides/slide/getimage#getimage_3)               |
-| public void RenderToGraphics(IRenderingOptions options, Graphics graphics) | Will be deleted completely                                       |
-| public void RenderToGraphics(IRenderingOptions options, Graphics graphics, float scaleX, float scaleY) | Will be deleted completely                             |
-| public void RenderToGraphics(IRenderingOptions options, Graphics graphics, Size renderingSize) | Will be deleted completely                                    |
+| public void RenderToGraphics(IRenderingOptions options, Graphics graphics) | No Modern API replacement                                       |
+| public void RenderToGraphics(IRenderingOptions options, Graphics graphics, float scaleX, float scaleY) | No Modern API replacement                             |
+| public void RenderToGraphics(IRenderingOptions options, Graphics graphics, Size renderingSize) | No Modern API replacement                                    |
 
 ### **Output**
 | Method Signature                                                | Replacement Method Signature                                |
@@ -273,17 +275,17 @@ using (Presentation pres = new Presentation())
 |-----------------------------------------------------------|-----------------------------------------------------|
 | Bitmap GetTileImage(Color background, Color foreground)   | [GetTileIImage(SlidesImage image)](https://reference.aspose.com/slides/net/aspose.slides/ipatternformateffectivedata/gettileiimage)                    |
 
-## **API Support for Graphics and PrinterSettings Will Be Discontinued**
+## **API Support for Graphics and PrinterSettings**
 
-The [Graphics](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.graphics) class is not supported for cross-platform versions of .NET6 and higher. In Aspose Slides, the part of the API that uses it will be removed:
-[Slide](https://reference.aspose.com/slides/net/aspose.slides/slide/)
+The [Graphics](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.graphics) class is not supported for cross-platform versions of .NET6 and higher. In Aspose Slides, use the Modern API image-rendering methods instead of the API that renders to [Graphics](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.graphics):
+[ISlide](https://reference.aspose.com/slides/net/aspose.slides/islide/)
 - [public void RenderToGraphics(IRenderingOptions options, Graphics graphics)](https://reference.aspose.com/slides/net/aspose.slides/slide/rendertographics/#rendertographics_3)
 - [public void RenderToGraphics(IRenderingOptions options, Graphics graphics, float scaleX, float scaleY)](https://reference.aspose.com/slides/net/aspose.slides/slide/rendertographics/#rendertographics_3)
 - [public void RenderToGraphics(IRenderingOptions options, Graphics graphics, Size renderingSize)](https://reference.aspose.com/slides/net/aspose.slides/slide/rendertographics/#rendertographics_5)
 
-Also, the part of the API that is related to printing will be removed:
+Also, the API that is related to printing through [PrinterSettings](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.printing.printersettings) has no direct Modern API replacement:
 
-[Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/):
+[IPresentation](https://reference.aspose.com/slides/net/aspose.slides/ipresentation/):
 - [public void Presentation.Print](https://reference.aspose.com/slides/net/aspose.slides/presentation/print/#print)
 - [public void Print(PrinterSettings printerSettings)](https://reference.aspose.com/slides/net/aspose.slides/presentation/print/#print_1)
 - [public void Print(string printerName)](https://reference.aspose.com/slides/net/aspose.slides/presentation/print/#print_3)
@@ -291,11 +293,11 @@ Also, the part of the API that is related to printing will be removed:
 
 ## **FAQ**
 
-**Why was System.Drawing.Graphics dropped?**
+**Why was [Graphics](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.graphics) dropped?**
 
-Support for `Graphics` is being removed from the public API to unify work with rendering and images, eliminate ties to platform-specific dependencies, and switch to a cross-platform approach with [IImage](https://reference.aspose.com/slides/net/aspose.slides/iimage/). All rendering methods to `Graphics` will be removed.
+Support for [Graphics](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.graphics) is deprecated in the public API to unify work with rendering and images, eliminate ties to platform-specific dependencies, and switch to a cross-platform approach with [IImage](https://reference.aspose.com/slides/net/aspose.slides/iimage/). Use `GetImage` or `GetImages` instead of rendering to [Graphics](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.graphics).
 
-**What is the practical benefit of IImage compared to Image/Bitmap?**
+**What is the practical benefit of [IImage](https://reference.aspose.com/slides/net/aspose.slides/iimage/) compared to [Image](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.image)/[Bitmap](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.bitmap)?**
 
 [IImage](https://reference.aspose.com/slides/net/aspose.slides/iimage/) unifies working with both raster and vector images, simplifies saving to various formats via [ImageFormat](https://reference.aspose.com/slides/net/aspose.slides/imageformat/), reduces dependence on `System.Drawing`, and makes code more portable across environments.
 

--- a/en/nodejs-java/developer-guide/modern-api/_index.md
+++ b/en/nodejs-java/developer-guide/modern-api/_index.md
@@ -29,19 +29,21 @@ Historically, Aspose Slides has a dependency on java.awt and has in the public A
 
 As of version 24.4, this public API is declared deprecated.
 
-In order to get rid of dependencies on these classes, we added the so-called "Modern API" - i.e. the API that should be used instead of the deprecated one, whose signatures contain dependencies on BufferedImage. Graphics2D is declared deprecated and its support is removed from the public Slides API.
+In order to get rid of dependencies on these classes, we added the so-called "Modern API" - i.e. the API that should be used instead of the deprecated one, whose signatures contain dependencies on [BufferedImage](https://docs.oracle.com/javase/8/docs/api/java/awt/image/BufferedImage.html). [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) is declared deprecated and its support is removed from the public Slides API.
 
-Removal of the deprecated public API with dependencies on System.Drawing will be in release 24.8.
+In current versions, treat the public API that depends on java.awt types as legacy/deprecated. Use the Modern API for new code and when migrating existing image-processing workflows.
 
 ## **Modern API**
 
 Added the following classes and enums to the public API:
 
-- IImage - represents the raster or vector image.
-- ImageFormat - represents the file format of the image.
-- Images - methods to instantiate and work with the IImage class.
+- [IImage](https://reference.aspose.com/slides/nodejs-java/aspose.slides/iimage/) - represents the raster or vector image.
+- [ImageFormat](https://reference.aspose.com/slides/nodejs-java/aspose.slides/imageformat/) - represents the file format of the image.
+- [Images](https://reference.aspose.com/slides/nodejs-java/aspose.slides/images/) - methods to instantiate and work with the [IImage](https://reference.aspose.com/slides/nodejs-java/aspose.slides/iimage/) class.
 
-Please note that IImage is disposable (it implements the IDisposable class and its use should be wrapped in using or dispose-it in another convenient way).
+Please note that [IImage](https://reference.aspose.com/slides/nodejs-java/aspose.slides/iimage/) is disposable and its use should be followed by a `dispose()` call or another convenient disposal pattern.
+
+Use `getImage` to render a single slide or shape. Use `getImages` to render several presentation slides. Use [Images](https://reference.aspose.com/slides/nodejs-java/aspose.slides/images/) methods to load images, `addImage` with [IImage](https://reference.aspose.com/slides/nodejs-java/aspose.slides/iimage/) to add them to a presentation, and `replaceImage` with [IImage](https://reference.aspose.com/slides/nodejs-java/aspose.slides/iimage/) to update an existing presentation image.
 
 A typical scenario of using the new API may look as follows:
 
@@ -77,9 +79,9 @@ try {
 
 ## **Replacing Old Code with Modern API**
 
-In general, you will need to replace the call to the old method using ImageIO with the new one.
+In general, you will need to replace calls that use [BufferedImage](https://docs.oracle.com/javase/8/docs/api/java/awt/image/BufferedImage.html) and [ImageIO](https://docs.oracle.com/javase/8/docs/api/javax/imageio/ImageIO.html) with the new methods that use [IImage](https://reference.aspose.com/slides/nodejs-java/aspose.slides/iimage/).
 
-Old:
+Legacy/deprecated API:
 ``` javascript
 var imageio = java.import("javax.imageio.ImageIO");
 var size = java.newInstanceSync("java.awt.Dimension", 1920, 1080);
@@ -87,7 +89,7 @@ var slideImage = pres.getSlides().get_Item(0).getThumbnail(size);
 var file = java.newInstanceSync("java.io.File", "image.png");
 imageio.write(slideImage, "PNG", file);
 ```
-New:
+Modern API:
 ``` javascript
 var size = java.newInstanceSync("java.awt.Dimension", 1920, 1080);
 var slideImage = pres.getSlides().get_Item(0).getImage(size);
@@ -97,7 +99,7 @@ slideImage.dispose();
 
 ### **Getting a Slide Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` javascript
 var pres = new aspose.slides.Presentation("pres.pptx");
@@ -126,7 +128,7 @@ try {
 
 ### **Getting a Shape Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` javascript
 var pres = new aspose.slides.Presentation("pres.pptx");
@@ -155,7 +157,7 @@ try {
 
 ### **Getting a Presentation Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` javascript
 var pres = new aspose.slides.Presentation("pres.pptx");
@@ -200,7 +202,7 @@ try {
 
 ### **Adding a Picture to a Presentation**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` javascript
 var pres = new aspose.slides.Presentation();
@@ -231,7 +233,7 @@ try {
 }
 ```
 
-## **Methods to Be Removed and Their Replacement in Modern API**
+## **Deprecated Methods and Their Replacement in Modern API**
 
 ### **Presentation**
 | Method Signature                               | Replacement Method Signature                             |
@@ -259,9 +261,9 @@ try {
 | public final BufferedImage getThumbnail(IRenderingOptions options, Dimension imageSize) | public final IImage getImage(IRenderingOptions options, Dimension imageSize) |
 | public final BufferedImage getThumbnail(ITiffOptions options) | public final IImage getImage(ITiffOptions options) |
 | public final BufferedImage getThumbnail(Dimension imageSize) | public final IImage getImage(Dimension imageSize) |
-| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics) | Will be deleted completely  |
-| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, float scaleX, float scaleY) | Will be deleted completely  |
-| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, Dimension renderingSize) | Will be deleted completely  |
+| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics) | No Modern API replacement  |
+| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, float scaleX, float scaleY) | No Modern API replacement  |
+| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, Dimension renderingSize) | No Modern API replacement  |
 
 ### **Output**
 | Method Signature                                                | Replacement Method Signature                                |
@@ -290,11 +292,11 @@ try {
 | public final java.awt.image.BufferedImage getTileImage(Color background, Color foreground) | public final IImage getTileIImage(Color background, Color foreground) |
 
 
-## **API Support for Graphics2D Will Be Discontinued**
+## **API Support for Graphics2D**
 
-Methods with [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) are declared deprecated and their support will be removed from the public API.
+Methods with [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) are declared deprecated and have no direct Modern API replacement.
 
-The part of the API that uses it will be removed:
+Use the Modern API image-rendering methods instead of the API that renders to [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html):
 
 [Slide](https://reference.aspose.com/slides/nodejs-java/aspose.slides/slide/)
 
@@ -304,7 +306,7 @@ The part of the API that uses it will be removed:
 
 # **FAQ**
 
-**What is the practical benefit of IImage compared to Image/Bitmap?**
+**What is the practical benefit of [IImage](https://reference.aspose.com/slides/nodejs-java/aspose.slides/iimage/) compared to [BufferedImage](https://docs.oracle.com/javase/8/docs/api/java/awt/image/BufferedImage.html)?**
 
 [IImage](https://reference.aspose.com/slides/nodejs-java/aspose.slides/iimage/) unifies working with both raster and vector images and simplifies saving to various formats via [ImageFormat](https://reference.aspose.com/slides/nodejs-java/aspose.slides/imageformat/).
 

--- a/en/php-java/developer-guide/modern-api/_index.md
+++ b/en/php-java/developer-guide/modern-api/_index.md
@@ -28,19 +28,21 @@ Historically, Aspose Slides has a dependency on java.awt and has in the public A
 
 As of version 24.4, this public API is declared deprecated.
 
-In order to get rid of dependencies on these classes, we added the so-called "Modern API" - i.e. the API that should be used instead of the deprecated one, whose signatures contain dependencies on BufferedImage. Graphics2D is declared deprecated and its support is removed from the public Slides API.
+In order to get rid of dependencies on these classes, we added the so-called "Modern API" - i.e. the API that should be used instead of the deprecated one, whose signatures contain dependencies on [BufferedImage](https://docs.oracle.com/javase/8/docs/api/java/awt/image/BufferedImage.html). [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) is declared deprecated and its support is removed from the public Slides API.
 
-Removal of the deprecated public API with dependencies on System.Drawing will be in release 24.8.
+In current versions, treat the public API that depends on java.awt types as legacy/deprecated. Use the Modern API for new code and when migrating existing image-processing workflows.
 
 ## **Modern API**
 
 Added the following classes and enums to the public API:
 
-- IImage - represents the raster or vector image.
-- ImageFormat - represents the file format of the image.
-- Images - methods to instantiate and work with the IImage class.
+- [IImage](https://reference.aspose.com/slides/php-java/aspose.slides/iimage/) - represents the raster or vector image.
+- [ImageFormat](https://reference.aspose.com/slides/php-java/aspose.slides/imageformat/) - represents the file format of the image.
+- [Images](https://reference.aspose.com/slides/php-java/aspose.slides/images/) - methods to instantiate and work with the [IImage](https://reference.aspose.com/slides/php-java/aspose.slides/iimage/) class.
 
-Note that `IImage` is disposable (it should be disposed of after use).
+Note that [IImage](https://reference.aspose.com/slides/php-java/aspose.slides/iimage/) is disposable (it should be disposed of after use).
+
+Use `getImage` to render a single slide or shape. Use `getImages` to render several presentation slides. Use [Images](https://reference.aspose.com/slides/php-java/aspose.slides/images/) methods to load images, `addImage` with [IImage](https://reference.aspose.com/slides/php-java/aspose.slides/iimage/) to add them to a presentation, and `replaceImage` with [IImage](https://reference.aspose.com/slides/php-java/aspose.slides/iimage/) to update an existing presentation image.
 
 A typical scenario of using the new API may look as follows:
 
@@ -76,9 +78,9 @@ $pres->dispose();
 
 ## **Replacing Old Code with Modern API**
 
-In general, you will need to replace the call to the old method using ImageIO with the new one.
+In general, you will need to replace calls that use [BufferedImage](https://docs.oracle.com/javase/8/docs/api/java/awt/image/BufferedImage.html) and [ImageIO](https://docs.oracle.com/javase/8/docs/api/javax/imageio/ImageIO.html) with the new methods that use [IImage](https://reference.aspose.com/slides/php-java/aspose.slides/iimage/).
 
-Old:
+Legacy/deprecated API:
 ``` php
 $dimension = new Java("java.awt.Dimension", 1920, 1080);
 $slideImage = $pres->getSlides()->get_Item(0)->getThumbnail($dimension);
@@ -86,7 +88,7 @@ $imageio = new Java("javax.imageio.ImageIO");
 $javafile = new Java("java.io.File", "image.png");
 $imageio->write($slideImage, "PNG", $javafile);
 ```
-New:
+Modern API:
 ``` php
 $dimension = new Java("java.awt.Dimension", 1920, 1080);
 $slideImage = $pres->getSlides()->get_Item(0)->getImage($dimension);
@@ -96,7 +98,7 @@ $slideImage->dispose();
 
 ### **Getting a Slide Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` php
 use aspose\slides\Presentation;
@@ -131,7 +133,7 @@ $pres->dispose();
 
 ### **Getting a Shape Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` php
 use aspose\slides\Presentation;
@@ -166,7 +168,7 @@ $pres->dispose();
 
 ### **Getting a Presentation Thumbnail**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` php
 use aspose\slides\Presentation;
@@ -215,7 +217,7 @@ $pres->dispose();
 
 ### **Adding a Picture to a Presentation**
 
-Code using a deprecated API:
+Legacy/deprecated API:
 
 ``` php
 use aspose\slides\Presentation;
@@ -254,7 +256,7 @@ $pres->getSlides()->get_Item(0)->getShapes()->addPictureFrame(ShapeType::Rectang
 $pres->dispose();
 ```
 
-## **Methods to Be Removed and Their Replacement in Modern API**
+## **Deprecated Methods and Their Replacement in Modern API**
 
 ### **Presentation**
 | Method Signature                               | Replacement Method Signature                             |
@@ -282,9 +284,9 @@ $pres->dispose();
 | public final BufferedImage getThumbnail(IRenderingOptions options, Dimension imageSize) | public final IImage getImage(IRenderingOptions options, Dimension imageSize) |
 | public final BufferedImage getThumbnail(ITiffOptions options) | public final IImage getImage(ITiffOptions options) |
 | public final BufferedImage getThumbnail(Dimension imageSize) | public final IImage getImage(Dimension imageSize) |
-| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics) | Will be deleted completely  |
-| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, float scaleX, float scaleY) | Will be deleted completely  |
-| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, Dimension renderingSize) | Will be deleted completely  |
+| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics) | No Modern API replacement  |
+| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, float scaleX, float scaleY) | No Modern API replacement  |
+| public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, Dimension renderingSize) | No Modern API replacement  |
 
 ### **Output**
 | Method Signature                                                | Replacement Method Signature                                |
@@ -313,25 +315,25 @@ $pres->dispose();
 | public final java.awt.image.BufferedImage getTileImage(Color background, Color foreground) | public final IImage getTileIImage(Color background, Color foreground) |
 
 
-## **API Support for Graphics2D Will Be Discontinued**
+## **API Support for Graphics2D**
 
-Methods with [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) are declared deprecated and their support will be removed from the public API.
+Methods with [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) are declared deprecated and have no direct Modern API replacement.
 
-The part of the API that uses it will be removed:
+Use the Modern API image-rendering methods instead of the API that renders to [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html):
 
-[Slide](https://reference.aspose.com/slides/java/com.aspose.slides/slide/)
+[Slide](https://reference.aspose.com/slides/php-java/aspose.slides/slide/)
 
-- [public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics)](https://reference.aspose.com/slides/java/com.aspose.slides/slide/#renderToGraphics-com.aspose.slides.IRenderingOptions-java.awt.Graphics2D-)
-- [public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, float scaleX, float scaleY)](https://reference.aspose.com/slides/java/com.aspose.slides/slide/#renderToGraphics-com.aspose.slides.IRenderingOptions-java.awt.Graphics2D-float-float-)
-- [public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, Dimension renderingSize)](https://reference.aspose.com/slides/java/com.aspose.slides/slide/#renderToGraphics-com.aspose.slides.IRenderingOptions-java.awt.Graphics2D-java.awt.Dimension-)
+- [public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics)](https://reference.aspose.com/slides/php-java/aspose.slides/slide/#renderToGraphics-aspose.slides.IRenderingOptions-java.awt.Graphics2D-)
+- [public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, float scaleX, float scaleY)](https://reference.aspose.com/slides/php-java/aspose.slides/slide/#renderToGraphics-aspose.slides.IRenderingOptions-java.awt.Graphics2D-float-float-)
+- [public final void renderToGraphics(IRenderingOptions options, Graphics2D graphics, Dimension renderingSize)](https://reference.aspose.com/slides/php-java/aspose.slides/slide/#renderToGraphics-aspose.slides.IRenderingOptions-java.awt.Graphics2D-java.awt.Dimension-)
 
 ## **FAQ**
 
-**Why was java.awt.Graphics2D dropped?**
+**Why was [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) dropped?**
 
-Support for `Graphics2D` is being removed from the public API to unify work with rendering and images, eliminate ties to platform-specific dependencies, and switch to a cross-platform approach with [IImage](https://reference.aspose.com/slides/php-java/aspose.slides/iimage/). All rendering methods to `Graphics2D` will be removed.
+Support for [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) is deprecated in the public API to unify work with rendering and images, eliminate ties to platform-specific dependencies, and switch to a cross-platform approach with [IImage](https://reference.aspose.com/slides/php-java/aspose.slides/iimage/). Use `getImage` or `getImages` instead of rendering to [Graphics2D](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html).
 
-**What is the practical benefit of IImage compared to BufferedImage?**
+**What is the practical benefit of [IImage](https://reference.aspose.com/slides/php-java/aspose.slides/iimage/) compared to [BufferedImage](https://docs.oracle.com/javase/8/docs/api/java/awt/image/BufferedImage.html)?**
 
 [IImage](https://reference.aspose.com/slides/php-java/aspose.slides/iimage/) unifies working with both raster and vector images and simplifies saving to various formats via [ImageFormat](https://reference.aspose.com/slides/php-java/aspose.slides/imageformat/).
 

--- a/en/python-net/developer-guide/modern-api/_index.md
+++ b/en/python-net/developer-guide/modern-api/_index.md
@@ -30,17 +30,19 @@ The Aspose.Slides for Python public API currently depends on the following `aspo
 
 As of version 24.4, this public API is **deprecated** due to [changes](https://releases.aspose.com/slides/python-net/release-notes/2024/aspose-slides-for-python-net-24-4-release-notes/#introducing-a-new-modern-api) in the Aspose.Slides for Python public API.
 
-To eliminate `aspose.pydrawing` from the public API, we introduced the **Modern API**. Methods that use `aspose.pydrawing.Image` and `aspose.pydrawing.Bitmap` are deprecated and will be replaced by their Modern API equivalents. Methods that use `aspose.pydrawing.Graphics` are deprecated, and support for them will be removed from the public API.
+To eliminate `aspose.pydrawing` from the public API, we introduced the **Modern API**. Methods that use `aspose.pydrawing.Image` and `aspose.pydrawing.Bitmap` are deprecated and should be replaced by their Modern API equivalents. Methods that use `aspose.pydrawing.Graphics` are deprecated and have no direct Modern API replacement.
 
-Removal of the deprecated API that depends on `aspose.pydrawing` is planned for release **24.8**.
+In current versions, treat the public API that depends on `aspose.pydrawing` as legacy/deprecated. Use the Modern API for new code and when migrating existing image-processing workflows.
 
 ## **Modern API**
 
 The following classes and enums have been added to the public API:
 
-- [`aspose.slides.IImage`](https://reference.aspose.com/slides/python-net/aspose.slides/iimage/) — represents a raster or vector image.
-- [`aspose.slides.ImageFormat`](https://reference.aspose.com/slides/python-net/aspose.slides/imageformat/) — represents an image file format.
-- [`aspose.slides.Images`](https://reference.aspose.com/slides/python-net/aspose.slides/images/) — provides methods to create and work with `IImage`.
+- [aspose.slides.IImage](https://reference.aspose.com/slides/python-net/aspose.slides/iimage/) - represents a raster or vector image.
+- [aspose.slides.ImageFormat](https://reference.aspose.com/slides/python-net/aspose.slides/imageformat/) - represents an image file format.
+- [aspose.slides.Images](https://reference.aspose.com/slides/python-net/aspose.slides/images/) - provides methods to create and work with [IImage](https://reference.aspose.com/slides/python-net/aspose.slides/iimage/).
+
+Use `get_image` to render a single slide or shape. Use `get_images` to render several presentation slides. Use [Images](https://reference.aspose.com/slides/python-net/aspose.slides/images/) methods to load images, `add_image` with [IImage](https://reference.aspose.com/slides/python-net/aspose.slides/iimage/) to add them to a presentation, and `replace_image` with [IImage](https://reference.aspose.com/slides/python-net/aspose.slides/iimage/) to update an existing presentation image.
 
 A typical usage scenario for the new API looks like this:
 
@@ -62,7 +64,7 @@ with slides.Presentation() as presentation:
 
 ## **Replace Old Code with the Modern API**
 
-For an easier transition, the new `IImage` class mirrors the separate APIs of the `Image` and `Bitmap` classes. In most cases, you only need to replace calls to methods that use `aspose.pydrawing` with their Modern API equivalents.
+For an easier transition, the new [IImage](https://reference.aspose.com/slides/python-net/aspose.slides/iimage/) class mirrors the separate APIs of the `aspose.pydrawing.Image` and `aspose.pydrawing.Bitmap` classes. In most cases, you only need to replace calls to methods that use `aspose.pydrawing` with their Modern API equivalents.
 
 ### **Get a Slide Thumbnail**
 
@@ -184,12 +186,12 @@ with slides.Presentation() as presentation:
 |get_thumbnails(options, slides, scale_x, scale_y)|[get_images(options, slides, scale_x, scale_y)](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/get_images/#asposeslidesexportirenderingoptions-listint-float-float)|
 |get_thumbnails(options, image_size)|[get_images(options, image_size)](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/get_images/#asposeslidesexportirenderingoptions-asposepydrawingsize)|
 |get_thumbnails(options, slides, image_size)|[get_images(options, slides, image_size)](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/get_images/#asposeslidesexportirenderingoptions-listint-asposepydrawingsize)|
-|save(fname, format, response, show_inline)|Will be deleted completely|
-|save(fname, format, options, response, show_inline)|Will be deleted completely|
-|print()|Will be deleted completely|
-|print(printer_settings)|Will be deleted completely|
-|print(printer_name)|Will be deleted completely|
-|print(printer_settings, pres_name)|Will be deleted completely|
+|save(fname, format, response, show_inline)|No Modern API replacement|
+|save(fname, format, options, response, show_inline)|No Modern API replacement|
+|print()|No Modern API replacement|
+|print(printer_settings)|No Modern API replacement|
+|print(printer_name)|No Modern API replacement|
+|print(printer_settings, pres_name)|No Modern API replacement|
 
 ### **Slide Class**
 
@@ -198,13 +200,13 @@ with slides.Presentation() as presentation:
 |get_thumbnail()|[get_image()](https://reference.aspose.com/slides/python-net/aspose.slides/slide/get_image/#)|
 |get_thumbnail(scale_x, scale_y)|[get_image(scale_x, scale_y)](https://reference.aspose.com/slides/python-net/aspose.slides/slide/get_image/#float-float)|
 |get_thumbnail(image_size)|[get_image(image_size)](https://reference.aspose.com/slides/python-net/aspose.slides/slide/get_image/#asposepydrawingsize)|
-|get_thumbnail(options)|[get_image(options: ITiffOotions)](https://reference.aspose.com/slides/python-net/aspose.slides/slide/get_image/#asposeslidesexportitiffoptions)|
+|get_thumbnail(options)|[get_image(options: ITiffOptions)](https://reference.aspose.com/slides/python-net/aspose.slides/slide/get_image/#asposeslidesexportitiffoptions)|
 |get_thumbnail(options)|[get_image(options: IRenderingOptions)](https://reference.aspose.com/slides/python-net/aspose.slides/slide/get_image/#asposeslidesexportirenderingoptions)|
 |get_thumbnail(options, scale_x, scale_y)|[get_image(options, scale_x, scale_y)](https://reference.aspose.com/slides/python-net/aspose.slides/slide/get_image/#asposeslidesexportirenderingoptions-float-float)|
 |get_thumbnail(options, image_size)|[get_image(options, image_size)](https://reference.aspose.com/slides/python-net/aspose.slides/slide/get_image/#asposeslidesexportirenderingoptions-asposepydrawingsize)|
-|render_to_graphics(options, graphics)|Will be deleted completely|
-|render_to_graphics(options, graphics, scale_x, scale_y)|Will be deleted completely|
-|render_to_graphics(options, graphics, rendering_size)|Will be deleted completely|
+|render_to_graphics(options, graphics)|No Modern API replacement|
+|render_to_graphics(options, graphics, scale_x, scale_y)|No Modern API replacement|
+|render_to_graphics(options, graphics, rendering_size)|No Modern API replacement|
 
 ### **Shape Class**
 
@@ -251,22 +253,22 @@ with slides.Presentation() as presentation:
 | :- | :- |
 |add(path, image: aspose.pydrawing.Image)|[add(path, image)](https://reference.aspose.com/slides/python-net/aspose.slides.export.web/output/add/#str-iimage)|
 
-## **API Support for aspose.pydrawing.Graphics Will Be Discontinued**
+## **API Support for aspose.pydrawing.Graphics**
 
-Methods that use `aspose.pydrawing.Graphics` are deprecated; support for them will be removed from the public API.
+Methods that use `aspose.pydrawing.Graphics` are deprecated and have no direct Modern API replacement.
 
-The API members that rely on `aspose.pydrawing.Graphics` and will be removed include:
+Use the Modern API image-rendering methods instead of the API that renders to `aspose.pydrawing.Graphics`:
 - `aspose.pydrawing.Slide.render_to_graphics(options, graphics)`
 - `aspose.pydrawing.Slide.render_to_graphics(options, graphics, scale_x, scale_y)`
 - `aspose.pydrawing.Slide.render_to_graphics(options, graphics, rendering_size)`
 
 # **FAQ**
 
-**Why was aspose.pydrawing.Graphics dropped?**
+**Why was `aspose.pydrawing.Graphics` dropped?**
 
-Support for Graphics is being removed from the public API to unify work with rendering and images, eliminate ties to platform-specific dependencies, and switch to a cross-platform approach with [IImage](https://reference.aspose.com/slides/python-net/aspose.slides/iimage/). All rendering methods to Graphics will be removed.
+Support for `aspose.pydrawing.Graphics` is deprecated in the public API to unify work with rendering and images, eliminate ties to platform-specific dependencies, and switch to a cross-platform approach with [IImage](https://reference.aspose.com/slides/python-net/aspose.slides/iimage/). Use `get_image` or `get_images` instead of rendering to `aspose.pydrawing.Graphics`.
 
-**What is the practical benefit of IImage compared to Image/Bitmap?**
+**What is the practical benefit of [IImage](https://reference.aspose.com/slides/python-net/aspose.slides/iimage/) compared to `aspose.pydrawing.Image`/`aspose.pydrawing.Bitmap`?**
 
 [IImage](https://reference.aspose.com/slides/python-net/aspose.slides/iimage/) unifies working with both raster and vector images, simplifies saving to various formats via [ImageFormat](https://reference.aspose.com/slides/python-net/aspose.slides/imageformat/), reduces dependence on pydrawing, and makes code more portable across environments.
 


### PR DESCRIPTION
Updated Modern API documentation to remove outdated 24.8 removal notes, clarify legacy/deprecated imaging APIs, mark old examples, add brief guidance for modern image workflows, fix wording and broken links, and link relevant API types in prose where appropriate.