### PR TITLE
Update docs for forum topic 328891

### DIFF
--- a/en/cpp/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
+++ b/en/cpp/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
@@ -324,3 +324,7 @@ Aspose.Slides does not accept a password when linking. A common approach is to r
 **Can multiple charts reference the same external workbook?**
 
 Yes. Each chart stores its own link. If they all point to the same file, updating that file will be reflected in each chart the next time the data is loaded.
+
+**Can I retrieve cached chart values when the workbook is linked externally and not available?**
+
+No. Aspose.Slides for C++ does not provide a public API to read the cached chart values stored in the chart XML when the external workbook cannot be loaded.


### PR DESCRIPTION
Forum topic: [328891](https://forum.aspose.com/t/access-cached-chart-values-of-externally-linked-workbook-charts-in-c/328891) - Access Cached Chart Values of Externally Linked Workbook Charts in C++

Summary:
- Add FAQ entry clarifying that cached chart values cannot be accessed via API when using an external workbook
- Document the current limitation regarding reading cached values

Updated documentation:
- Updated section: FAQ