### PR TITLE
Update docs for forum topic 328902

### DIFF
--- a/en/cpp/getting-started/system-requirements/_index.md
+++ b/en/cpp/getting-started/system-requirements/_index.md
@@ -43,6 +43,8 @@ Aspose.Slides for C++ is a native C++ library. Aspose.Slides for C++ supports th
 - Fedora 24 or later.
 - And other Linux x86_64 with glibc 2.23 or later.
 
+- Only **x86_64** architecture is supported on Linux; **ARM64** is not currently supported.
+
 ### **macOS**
 - macOS Monterey 12.1 or later.
 


### PR DESCRIPTION
Forum topic: [328902](https://forum.aspose.com/t/support-for-linux-arm64-in-aspose-slides-for-c/328902) - Support for Linux ARM64 in Aspose.Slides for C++

Summary:
- Add ARM64 limitation note under Linux OS support
- Clarify supported architecture for Linux

Updated documentation:
- Updated section: Linux