### PR TITLE
SLIDESDOC-783 Rewrite the article "Export Presentations to HTML with Externally Linked Images"

### DIFF
--- a/en/androidjava/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
+++ b/en/androidjava/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
@@ -1,0 +1,361 @@
+---
+title: Export Presentations to HTML with Externally Linked Images
+type: docs
+weight: 100
+url: /androidjava/exporting-presentations-to-html-with-externally-linked-images/
+keywords:
+- export PowerPoint
+- export OpenDocument
+- export presentation
+- export slide
+- export PPT
+- export PPTX
+- export ODP
+- PowerPoint to HTML
+- OpenDocument to HTML
+- presentation to HTML
+- slide to HTML
+- PPT to HTML
+- PPTX to HTML
+- ODP to HTML
+- linked image
+- externally linked image
+- linked resource
+- external resource
+- Android
+- Java
+- Aspose.Slides
+description: "Export PowerPoint and OpenDocument presentations to HTML in Android via Java using Aspose.Slides with images and other resources saved as external linked files."
+---
+
+## **Overview**
+
+By default, Aspose.Slides exports a presentation to a self-contained HTML file. Images and other resources are written directly into the HTML, usually as Base64 data. This is convenient when you need one portable file, but it is not always the best format for a web view, a CMS, or a server-side conversion pipeline that later publishes the output.
+
+Use externally linked resources when you want to:
+
+- reduce the size of the HTML document;
+- cache images, fonts, audio, or video separately in a browser or CDN;
+- inspect, replace, compress, or post-process generated resources after export;
+- keep the output structure closer to what a web application expects.
+
+For the general HTML conversion workflow, see [Convert PowerPoint Presentations to HTML](/slides/androidjava/convert-powerpoint-to-html/). This article focuses on the resource-linking part of the export.
+
+## **How Linked Resource Export Works**
+
+[ILinkEmbedController](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ilinkembedcontroller/) lets your application decide, resource by resource, whether the exporter embeds the data in the HTML or saves it externally and writes a link.
+
+The interface has three methods:
+
+- [ILinkEmbedController.getObjectStoringLocation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ilinkembedcontroller/) decides whether a resource should be linked or embedded.
+- [ILinkEmbedController.getUrl](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ilinkembedcontroller/) returns the URL that will be written to the generated HTML or to another linked resource.
+- [ILinkEmbedController.saveExternal](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ilinkembedcontroller/) writes the linked resource data to disk or to another storage target.
+
+The file system path and the browser URL are separate concerns. For example, the sample below writes resource files to `html-output/assets` in the application's file storage, while the HTML contains relative URLs such as `assets/resource-1.svg`. A browser resolves those URLs relative to the file that contains the link. Therefore, a link from `presentation.html` to an SVG file uses `assets/resource-1.svg`, while a link from that SVG file to an image saved in the same `assets` folder uses `resource-4.jpg`.
+
+## **Export HTML with Linked Resources**
+
+The following Android Java example creates an output directory, saves the HTML file there, and stores linked resources in an `assets` subdirectory. Pass an app-owned directory such as `context.getFilesDir()` as `applicationFilesDirectory`. The code avoids `java.nio.file` APIs, so it remains compatible with Android `minSdk` 19.
+
+The controller links common image, font, audio, video, and CSS resources when Aspose.Slides provides or can infer a safe file extension. Resources that are not recognized remain embedded.
+
+```java
+import com.aspose.slides.HtmlFormatter;
+import com.aspose.slides.HtmlOptions;
+import com.aspose.slides.ILinkEmbedController;
+import com.aspose.slides.LinkEmbedDecision;
+import com.aspose.slides.Presentation;
+import com.aspose.slides.SVGOptions;
+import com.aspose.slides.SaveFormat;
+import com.aspose.slides.SlideImageFormat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public class ExportToHtmlWithLinkedResources {
+    public static void exportPresentation(File applicationFilesDirectory) {
+        if (applicationFilesDirectory == null) {
+            throw new IllegalArgumentException("The application files directory must not be null.");
+        }
+
+        File inputFile = new File(applicationFilesDirectory, "presentation.pptx");
+        File outputDirectory = new File(applicationFilesDirectory, "html-output");
+        String assetDirectoryName = "assets";
+        File assetDirectory = new File(outputDirectory, assetDirectoryName);
+
+        createDirectory(outputDirectory, "HTML output");
+        createDirectory(assetDirectory, "asset output");
+
+        String assetUrlPrefix = assetDirectoryName + "/";
+        ExternalResourceController controller = new ExternalResourceController(assetDirectory, assetUrlPrefix);
+        SVGOptions svgOptions = new SVGOptions(controller);
+        SlideImageFormat slideImageFormat = SlideImageFormat.svg(svgOptions);
+
+        HtmlOptions htmlOptions = new HtmlOptions(controller);
+        htmlOptions.setHtmlFormatter(HtmlFormatter.createDocumentFormatter("", false));
+        htmlOptions.setSlideImageFormat(slideImageFormat);
+
+        Presentation presentation = new Presentation(inputFile.getAbsolutePath());
+        try {
+            File htmlFile = new File(outputDirectory, "presentation.html");
+            presentation.save(htmlFile.getAbsolutePath(), SaveFormat.Html, htmlOptions);
+        } finally {
+            presentation.dispose();
+        }
+    }
+
+    private static final class ExternalResourceController implements ILinkEmbedController {
+        private static final Map<String, String> EXTENSIONS_BY_CONTENT_TYPE = createExtensionsByContentType();
+
+        private final File assetDirectory;
+        private final String assetUrlPrefix;
+        private final Map<Integer, String> fileNamesByResourceId = new HashMap<Integer, String>();
+
+        private ExternalResourceController(File assetDirectory, String assetUrlPrefix) {
+            if (assetDirectory == null) {
+                throw new IllegalArgumentException("The asset output directory must not be null.");
+            }
+
+            this.assetDirectory = assetDirectory;
+            this.assetUrlPrefix = normalizeUrlPrefix(assetUrlPrefix);
+        }
+
+        @Override
+        public int getObjectStoringLocation(
+                int resourceId,
+                byte[] entityData,
+                String semanticName,
+                String contentType,
+                String recommendedExtension) {
+            String extension = resolveExtension(contentType, recommendedExtension);
+            if (extension == null) {
+                return LinkEmbedDecision.Embed;
+            }
+
+            fileNamesByResourceId.put(resourceId, "resource-" + resourceId + extension);
+            return LinkEmbedDecision.Link;
+        }
+
+        @Override
+        public String getUrl(int resourceId, int referrer) {
+            String fileName = fileNamesByResourceId.get(resourceId);
+            if (fileName == null) {
+                return null;
+            }
+
+            if (fileNamesByResourceId.containsKey(referrer)) {
+                return fileName;
+            }
+
+            return assetUrlPrefix + fileName;
+        }
+
+        @Override
+        public void saveExternal(int resourceId, byte[] entityData) {
+            String fileName = fileNamesByResourceId.get(resourceId);
+            if (fileName == null) {
+                throw new IllegalStateException(
+                        "Resource " + resourceId + " was not registered for external storage.");
+            }
+
+            if (entityData == null || entityData.length == 0) {
+                throw new IllegalStateException(
+                        "Resource " + resourceId + " contains no data and cannot be saved.");
+            }
+
+            createDirectory(assetDirectory, "asset output");
+
+            File outputFile = new File(assetDirectory, fileName);
+            FileOutputStream outputStream = null;
+            try {
+                outputStream = new FileOutputStream(outputFile);
+                outputStream.write(entityData);
+            } catch (IOException exception) {
+                throw new IllegalStateException(
+                        "Failed to save external resource " + resourceId +
+                                " to " + outputFile.getAbsolutePath() + ".",
+                        exception);
+            } finally {
+                closeOutputStream(outputStream, outputFile);
+            }
+        }
+
+        private static Map<String, String> createExtensionsByContentType() {
+            Map<String, String> extensionsByContentType = new HashMap<String, String>();
+            extensionsByContentType.put("image/jpeg", ".jpg");
+            extensionsByContentType.put("image/png", ".png");
+            extensionsByContentType.put("image/gif", ".gif");
+            extensionsByContentType.put("image/bmp", ".bmp");
+            extensionsByContentType.put("image/svg+xml", ".svg");
+            extensionsByContentType.put("image/tiff", ".tiff");
+            extensionsByContentType.put("image/x-emf", ".emf");
+            extensionsByContentType.put("image/x-wmf", ".wmf");
+            extensionsByContentType.put("font/woff", ".woff");
+            extensionsByContentType.put("font/woff2", ".woff2");
+            extensionsByContentType.put("font/ttf", ".ttf");
+            extensionsByContentType.put("application/font-woff", ".woff");
+            extensionsByContentType.put("application/vnd.ms-fontobject", ".eot");
+            extensionsByContentType.put("application/x-font-ttf", ".ttf");
+            extensionsByContentType.put("text/css", ".css");
+            extensionsByContentType.put("audio/mpeg", ".mp3");
+            extensionsByContentType.put("audio/mp4", ".m4a");
+            extensionsByContentType.put("audio/wav", ".wav");
+            extensionsByContentType.put("video/mp4", ".mp4");
+            extensionsByContentType.put("video/webm", ".webm");
+            return extensionsByContentType;
+        }
+
+        private static String resolveExtension(String contentType, String recommendedExtension) {
+            if (contentType != null && !contentType.trim().equals("")) {
+                String normalizedContentType = contentType.toLowerCase(Locale.US);
+                String mappedExtension = EXTENSIONS_BY_CONTENT_TYPE.get(normalizedContentType);
+                if (mappedExtension != null) {
+                    return mappedExtension;
+                }
+            }
+
+            if (!isSupportedContentType(contentType)) {
+                return null;
+            }
+
+            return normalizeExtension(recommendedExtension);
+        }
+
+        private static boolean isSupportedContentType(String contentType) {
+            return contentType != null &&
+                    (contentType.regionMatches(true, 0, "image/", 0, "image/".length()) ||
+                     contentType.regionMatches(true, 0, "font/", 0, "font/".length()) ||
+                     contentType.regionMatches(true, 0, "audio/", 0, "audio/".length()) ||
+                     contentType.regionMatches(true, 0, "video/", 0, "video/".length()));
+        }
+
+        private static String normalizeExtension(String extension) {
+            if (extension == null || extension.trim().equals("")) {
+                return null;
+            }
+
+            String extensionCharacters = extension.trim();
+            while (extensionCharacters.startsWith(".")) {
+                extensionCharacters = extensionCharacters.substring(1);
+            }
+
+            if (extensionCharacters.equals("")) {
+                return null;
+            }
+
+            int characterCount = extensionCharacters.length();
+            for (int index = 0; index < characterCount; index++) {
+                char character = extensionCharacters.charAt(index);
+                if (!Character.isLetterOrDigit(character)) {
+                    return null;
+                }
+            }
+
+            return "." + extensionCharacters.toLowerCase(Locale.US);
+        }
+
+        private static String normalizeUrlPrefix(String urlPrefix) {
+            if (urlPrefix == null || urlPrefix.equals("")) {
+                return "";
+            }
+
+            String normalizedUrlPrefix = urlPrefix.replace('\\', '/');
+            return normalizedUrlPrefix.endsWith("/")
+                    ? normalizedUrlPrefix
+                    : normalizedUrlPrefix + "/";
+        }
+    }
+
+    private static void createDirectory(File directory, String description) {
+        if (directory.exists()) {
+            if (!directory.isDirectory()) {
+                throw new IllegalStateException(
+                        "The " + description + " path exists but is not a directory: " +
+                                directory.getAbsolutePath());
+            }
+
+            return;
+        }
+
+        if (!directory.mkdirs()) {
+            throw new IllegalStateException(
+                    "Failed to create the " + description + " directory: " +
+                            directory.getAbsolutePath());
+        }
+    }
+
+    private static void closeOutputStream(FileOutputStream outputStream, File outputFile) {
+        if (outputStream == null) {
+            return;
+        }
+
+        try {
+            outputStream.close();
+        } catch (IOException exception) {
+            throw new IllegalStateException(
+                    "Failed to close the external resource file: " +
+                            outputFile.getAbsolutePath(),
+                    exception);
+        }
+    }
+}
+```
+
+After the export, the output folder has this structure:
+
+```text
+html-output/
+  presentation.html
+  assets/
+    resource-1.svg
+    resource-2.svg
+    resource-3.svg
+    resource-4.jpg
+    resource-5.png
+```
+
+The exact files depend on the presentation content and export options. For example, raster images are commonly exported as JPEG or PNG. Aspose.Slides may choose a different image codec than the one used in the source presentation when that produces a smaller or more suitable file. Images with transparency are exported as PNG.
+
+## **Choosing URLs for Deployment**
+
+The sample uses a relative URL prefix: `assets/`. If `presentation.html` is opened from `html-output/presentation.html`, the browser loads `html-output/assets/resource-1.svg`.
+
+When one linked resource refers to another linked resource, the sample uses the `referrer` parameter in [ILinkEmbedController.getUrl](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ilinkembedcontroller/) and returns only the file name. For example, if `resource-1.svg` and `resource-4.jpg` are both in the `assets` folder, the SVG file should refer to `resource-4.jpg`, not to `assets/resource-4.jpg`.
+
+Use a different URL prefix when the files are deployed elsewhere:
+
+- Use `assets/` when the asset directory is next to the HTML file.
+- Use `../assets/` when the asset directory is one level above the HTML file.
+- Use `https://cdn.example.com/presentations/job-123/assets/` when the files are uploaded to a CDN or static file server.
+
+The URL returned by [ILinkEmbedController.getUrl](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ilinkembedcontroller/) must match the final deployed location of the file written by [ILinkEmbedController.saveExternal](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ilinkembedcontroller/). In Android applications, use app-specific storage, a cache directory, or a directory obtained through the Storage Access Framework according to your publishing workflow. In server applications, use a unique output directory or object-storage prefix for each conversion job to avoid overwriting files from another export.
+
+## **When to Embed Instead**
+
+Embedded Base64 HTML is still useful when the output must be a single file, such as an email attachment, an offline preview, or a document that will be moved without a supporting asset folder. Linked resources are a better fit when the HTML will be served by a web application, stored in a CMS, optimized by a build pipeline, or cached by browsers independently from the HTML.
+
+## **FAQ**
+
+**Can I externalize only images and keep other resources embedded?**
+
+Yes. In [ILinkEmbedController.getObjectStoringLocation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ilinkembedcontroller/), return `Link` from [LinkEmbedDecision](https://reference.aspose.com/slides/androidjava/com.aspose.slides/linkembeddecision/) only for the content types you want to save as separate files, and return `Embed` for everything else.
+
+**Why does the exported image extension differ from the source presentation?**
+
+Aspose.Slides may re-encode raster images during HTML export to improve size or browser compatibility. For example, an image from the source file may be written as JPEG or PNG depending on the rendered result.
+
+**Do relative URLs work after I move the HTML file?**
+
+Relative URLs work only when the same relative folder structure is preserved. If the HTML references `assets/resource-1.png`, the `assets` folder must stay next to the HTML file unless you generate a different URL prefix.
+
+**Can I write resources to public external storage on Android?**
+
+Yes, if your application has a valid destination and permission model for the target Android version. For generated HTML that is used only by your app, app-specific files or cache directories are usually simpler. For user-visible output, use a user-selected location or another storage approach that fits your app.
+
+**Should server applications reuse the same output folder?**
+
+No. Use a unique output directory or storage prefix for each conversion job. This avoids filename collisions and prevents one export from overwriting resources generated by another export.

--- a/en/cpp/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
+++ b/en/cpp/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
@@ -20,150 +20,310 @@ keywords:
 - ODP to HTML
 - linked image
 - externally linked image
+- linked resource
+- external resource
 - C++
 - Aspose.Slides
-description: "Export PowerPoint and OpenDocument presentations to HTML in C++ using Aspose.Slides with externally linked images—faster pages, code examples, and setup tips."
+description: "Export PowerPoint and OpenDocument presentations to HTML in C++ using Aspose.Slides with images and other resources saved as external linked files."
 ---
 
-{{% alert color="primary" %}}
+## **Overview**
 
-The presentation-to-HTML export process lets you specify:
+By default, Aspose.Slides exports a presentation to a self-contained HTML file. Images and other resources are written directly into the HTML, usually as Base64 data. This is convenient when you need one portable file, but it is not always the best format for a website, a CMS, or a server-side conversion pipeline.
 
-1. which resources are embedded in the resulting HTML file, and
-1. which resources are saved externally and referenced from the HTML file.
+Use externally linked resources when you want to:
 
-{{% /alert %}}
+- reduce the size of the HTML document;
+- cache images, fonts, audio, or video separately in a browser or CDN;
+- inspect, replace, compress, or post-process generated resources after export;
+- keep the output structure closer to what a web application expects.
 
-## **Background**
+For the general HTML conversion workflow, see [Convert PowerPoint Presentations to HTML](/slides/cpp/convert-powerpoint-to-html/). This article focuses on the resource-linking part of the export.
 
-An alternative approach using [ILinkEmbedController](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/) avoids these limitations.
+## **How Linked Resource Export Works**
 
-The `LinkController` class below implements [ILinkEmbedController](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/) and is passed to the [HtmlOptions](https://reference.aspose.com/slides/cpp/aspose.slides.export/htmloptions/htmloptions/#htmloptionshtmloptionssystemsharedptrilinkembedcontroller-constructor) constructor. The interface exposes three methods that control how resources are embedded or linked during HTML export:
+[ILinkEmbedController](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/) lets your application decide, resource by resource, whether the exporter embeds the data in the HTML or saves it externally and writes a link.
 
-[GetObjectStoringLocation(id, entityData, semanticName, contentType, recommendedExtension)](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/getobjectstoringlocation): Called when the exporter encounters a resource and must decide where to store it. The most important parameters are `id` (the resource’s unique identifier for this export run) and `contentType` (the resource MIME type). Return [LinkEmbedDecision.Link](https://reference.aspose.com/slides/cpp/aspose.slides.export/linkembeddecision/) to link the resource, or [LinkEmbedDecision.Embed](https://reference.aspose.com/slides/cpp/aspose.slides.export/linkembeddecision/) to embed it.
+The interface has three methods:
 
-[GetUrl(id, referrer)](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/geturl/): Returns the URL that will appear in the resulting HTML for the resource identified by `id` (optionally considering the referrer object).
+- [ILinkEmbedController::GetObjectStoringLocation](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/getobjectstoringlocation/) decides whether a resource should be linked or embedded.
+- [ILinkEmbedController::GetUrl](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/geturl/) returns the URL that will be written to the generated HTML or to another linked resource.
+- [ILinkEmbedController::SaveExternal](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/saveexternal/) writes the linked resource data to disk or to another storage target.
 
-[SaveExternal(id, entityData)](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/saveexternal/): Called when a resource selected for linking needs to be written externally. Because the identifier and contents are provided (as a byte array), you can persist the resource however you like.
+The file system path and the browser URL are separate concerns. For example, the sample below writes resource files to `html-output/assets` on disk, while the HTML contains relative URLs such as `assets/resource-1.svg`. A browser resolves those URLs relative to the file that contains the link. Therefore, a link from `presentation.html` to an SVG file uses `assets/resource-1.svg`, while a link from that SVG file to an image saved in the same `assets` folder uses `resource-4.jpg`.
 
-The C++ `LinkController` implementation of [ILinkEmbedController](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/) follows below.
+## **Export HTML with Linked Resources**
+
+The following C++ example creates an output directory, saves the HTML file there, and stores linked resources in an `assets` subdirectory. The controller links common image, font, audio, video, and CSS resources when Aspose.Slides provides or can infer a safe file extension. Resources that are not recognized remain embedded.
 
 ```cpp
-class LinkController : public ILinkEmbedController
+class ExternalResourceController : public ILinkEmbedController
 {
 public:
-    // Initializes a new instance of the LinkController class.
-    LinkController()
+    ExternalResourceController(String assetDirectory, String assetUrlPrefix)
     {
-        m_externalImages = System::MakeObject<Dictionary<int32_t, String>>();
-    }
-
-    // Initializes a new instance of the LinkController class and sets the path where generated resource files will be saved.
-    // savePath - Path to the location where generated resource files will be stored.
-    LinkController::LinkController(String savePath) : LinkController()
-    {
-        m_savePath = savePath;
-    }
-
-    // Determines whether to embed the resource or store it externally.
-    // id - A unique identifier for each object during the export operation.
-    LinkEmbedDecision GetObjectStoringLocation(int32_t id, ArrayPtr<uint8_t> entityData, 
-        String semanticName, String contentType, String recomendedExtension) override
-    {
-        String template_;
-
-        // The s_templates dictionary maps content types to file name templates for resources stored externally.
-        if (s_templates->TryGetValue(contentType, template_))
+        if (IsNullOrWhiteSpace(assetDirectory))
         {
-            // Store this resource for external linking.
-            m_externalImages->Add(id, template_);
-            return LinkEmbedDecision::Link;
+            throw Exception(u"The asset output directory must not be empty.");
         }
 
-        // All other resources are embedded.
-        return LinkEmbedDecision::Embed;
+        m_assetDirectory = assetDirectory;
+        m_assetUrlPrefix = NormalizeUrlPrefix(assetUrlPrefix);
+        m_fileNamesByResourceId = MakeObject<Dictionary<int, String>>();
     }
 
-    // Builds the URL for a previously externalized resource.
-    // Constructs the resource reference to use in tags such as <img src="%result%">.
-    // Checks the dictionary to exclude resources that were not externalized.
-    // Also retrieves the corresponding file name template.
-    String GetUrl(int32_t id, int32_t referrer) override
+    LinkEmbedDecision GetObjectStoringLocation(
+        int resourceId,
+        ArrayPtr<uint8_t> entityData,
+        String semanticName,
+        String contentType,
+        String recommendedExtension) override
     {
-        String template_;
-        if (m_externalImages->TryGetValue(id, template_))
+        auto extension = ResolveExtension(contentType, recommendedExtension);
+        if (String::IsNullOrEmpty(extension))
         {
-            // Assumes resource files are stored alongside the HTML file.
-            // The image tag will look like <img src="image-1.png"> with the appropriate resource ID and extension.
-            String fileUrl = String::Format(template_, id);
-            return fileUrl;
+            return LinkEmbedDecision::Embed;
         }
 
-        // Return null for resources that remain embedded.
-        return nullptr;
+        auto fileName = String::Format(u"resource-{0}{1}", resourceId, extension);
+        m_fileNamesByResourceId->Add(resourceId, fileName);
+        return LinkEmbedDecision::Link;
     }
 
-    // Saves an externalized resource to disk.
-    // Checks the dictionary again. If the ID is not found, it indicates an error in GetObjectStoringLocation or GetUrl.
-    void SaveExternal(int32_t id, ArrayPtr<uint8_t> entityData) override
+    String GetUrl(int resourceId, int referrer) override
     {
-        // Here we actually save the resource files to disk.
-        // Once again, checking the dictionary. If the id is not found here it is a sign of an error in GetObjectStoringLocation or GetUrl methods.
-        if (m_externalImages->ContainsKey(id))
+        String fileName;
+        if (!m_fileNamesByResourceId->TryGetValue(resourceId, fileName))
         {
-            // Uses the stored file name template and combines it with the target path.
-            // Constructs the file name using the stored template and the ID.
-            String fileName = String::Format(m_externalImages->idx_get(id), id);
-            
-            // Combines it with the destination directory.
-            const String savePath = m_savePath != nullptr ? m_savePath : String::Empty;
-            String filePath = Path::Combine(savePath, fileName);
+            return nullptr;
+        }
 
-            auto fs = System::MakeObject<FileStream>(filePath, FileMode::Create);
-            fs->Write(entityData, 0, entityData->get_Length());
-        }
-        else
+        if (m_fileNamesByResourceId->ContainsKey(referrer))
         {
-            throw Exception(u"Something is wrong.");
+            return fileName;
         }
+
+        return m_assetUrlPrefix + fileName;
+    }
+
+    void SaveExternal(int resourceId, ArrayPtr<uint8_t> entityData) override
+    {
+        String fileName;
+        if (!m_fileNamesByResourceId->TryGetValue(resourceId, fileName))
+        {
+            auto message = String::Format(u"Resource {0} was not registered for external storage.", resourceId);
+            throw Exception(message);
+        }
+
+        if (entityData == nullptr || entityData->get_Length() == 0)
+        {
+            auto message = String::Format(u"Resource {0} contains no data and cannot be saved.", resourceId);
+            throw Exception(message);
+        }
+
+        Directory::CreateDirectory_(m_assetDirectory);
+
+        auto filePath = Path::Combine(m_assetDirectory, fileName);
+        auto fileStream = MakeObject<FileStream>(filePath, FileMode::Create, FileAccess::Write);
+        fileStream->Write(entityData, 0, entityData->get_Length());
+        fileStream->Close();
     }
 
 private:
-    // The path where generated resource files are saved.
-    String m_savePath;
+    String m_assetDirectory;
+    String m_assetUrlPrefix;
+    SharedPtr<Dictionary<int, String>> m_fileNamesByResourceId;
 
-    // A dictionary mapping resource IDs to file name templates.
-    SharedPtr<Dictionary<int32_t, String>> m_externalImages;
-
-    // A dictionary mapping content types of externally stored resources to file name templates.
-    static SharedPtr<Dictionary<String, String>> s_templates;
-
-    static struct __StaticConstructor__
+    static SharedPtr<Dictionary<String, String>> GetExtensionsByContentType()
     {
-        __StaticConstructor__()
+        auto extensionsByContentType = MakeObject<Dictionary<String, String>>();
+        extensionsByContentType->Add(u"image/jpeg", u".jpg");
+        extensionsByContentType->Add(u"image/png", u".png");
+        extensionsByContentType->Add(u"image/gif", u".gif");
+        extensionsByContentType->Add(u"image/bmp", u".bmp");
+        extensionsByContentType->Add(u"image/svg+xml", u".svg");
+        extensionsByContentType->Add(u"image/tiff", u".tiff");
+        extensionsByContentType->Add(u"image/x-emf", u".emf");
+        extensionsByContentType->Add(u"image/x-wmf", u".wmf");
+        extensionsByContentType->Add(u"font/woff", u".woff");
+        extensionsByContentType->Add(u"font/woff2", u".woff2");
+        extensionsByContentType->Add(u"font/ttf", u".ttf");
+        extensionsByContentType->Add(u"application/font-woff", u".woff");
+        extensionsByContentType->Add(u"application/vnd.ms-fontobject", u".eot");
+        extensionsByContentType->Add(u"application/x-font-ttf", u".ttf");
+        extensionsByContentType->Add(u"text/css", u".css");
+        extensionsByContentType->Add(u"audio/mpeg", u".mp3");
+        extensionsByContentType->Add(u"audio/mp4", u".m4a");
+        extensionsByContentType->Add(u"audio/wav", u".wav");
+        extensionsByContentType->Add(u"video/mp4", u".mp4");
+        extensionsByContentType->Add(u"video/webm", u".webm");
+        return extensionsByContentType;
+    }
+
+    static String ResolveExtension(String contentType, String recommendedExtension)
+    {
+        auto normalizedContentType = NormalizeContentType(contentType);
+        auto extensionsByContentType = GetExtensionsByContentType();
+
+        String mappedExtension;
+        if (!String::IsNullOrEmpty(normalizedContentType) &&
+            extensionsByContentType->TryGetValue(normalizedContentType, mappedExtension))
         {
-            s_templates->Add(u"image/jpeg", u"image-{0}.jpg");
-            s_templates->Add(u"image/png", u"image-{0}.png");
+            return mappedExtension;
         }
-    } s_constructor__;
+
+        if (!IsSupportedContentType(normalizedContentType))
+        {
+            return nullptr;
+        }
+
+        return NormalizeExtension(recommendedExtension);
+    }
+
+    static bool IsSupportedContentType(String contentType)
+    {
+        return !String::IsNullOrEmpty(contentType) &&
+            (contentType.StartsWith(u"image/") ||
+                contentType.StartsWith(u"font/") ||
+                contentType.StartsWith(u"audio/") ||
+                contentType.StartsWith(u"video/"));
+    }
+
+    static String NormalizeContentType(String contentType)
+    {
+        if (IsNullOrWhiteSpace(contentType))
+        {
+            return nullptr;
+        }
+
+        return contentType.Trim().ToLowerInvariant();
+    }
+
+    static String NormalizeExtension(String extension)
+    {
+        if (IsNullOrWhiteSpace(extension))
+        {
+            return nullptr;
+        }
+
+        auto extensionCharacters = extension.Trim();
+        if (extensionCharacters.StartsWith(u"."))
+        {
+            extensionCharacters = extensionCharacters.Substring(1);
+        }
+
+        if (String::IsNullOrEmpty(extensionCharacters))
+        {
+            return nullptr;
+        }
+
+        auto extensionLength = extensionCharacters.get_Length();
+        for (int index = 0; index < extensionLength; index++)
+        {
+            auto character = extensionCharacters[index];
+            if (!Char::IsLetterOrDigit(character))
+            {
+                return nullptr;
+            }
+        }
+
+        return u"." + extensionCharacters.ToLowerInvariant();
+    }
+
+    static String NormalizeUrlPrefix(String urlPrefix)
+    {
+        if (String::IsNullOrEmpty(urlPrefix))
+        {
+            return String::Empty;
+        }
+
+        auto normalizedUrlPrefix = urlPrefix.Replace(u"\\", u"/");
+        if (normalizedUrlPrefix.EndsWith(u"/"))
+        {
+            return normalizedUrlPrefix;
+        }
+
+        return normalizedUrlPrefix + u"/";
+    }
+
+    static bool IsNullOrWhiteSpace(String value)
+    {
+        return String::IsNullOrEmpty(value) || String::IsNullOrEmpty(value.Trim());
+    }
 };
 ```
-
-After implementing the `LinkController` class, you can use it with the [HtmlOptions](https://reference.aspose.com/slides/cpp/aspose.slides.export/htmloptions/htmloptions/) class to export the presentation to HTML with externally linked images, as shown below:
-
 ```cpp
-auto presentation = MakeObject<Presentation>(u"C:\\data\\input.pptx");
+auto inputFilePath = String(u"presentation.pptx");
+auto outputDirectory = String(u"html-output");
+auto assetDirectoryName = String(u"assets");
+auto assetDirectory = Path::Combine(outputDirectory, assetDirectoryName);
 
-auto htmlOptions = MakeObject<HtmlOptions>(MakeObject<LinkController>(u"C:\\data\\out\\"));
-htmlOptions->set_SlideImageFormat(SlideImageFormat::Svg(MakeObject<SVGOptions>()));
-// This line hides slide titles in the generated HTML.
-// Comment it out if you prefer slide titles to be displayed.
+Directory::CreateDirectory_(outputDirectory);
+Directory::CreateDirectory_(assetDirectory);
+
+auto assetUrlPrefix = assetDirectoryName + u"/";
+auto controller = MakeObject<ExternalResourceController>(assetDirectory, assetUrlPrefix);
+auto svgOptions = MakeObject<SVGOptions>(controller);
+auto slideImageFormat = SlideImageFormat::Svg(svgOptions);
+
+auto htmlOptions = MakeObject<HtmlOptions>(controller);
 htmlOptions->set_HtmlFormatter(HtmlFormatter::CreateDocumentFormatter(String::Empty, false));
+htmlOptions->set_SlideImageFormat(slideImageFormat);
 
-presentation->Save(u"C:\\data\\out\\output.html", SaveFormat::Html, htmlOptions);
+auto presentation = MakeObject<Presentation>(inputFilePath);
+
+auto htmlFilePath = Path::Combine(outputDirectory, u"presentation.html");
+presentation->Save(htmlFilePath, SaveFormat::Html, htmlOptions);
 presentation->Dispose();
 ```
 
-We assigned `SlideImageFormat::Svg` to the `SlideImageFormat` property so that the resulting HTML file will contain SVG data to render the presentation’s contents.
+After the export, the output folder has this structure:
 
-Content types: If the presentation contains raster bitmaps, then the class code must be prepared to process both `image/jpeg` and `image/png` content types. The content of the exported bitmap images may not match what was stored in the presentation. Aspose.Slides’ internal algorithms perform size optimization and use either the JPEG or PNG codec (depending on which produces a smaller file size). Images containing an alpha channel (transparency) are always encoded as PNG.
+```text
+html-output/
+  presentation.html
+  assets/
+    resource-1.svg
+    resource-2.svg
+    resource-3.svg
+    resource-4.jpg
+    resource-5.png
+```
+
+The exact files depend on the presentation content and export options. For example, raster images are commonly exported as JPEG or PNG. Aspose.Slides may choose a different image codec than the one used in the source presentation when that produces a smaller or more suitable file. Images with transparency are exported as PNG.
+
+## **Choosing URLs for Deployment**
+
+The sample uses a relative URL prefix: `assets/`. If `presentation.html` is opened from `html-output/presentation.html`, the browser loads `html-output/assets/resource-1.svg`.
+
+When one linked resource refers to another linked resource, the sample uses the `referrer` parameter in [ILinkEmbedController::GetUrl](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/geturl/) and returns only the file name. For example, if `resource-1.svg` and `resource-4.jpg` are both in the `assets` folder, the SVG file should refer to `resource-4.jpg`, not to `assets/resource-4.jpg`.
+
+Use a different URL prefix when the files are deployed elsewhere:
+
+- Use `assets/` when the asset directory is next to the HTML file.
+- Use `../assets/` when the asset directory is one level above the HTML file.
+- Use `https://cdn.example.com/presentations/job-123/assets/` when the files are uploaded to a CDN or static file server.
+
+The URL returned by [ILinkEmbedController::GetUrl](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/geturl/) must match the final deployed location of the file written by [ILinkEmbedController::SaveExternal](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/saveexternal/). In server applications, use a unique output directory or object-storage prefix for each conversion job to avoid overwriting files from another export.
+
+## **When to Embed Instead**
+
+Embedded Base64 HTML is still useful when the output must be a single file, such as an email attachment, an offline preview, or a document that will be moved without a supporting asset folder. Linked resources are a better fit when the HTML will be served by a web application, stored in a CMS, optimized by a build pipeline, or cached by browsers independently from the HTML.
+
+## **FAQ**
+
+**Can I externalize only images and keep other resources embedded?**
+
+Yes. In [ILinkEmbedController::GetObjectStoringLocation](https://reference.aspose.com/slides/cpp/aspose.slides.export/ilinkembedcontroller/getobjectstoringlocation/), return `LinkEmbedDecision::Link` only for the content types you want to save as separate files, and return `LinkEmbedDecision::Embed` for everything else.
+
+**Why does the exported image extension differ from the source presentation?**
+
+Aspose.Slides may re-encode raster images during HTML export to improve size or browser compatibility. For example, an image from the source file may be written as JPEG or PNG depending on the rendered result.
+
+**Do relative URLs work after I move the HTML file?**
+
+Relative URLs work only when the same relative folder structure is preserved. If the HTML references `assets/resource-1.png`, the `assets` folder must stay next to the HTML file unless you generate a different URL prefix.
+
+**Should server applications reuse the same output folder?**
+
+No. Use a unique output directory or storage prefix for each conversion job. This avoids filename collisions and prevents one export from overwriting resources generated by another export.

--- a/en/java/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
+++ b/en/java/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
@@ -1,0 +1,308 @@
+---
+title: Export Presentations to HTML with Externally Linked Images
+type: docs
+weight: 100
+url: /java/exporting-presentations-to-html-with-externally-linked-images/
+keywords:
+- export PowerPoint
+- export OpenDocument
+- export presentation
+- export slide
+- export PPT
+- export PPTX
+- export ODP
+- PowerPoint to HTML
+- OpenDocument to HTML
+- presentation to HTML
+- slide to HTML
+- PPT to HTML
+- PPTX to HTML
+- ODP to HTML
+- linked image
+- externally linked image
+- linked resource
+- external resource
+- Java
+- Aspose.Slides
+description: "Export PowerPoint and OpenDocument presentations to HTML in Java using Aspose.Slides with images and other resources saved as external linked files."
+---
+
+## **Overview**
+
+By default, Aspose.Slides exports a presentation to a self-contained HTML file. Images and other resources are written directly into the HTML, usually as Base64 data. This is convenient when you need one portable file, but it is not always the best format for a website, a CMS, or a server-side conversion pipeline.
+
+Use externally linked resources when you want to:
+
+- reduce the size of the HTML document;
+- cache images, fonts, audio, or video separately in a browser or CDN;
+- inspect, replace, compress, or post-process generated resources after export;
+- keep the output structure closer to what a web application expects.
+
+For the general HTML conversion workflow, see [Convert PowerPoint Presentations to HTML](/slides/java/convert-powerpoint-to-html/). This article focuses on the resource-linking part of the export.
+
+## **How Linked Resource Export Works**
+
+[ILinkEmbedController](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/) lets your application decide, resource by resource, whether the exporter embeds the data in the HTML or saves it externally and writes a link.
+
+The interface has three methods:
+
+- [ILinkEmbedController.getObjectStoringLocation](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/) decides whether a resource should be linked or embedded.
+- [ILinkEmbedController.getUrl](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/) returns the URL that will be written to the generated HTML or to another linked resource.
+- [ILinkEmbedController.saveExternal](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/) writes the linked resource data to disk or to another storage target.
+
+The file system path and the browser URL are separate concerns. For example, the sample below writes resource files to `html-output/assets` on disk, while the HTML contains relative URLs such as `assets/resource-1.svg`. A browser resolves those URLs relative to the file that contains the link. Therefore, a link from `presentation.html` to an SVG file uses `assets/resource-1.svg`, while a link from that SVG file to an image saved in the same `assets` folder uses `resource-4.jpg`.
+
+## **Export HTML with Linked Resources**
+
+The following Java example creates an output directory, saves the HTML file there, and stores linked resources in an `assets` subdirectory. The controller links common image, font, audio, video, and CSS resources when Aspose.Slides provides or can infer a safe file extension. Resources that are not recognized remain embedded.
+
+```java
+import com.aspose.slides.HtmlFormatter;
+import com.aspose.slides.HtmlOptions;
+import com.aspose.slides.ILinkEmbedController;
+import com.aspose.slides.LinkEmbedDecision;
+import com.aspose.slides.Presentation;
+import com.aspose.slides.SVGOptions;
+import com.aspose.slides.SaveFormat;
+import com.aspose.slides.SlideImageFormat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public class ExportToHtmlWithLinkedResources {
+    public static void main(String[] args) throws IOException {
+        Path inputFilePath = Paths.get("presentation.pptx");
+        Path outputDirectory = Paths.get("html-output");
+        String assetDirectoryName = "assets";
+        Path assetDirectory = outputDirectory.resolve(assetDirectoryName);
+
+        Files.createDirectories(outputDirectory);
+        Files.createDirectories(assetDirectory);
+
+        String assetUrlPrefix = assetDirectoryName + "/";
+        ExternalResourceController controller = new ExternalResourceController(assetDirectory, assetUrlPrefix);
+        SVGOptions svgOptions = new SVGOptions(controller);
+        SlideImageFormat slideImageFormat = SlideImageFormat.svg(svgOptions);
+
+        HtmlOptions htmlOptions = new HtmlOptions(controller);
+        htmlOptions.setHtmlFormatter(HtmlFormatter.createDocumentFormatter("", false));
+        htmlOptions.setSlideImageFormat(slideImageFormat);
+
+        Presentation presentation = new Presentation(inputFilePath.toString());
+        try {
+            Path htmlFilePath = outputDirectory.resolve("presentation.html");
+            presentation.save(htmlFilePath.toString(), SaveFormat.Html, htmlOptions);
+        } finally {
+            presentation.dispose();
+        }
+    }
+
+    private static final class ExternalResourceController implements ILinkEmbedController {
+        private static final Map<String, String> EXTENSIONS_BY_CONTENT_TYPE = createExtensionsByContentType();
+
+        private final Path assetDirectory;
+        private final String assetUrlPrefix;
+        private final Map<Integer, String> fileNamesByResourceId = new HashMap<>();
+
+        private ExternalResourceController(Path assetDirectory, String assetUrlPrefix) {
+            if (assetDirectory == null) {
+                throw new IllegalArgumentException("The asset output directory must not be null.");
+            }
+
+            this.assetDirectory = assetDirectory;
+            this.assetUrlPrefix = normalizeUrlPrefix(assetUrlPrefix);
+        }
+
+        @Override
+        public int getObjectStoringLocation(
+                int resourceId,
+                byte[] entityData,
+                String semanticName,
+                String contentType,
+                String recommendedExtension) {
+            String extension = resolveExtension(contentType, recommendedExtension);
+            if (extension == null) {
+                return LinkEmbedDecision.Embed;
+            }
+
+            fileNamesByResourceId.put(resourceId, "resource-" + resourceId + extension);
+            return LinkEmbedDecision.Link;
+        }
+
+        @Override
+        public String getUrl(int resourceId, int referrer) {
+            String fileName = fileNamesByResourceId.get(resourceId);
+            if (fileName == null) {
+                return null;
+            }
+
+            if (fileNamesByResourceId.containsKey(referrer)) {
+                return fileName;
+            }
+
+            return assetUrlPrefix + fileName;
+        }
+
+        @Override
+        public void saveExternal(int resourceId, byte[] entityData) {
+            String fileName = fileNamesByResourceId.get(resourceId);
+            if (fileName == null) {
+                throw new IllegalStateException(
+                        "Resource " + resourceId + " was not registered for external storage.");
+            }
+
+            if (entityData == null || entityData.length == 0) {
+                throw new IllegalStateException(
+                        "Resource " + resourceId + " contains no data and cannot be saved.");
+            }
+
+            try {
+                Files.createDirectories(assetDirectory);
+                Path filePath = assetDirectory.resolve(fileName);
+                Files.write(filePath, entityData);
+            } catch (IOException exception) {
+                throw new IllegalStateException("Failed to save external resource " + resourceId + ".", exception);
+            }
+        }
+
+        private static Map<String, String> createExtensionsByContentType() {
+            Map<String, String> extensionsByContentType = new HashMap<>();
+            extensionsByContentType.put("image/jpeg", ".jpg");
+            extensionsByContentType.put("image/png", ".png");
+            extensionsByContentType.put("image/gif", ".gif");
+            extensionsByContentType.put("image/bmp", ".bmp");
+            extensionsByContentType.put("image/svg+xml", ".svg");
+            extensionsByContentType.put("image/tiff", ".tiff");
+            extensionsByContentType.put("image/x-emf", ".emf");
+            extensionsByContentType.put("image/x-wmf", ".wmf");
+            extensionsByContentType.put("font/woff", ".woff");
+            extensionsByContentType.put("font/woff2", ".woff2");
+            extensionsByContentType.put("font/ttf", ".ttf");
+            extensionsByContentType.put("application/font-woff", ".woff");
+            extensionsByContentType.put("application/vnd.ms-fontobject", ".eot");
+            extensionsByContentType.put("application/x-font-ttf", ".ttf");
+            extensionsByContentType.put("text/css", ".css");
+            extensionsByContentType.put("audio/mpeg", ".mp3");
+            extensionsByContentType.put("audio/mp4", ".m4a");
+            extensionsByContentType.put("audio/wav", ".wav");
+            extensionsByContentType.put("video/mp4", ".mp4");
+            extensionsByContentType.put("video/webm", ".webm");
+            return extensionsByContentType;
+        }
+
+        private static String resolveExtension(String contentType, String recommendedExtension) {
+            if (contentType != null && !contentType.trim().isEmpty()) {
+                String mappedExtension = EXTENSIONS_BY_CONTENT_TYPE.get(contentType);
+                if (mappedExtension != null) {
+                    return mappedExtension;
+                }
+            }
+
+            if (!isSupportedContentType(contentType)) {
+                return null;
+            }
+
+            return normalizeExtension(recommendedExtension);
+        }
+
+        private static boolean isSupportedContentType(String contentType) {
+            return contentType != null &&
+                    (contentType.regionMatches(true, 0, "image/", 0, "image/".length()) ||
+                     contentType.regionMatches(true, 0, "font/", 0, "font/".length()) ||
+                     contentType.regionMatches(true, 0, "audio/", 0, "audio/".length()) ||
+                     contentType.regionMatches(true, 0, "video/", 0, "video/".length()));
+        }
+
+        private static String normalizeExtension(String extension) {
+            if (extension == null || extension.trim().isEmpty()) {
+                return null;
+            }
+
+            String extensionCharacters = extension.trim();
+            while (extensionCharacters.startsWith(".")) {
+                extensionCharacters = extensionCharacters.substring(1);
+            }
+
+            if (extensionCharacters.isEmpty()) {
+                return null;
+            }
+
+            for (int index = 0; index < extensionCharacters.length(); index++) {
+                char character = extensionCharacters.charAt(index);
+                if (!Character.isLetterOrDigit(character)) {
+                    return null;
+                }
+            }
+
+            return "." + extensionCharacters.toLowerCase(Locale.ROOT);
+        }
+
+        private static String normalizeUrlPrefix(String urlPrefix) {
+            if (urlPrefix == null || urlPrefix.isEmpty()) {
+                return "";
+            }
+
+            String normalizedUrlPrefix = urlPrefix.replace('\\', '/');
+            return normalizedUrlPrefix.endsWith("/")
+                    ? normalizedUrlPrefix
+                    : normalizedUrlPrefix + "/";
+        }
+    }
+}
+```
+
+After the export, the output folder has this structure:
+
+```text
+html-output/
+  presentation.html
+  assets/
+    resource-1.svg
+    resource-2.svg
+    resource-3.svg
+    resource-4.jpg
+    resource-5.png
+```
+
+The exact files depend on the presentation content and export options. For example, raster images are commonly exported as JPEG or PNG. Aspose.Slides may choose a different image codec than the one used in the source presentation when that produces a smaller or more suitable file. Images with transparency are exported as PNG.
+
+## **Choosing URLs for Deployment**
+
+The sample uses a relative URL prefix: `assets/`. If `presentation.html` is opened from `html-output/presentation.html`, the browser loads `html-output/assets/resource-1.svg`.
+
+When one linked resource refers to another linked resource, the sample uses the `referrer` parameter in [ILinkEmbedController.getUrl](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/) and returns only the file name. For example, if `resource-1.svg` and `resource-4.jpg` are both in the `assets` folder, the SVG file should refer to `resource-4.jpg`, not to `assets/resource-4.jpg`.
+
+Use a different URL prefix when the files are deployed elsewhere:
+
+- Use `assets/` when the asset directory is next to the HTML file.
+- Use `../assets/` when the asset directory is one level above the HTML file.
+- Use `https://cdn.example.com/presentations/job-123/assets/` when the files are uploaded to a CDN or static file server.
+
+The URL returned by [ILinkEmbedController.getUrl](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/) must match the final deployed location of the file written by [ILinkEmbedController.saveExternal](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/). In server applications, use a unique output directory or object-storage prefix for each conversion job to avoid overwriting files from another export.
+
+## **When to Embed Instead**
+
+Embedded Base64 HTML is still useful when the output must be a single file, such as an email attachment, an offline preview, or a document that will be moved without a supporting asset folder. Linked resources are a better fit when the HTML will be served by a web application, stored in a CMS, optimized by a build pipeline, or cached by browsers independently from the HTML.
+
+## **FAQ**
+
+**Can I externalize only images and keep other resources embedded?**
+
+Yes. In [ILinkEmbedController.getObjectStoringLocation](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/), return `LinkEmbedDecision.Link` only for the content types you want to save as separate files, and return `LinkEmbedDecision.Embed` for everything else.
+
+**Why does the exported image extension differ from the source presentation?**
+
+Aspose.Slides may re-encode raster images during HTML export to improve size or browser compatibility. For example, an image from the source file may be written as JPEG or PNG depending on the rendered result.
+
+**Do relative URLs work after I move the HTML file?**
+
+Relative URLs work only when the same relative folder structure is preserved. If the HTML references `assets/resource-1.png`, the `assets` folder must stay next to the HTML file unless you generate a different URL prefix.
+
+**Should server applications reuse the same output folder?**
+
+No. Use a unique output directory or storage prefix for each conversion job. This avoids filename collisions and prevents one export from overwriting resources generated by another export.

--- a/en/net/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
+++ b/en/net/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
@@ -20,164 +20,273 @@ keywords:
 - ODP to HTML
 - linked image
 - externally linked image
+- linked resource
+- external resource
 - .NET
 - C#
 - Aspose.Slides
-description: "Export PowerPoint and OpenDocument presentations to HTML in .NET using Aspose.Slides with externally linked images—faster pages, code examples, and setup tips."
+description: "Export PowerPoint and OpenDocument presentations to HTML in .NET using Aspose.Slides with images and other resources saved as external linked files."
 ---
 
-{{% alert color="primary" %}} 
+## **Overview**
 
-The presentation-to-HTML export process lets you specify:
+By default, Aspose.Slides exports a presentation to a self-contained HTML file. Images and other resources are written directly into the HTML, usually as Base64 data. This is convenient when you need one portable file, but it is not always the best format for a website, a CMS, or a server-side conversion pipeline.
 
-1. which resources are embedded in the resulting HTML file, and
-1. which resources are saved externally and referenced from the HTML file.
+Use externally linked resources when you want to:
 
-{{% /alert %}} 
+- reduce the size of the HTML document;
+- cache images, fonts, audio, or video separately in a browser or CDN;
+- inspect, replace, compress, or post-process generated resources after export;
+- keep the output structure closer to what a web application expects.
 
-## **Background**
+For the general HTML conversion workflow, see [Convert PowerPoint Presentations to HTML](/slides/net/convert-powerpoint-to-html/). This article focuses on the resource-linking part of the export.
 
-By default, HTML export embeds all resources directly in the HTML using Base64 encoding. This produces a single, self-contained HTML file that’s convenient for viewing and distribution. However, this approach has drawbacks:
+## **How Linked Resource Export Works**
 
-* The resulting file is significantly larger than the original resources because of Base64 overhead.
-* Embedded images and other assets are difficult to update or replace.
+[ILinkEmbedController](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/) lets your application decide, resource by resource, whether the exporter embeds the data in the HTML or saves it externally and writes a link.
 
-## **Alternative Approach**
+The interface has three methods:
 
-An alternative approach using [ILinkEmbedController](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/) avoids these limitations.
+- [ILinkEmbedController.GetObjectStoringLocation](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/getobjectstoringlocation/) decides whether a resource should be linked or embedded.
+- [ILinkEmbedController.GetUrl](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/geturl/) returns the URL that will be written to the generated HTML or to another linked resource.
+- [ILinkEmbedController.SaveExternal](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/saveexternal/) writes the linked resource data to disk or to another storage target.
 
-The `LinkController` class below implements [ILinkEmbedController](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/) and is passed to the [HtmlOptions](https://reference.aspose.com/slides/net/aspose.slides.export/htmloptions/htmloptions/#constructor_1) constructor. The interface exposes three methods that control how resources are embedded or linked during HTML export:
+The file system path and the browser URL are separate concerns. For example, the sample below writes resource files to `html-output/assets` on disk, while the HTML contains relative URLs such as `assets/resource-1.svg`. A browser resolves those URLs relative to the file that contains the link. Therefore, a link from `presentation.html` to an SVG file uses `assets/resource-1.svg`, while a link from that SVG file to an image saved in the same `assets` folder uses `resource-4.jpg`.
 
-[GetObjectStoringLocation(id, entityData, semanticName, contentType, recommendedExtension)](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/getobjectstoringlocation): Called when the exporter encounters a resource and must decide where to store it. The most important parameters are `id` (the resource’s unique identifier for this export run) and `contentType` (the resource MIME type). Return [LinkEmbedDecision.Link](https://reference.aspose.com/slides/net/aspose.slides.export/linkembeddecision/) to link the resource, or [LinkEmbedDecision.Embed](https://reference.aspose.com/slides/net/aspose.slides.export/linkembeddecision/) to embed it.
+## **Export HTML with Linked Resources**
 
-[GetUrl(id, referrer)](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/geturl/): Returns the URL that will appear in the resulting HTML for the resource identified by `id` (optionally considering the referrer object).
+The following C# example creates an output directory, saves the HTML file there, and stores linked resources in an `assets` subdirectory. The controller links common image, font, audio, video, and CSS resources when Aspose.Slides provides or can infer a safe file extension. Resources that are not recognized remain embedded.
 
-[SaveExternal(id, entityData)](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/saveexternal/): Called when a resource selected for linking needs to be written externally. Because the identifier and contents are provided (as a byte array), you can persist the resource however you like.
+```csharp
+using Aspose.Slides;
+using Aspose.Slides.Export;
+using System;
+using System.Collections.Generic;
+using System.IO;
 
-The C# `LinkController` implementation of [ILinkEmbedController](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/) follows below.
+var inputFilePath = "presentation.pptx";
+var outputDirectory = "html-output";
+var assetDirectoryName = "assets";
+var assetDirectory = Path.Combine(outputDirectory, assetDirectoryName);
 
-```cs
-class LinkController : ILinkEmbedController
+Directory.CreateDirectory(outputDirectory);
+Directory.CreateDirectory(assetDirectory);
+
+var assetUrlPrefix = assetDirectoryName + "/";
+var controller = new ExternalResourceController(assetDirectory, assetUrlPrefix);
+var svgOptions = new SVGOptions(controller);
+var slideImageFormat = SlideImageFormat.Svg(svgOptions);
+
+var htmlOptions = new HtmlOptions(controller)
 {
-    static LinkController()
-    {
-        s_templates.Add("image/jpeg", "image-{0}.jpg");
-        s_templates.Add("image/png", "image-{0}.png");
-    }
+    HtmlFormatter = HtmlFormatter.CreateDocumentFormatter(string.Empty, false),
+    SlideImageFormat = slideImageFormat
+};
 
-    /// <summary>
-    /// Initializes a new instance of the LinkController class.
-    /// </summary>
-    public LinkController()
-    {
-        m_externalImages = new Dictionary<int, string>();
-    }
+using var presentation = new Presentation(inputFilePath);
 
-    /// <summary>
-    /// Initializes a new instance of the LinkController class and sets the path where generated resource files will be saved.
-    /// </summary>
-    /// <param name="savePath">Path to the location where generated resource files will be stored.</param>
-    public LinkController(string savePath)
-        : this()
-    {
-        SavePath = savePath;
-    }
+var htmlFilePath = Path.Combine(outputDirectory, "presentation.html");
+presentation.Save(htmlFilePath, SaveFormat.Html, htmlOptions);
 
-    /// <summary>
-    /// Determines whether to embed the resource or store it externally.
-    /// </summary>
-    /// <param name="id">A unique identifier for each object during the export operation.</param>
-    public LinkEmbedDecision GetObjectStoringLocation(int id, byte[] entityData, string semanticName, string contentType, string recomendedExtension)
+public sealed class ExternalResourceController : ILinkEmbedController
+{
+    private static readonly Dictionary<string, string> ExtensionsByContentType = new(StringComparer.OrdinalIgnoreCase)
     {
-        string template;
+        ["image/jpeg"] = ".jpg",
+        ["image/png"] = ".png",
+        ["image/gif"] = ".gif",
+        ["image/bmp"] = ".bmp",
+        ["image/svg+xml"] = ".svg",
+        ["image/tiff"] = ".tiff",
+        ["image/x-emf"] = ".emf",
+        ["image/x-wmf"] = ".wmf",
+        ["font/woff"] = ".woff",
+        ["font/woff2"] = ".woff2",
+        ["font/ttf"] = ".ttf",
+        ["application/font-woff"] = ".woff",
+        ["application/vnd.ms-fontobject"] = ".eot",
+        ["application/x-font-ttf"] = ".ttf",
+        ["text/css"] = ".css",
+        ["audio/mpeg"] = ".mp3",
+        ["audio/mp4"] = ".m4a",
+        ["audio/wav"] = ".wav",
+        ["video/mp4"] = ".mp4",
+        ["video/webm"] = ".webm"
+    };
 
-        // The s_templates dictionary maps content types to file name templates for resources stored externally.
-        if (s_templates.TryGetValue(contentType, out template))
+    private readonly string assetDirectory;
+    private readonly string assetUrlPrefix;
+    private readonly Dictionary<int, string> fileNamesByResourceId = new();
+
+    public ExternalResourceController(string assetDirectory, string assetUrlPrefix)
+    {
+        if (string.IsNullOrWhiteSpace(assetDirectory))
         {
-            // Store this resource for external linking.
-            m_externalImages.Add(id, template);
-            return LinkEmbedDecision.Link;
+            throw new ArgumentException("The asset output directory must not be empty.", nameof(assetDirectory));
         }
 
-        // All other resources are embedded.
-        return LinkEmbedDecision.Embed;
+        this.assetDirectory = assetDirectory;
+        this.assetUrlPrefix = NormalizeUrlPrefix(assetUrlPrefix);
     }
 
-    /// <summary>
-    /// Builds the URL for a previously externalized resource.
-    /// Constructs the resource reference to use in tags such as <img src="%result%">.
-    /// Checks the dictionary to exclude resources that were not externalized.
-    /// Also retrieves the corresponding file name template.
-    /// </summary>
-    public string GetUrl(int id, int referrer)
+    public LinkEmbedDecision GetObjectStoringLocation(
+        int resourceId,
+        byte[] entityData,
+        string semanticName,
+        string contentType,
+        string recommendedExtension)
     {
-        string template;
-        if (m_externalImages.TryGetValue(id, out template))
+        var extension = ResolveExtension(contentType, recommendedExtension);
+        if (extension == null)
         {
-            // Assumes resource files are stored alongside the HTML file.
-            // The image tag will look like <img src="image-1.png"> with the appropriate resource ID and extension.
-            var fileUrl = String.Format(template, id);
-            return fileUrl;
+            return LinkEmbedDecision.Embed;
         }
 
-        // Return null for resources that remain embedded.
-        return null;
+        fileNamesByResourceId[resourceId] = $"resource-{resourceId}{extension}";
+        return LinkEmbedDecision.Link;
     }
 
-    /// <summary>
-    /// Saves an externalized resource to disk.
-    /// Checks the dictionary again. If the ID is not found, it indicates an error in GetObjectStoringLocation or GetUrl.
-    /// </summary>
-    public void SaveExternal(int id, byte[] entityData)
+    public string GetUrl(int resourceId, int referrer)
     {
-        if (m_externalImages.ContainsKey(id))
+        if (!fileNamesByResourceId.TryGetValue(resourceId, out var fileName))
         {
-            // Uses the stored file name template and combines it with the target path.
-            // Constructs the file name using the stored template and the ID.
-            var fileName = String.Format(m_externalImages[id], id);
-
-            // Combines it with the destination directory.
-            var filePath = Path.Combine(SavePath ?? String.Empty, fileName);
-
-            using (var fs = new FileStream(filePath, FileMode.Create))
-                fs.Write(entityData, 0, entityData.Length);
+            return null;
         }
-        else
-            throw new Exception("Something is wrong.");
+
+        if (fileNamesByResourceId.ContainsKey(referrer))
+        {
+            return fileName;
+        }
+
+        return assetUrlPrefix + fileName;
     }
 
-    /// <summary>
-    /// Gets or sets the path where generated resource files are saved.
-    /// </summary>
-    public string SavePath { get; set; }
+    public void SaveExternal(int resourceId, byte[] entityData)
+    {
+        if (!fileNamesByResourceId.TryGetValue(resourceId, out var fileName))
+        {
+            throw new InvalidOperationException(
+                $"Resource {resourceId} was not registered for external storage.");
+        }
 
-    /// <summary>
-    /// A dictionary mapping resource IDs to file name templates.
-    /// </summary>
-    private readonly Dictionary<int, string> m_externalImages;
+        if (entityData == null || entityData.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"Resource {resourceId} contains no data and cannot be saved.");
+        }
 
-    /// <summary>
-    /// A dictionary mapping content types of externally stored resources to file name templates.
-    /// </summary>
-    private static readonly Dictionary<string, string> s_templates = new Dictionary<string, string>();
+        Directory.CreateDirectory(assetDirectory);
+
+        var filePath = Path.Combine(assetDirectory, fileName);
+        File.WriteAllBytes(filePath, entityData);
+    }
+
+    private static string ResolveExtension(string contentType, string recommendedExtension)
+    {
+        if (!string.IsNullOrWhiteSpace(contentType) &&
+            ExtensionsByContentType.TryGetValue(contentType, out var mappedExtension))
+        {
+            return mappedExtension;
+        }
+
+        if (!IsSupportedContentType(contentType))
+        {
+            return null;
+        }
+
+        return NormalizeExtension(recommendedExtension);
+    }
+
+    private static bool IsSupportedContentType(string contentType)
+    {
+        return contentType != null &&
+            (contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase) ||
+             contentType.StartsWith("font/", StringComparison.OrdinalIgnoreCase) ||
+             contentType.StartsWith("audio/", StringComparison.OrdinalIgnoreCase) ||
+             contentType.StartsWith("video/", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizeExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            return null;
+        }
+
+        var extensionCharacters = extension.Trim().TrimStart('.');
+        foreach (var character in extensionCharacters)
+        {
+            if (!char.IsLetterOrDigit(character))
+            {
+                return null;
+            }
+        }
+
+        return "." + extensionCharacters.ToLowerInvariant();
+    }
+
+    private static string NormalizeUrlPrefix(string urlPrefix)
+    {
+        if (string.IsNullOrEmpty(urlPrefix))
+        {
+            return string.Empty;
+        }
+
+        var normalizedUrlPrefix = urlPrefix.Replace('\\', '/');
+        return normalizedUrlPrefix.EndsWith("/")
+            ? normalizedUrlPrefix
+            : normalizedUrlPrefix + "/";
+    }
 }
 ```
 
-After implementing the `LinkController` class, you can use it with the [HtmlOptions](https://reference.aspose.com/slides/net/aspose.slides.export/htmloptions/htmloptions/) class to export the presentation to HTML with externally linked images, as shown below:
+After the export, the output folder has this structure:
 
-```cs
-using (var presentation = new Presentation(@"C:\data\input.pptx"))
-{
-    var htmlOptions = new HtmlOptions(new LinkController(@"C:\data\out\"));
-    htmlOptions.SlideImageFormat = SlideImageFormat.Svg(new SVGOptions());
-    // This line hides slide titles in the generated HTML.
-    // Comment it out if you prefer slide titles to be displayed.
-    htmlOptions.HtmlFormatter = HtmlFormatter.CreateDocumentFormatter(String.Empty, false);
-
-    presentation.Save(@"C:\data\out\output.html", SaveFormat.Html, htmlOptions);
-}
+```text
+html-output/
+  presentation.html
+  assets/
+    resource-1.svg
+    resource-2.svg
+    resource-3.svg
+    resource-4.jpg
+    resource-5.png
 ```
 
-We assigned `SlideImageFormat.Svg` to the `SlideImageFormat` property so that the resulting HTML file will contain SVG data to render the presentation’s contents.
+The exact files depend on the presentation content and export options. For example, raster images are commonly exported as JPEG or PNG. Aspose.Slides may choose a different image codec than the one used in the source presentation when that produces a smaller or more suitable file. Images with transparency are exported as PNG.
 
-Content types: If the presentation contains raster bitmaps, then the class code must be prepared to process both `image/jpeg` and `image/png` content types. The content of the exported bitmap images may not match what was stored in the presentation. Aspose.Slides’ internal algorithms perform size optimization and use either the JPEG or PNG codec (depending on which produces a smaller file size). Images containing an alpha channel (transparency) are always encoded as PNG.
+## **Choosing URLs for Deployment**
+
+The sample uses a relative URL prefix: `assets/`. If `presentation.html` is opened from `html-output/presentation.html`, the browser loads `html-output/assets/resource-1.svg`.
+
+When one linked resource refers to another linked resource, the sample uses the `referrer` parameter in [ILinkEmbedController.GetUrl](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/geturl/) and returns only the file name. For example, if `resource-1.svg` and `resource-4.jpg` are both in the `assets` folder, the SVG file should refer to `resource-4.jpg`, not to `assets/resource-4.jpg`.
+
+Use a different URL prefix when the files are deployed elsewhere:
+
+- Use `assets/` when the asset directory is next to the HTML file.
+- Use `../assets/` when the asset directory is one level above the HTML file.
+- Use `https://cdn.example.com/presentations/job-123/assets/` when the files are uploaded to a CDN or static file server.
+
+The URL returned by [ILinkEmbedController.GetUrl](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/geturl/) must match the final deployed location of the file written by [ILinkEmbedController.SaveExternal](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/saveexternal/). In server applications, use a unique output directory or object-storage prefix for each conversion job to avoid overwriting files from another export.
+
+## **When to Embed Instead**
+
+Embedded Base64 HTML is still useful when the output must be a single file, such as an email attachment, an offline preview, or a document that will be moved without a supporting asset folder. Linked resources are a better fit when the HTML will be served by a web application, stored in a CMS, optimized by a build pipeline, or cached by browsers independently from the HTML.
+
+## **FAQ**
+
+**Can I externalize only images and keep other resources embedded?**
+
+Yes. In [ILinkEmbedController.GetObjectStoringLocation](https://reference.aspose.com/slides/net/aspose.slides.export/ilinkembedcontroller/getobjectstoringlocation/), return `LinkEmbedDecision.Link` only for the content types you want to save as separate files, and return `LinkEmbedDecision.Embed` for everything else.
+
+**Why does the exported image extension differ from the source presentation?**
+
+Aspose.Slides may re-encode raster images during HTML export to improve size or browser compatibility. For example, an image from the source file may be written as JPEG or PNG depending on the rendered result.
+
+**Do relative URLs work after I move the HTML file?**
+
+Relative URLs work only when the same relative folder structure is preserved. If the HTML references `assets/resource-1.png`, the `assets` folder must stay next to the HTML file unless you generate a different URL prefix.
+
+**Should server applications reuse the same output folder?**
+
+No. Use a unique output directory or storage prefix for each conversion job. This avoids filename collisions and prevents one export from overwriting resources generated by another export.

--- a/en/nodejs-java/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
+++ b/en/nodejs-java/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
@@ -1,0 +1,307 @@
+---
+title: Export Presentations to HTML with Externally Linked Images
+type: docs
+weight: 100
+url: /nodejs-java/exporting-presentations-to-html-with-externally-linked-images/
+keywords:
+- export PowerPoint
+- export OpenDocument
+- export presentation
+- export slide
+- export PPT
+- export PPTX
+- export ODP
+- PowerPoint to HTML
+- OpenDocument to HTML
+- presentation to HTML
+- slide to HTML
+- PPT to HTML
+- PPTX to HTML
+- ODP to HTML
+- linked image
+- externally linked image
+- linked resource
+- external resource
+- JavaScript
+- Node.js
+- Aspose.Slides
+description: "Export PowerPoint and OpenDocument presentations to HTML in JavaScript using Aspose.Slides for Node.js via Java with images and other resources saved as external linked files."
+---
+
+## **Overview**
+
+By default, Aspose.Slides exports a presentation to a self-contained HTML file. Images and other resources are written directly into the HTML, usually as Base64 data. This is convenient when you need one portable file, but it is not always the best format for a website, a CMS, or a server-side conversion pipeline.
+
+Use externally linked resources when you want to:
+
+- reduce the size of the HTML document;
+- cache images, fonts, audio, or video separately in a browser or CDN;
+- inspect, replace, compress, or post-process generated resources after export;
+- keep the output structure closer to what a web application expects.
+
+For the general HTML conversion workflow, see [Convert PowerPoint Presentations to HTML](/slides/nodejs-java/convert-powerpoint-to-html/). This article focuses on the resource-linking part of the export.
+
+## **How Linked Resource Export Works**
+
+A Java proxy for [ILinkEmbedController](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/) lets your application decide, resource by resource, whether the exporter embeds the data in the HTML or saves it externally and writes a link.
+
+The controller has three methods:
+
+- [ILinkEmbedController.getObjectStoringLocation](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/) decides whether a resource should be linked or embedded.
+- [ILinkEmbedController.getUrl](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/) returns the URL that will be written to the generated HTML or to another linked resource.
+- [ILinkEmbedController.saveExternal](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/) writes the linked resource data to disk or to another storage target.
+
+The file system path and the browser URL are separate concerns. For example, the sample below writes resource files to `html-output/assets` on disk, while the HTML contains relative URLs such as `assets/resource-1.svg`. A browser resolves those URLs relative to the file that contains the link. Therefore, a link from `presentation.html` to an SVG file uses `assets/resource-1.svg`, while a link from that SVG file to an image saved in the same `assets` folder uses `resource-4.jpg`.
+
+## **Export HTML with Linked Resources**
+
+The following JavaScript example creates an output directory, saves the HTML file there, and stores linked resources in an `assets` subdirectory. The controller links common image, font, audio, video, and CSS resources when Aspose.Slides provides or can infer a safe file extension. Resources that are not recognized remain embedded.
+
+```javascript
+var aspose = aspose || {};
+aspose.slides = require("aspose.slides.via.java");
+const java = require("java");
+const fs = require("fs");
+const path = require("path");
+
+class ExternalResourceController {
+    constructor(assetDirectory, assetUrlPrefix) {
+        if (assetDirectory == null || assetDirectory.trim().length === 0) {
+            throw new Error("The asset output directory must not be empty.");
+        }
+
+        this.assetDirectory = assetDirectory;
+        this.assetUrlPrefix = normalizeUrlPrefix(assetUrlPrefix);
+        this.fileNamesByResourceId = new Map();
+    }
+
+    createProxy() {
+        const linkEmbedControllerInterfaceName = "com.aspose.slides.ILinkEmbedController";
+        let controller = this;
+        return java.newProxy(linkEmbedControllerInterfaceName, {
+            getObjectStoringLocation: function(resourceId, entityData, semanticName, contentType, recommendedExtension) {
+                return controller.getObjectStoringLocation(
+                    resourceId,
+                    entityData,
+                    semanticName,
+                    contentType,
+                    recommendedExtension);
+            },
+            getUrl: function(resourceId, referrer) {
+                return controller.getUrl(resourceId, referrer);
+            },
+            saveExternal: function(resourceId, entityData) {
+                controller.saveExternal(resourceId, entityData);
+            }
+        });
+    }
+
+    getObjectStoringLocation(resourceId, entityData, semanticName, contentType, recommendedExtension) {
+        let extension = resolveExtension(contentType, recommendedExtension);
+        if (extension == null) {
+            return aspose.slides.LinkEmbedDecision.Embed;
+        }
+
+        this.fileNamesByResourceId.set(resourceId, "resource-" + resourceId + extension);
+        return aspose.slides.LinkEmbedDecision.Link;
+    }
+
+    getUrl(resourceId, referrer) {
+        let fileName = this.fileNamesByResourceId.get(resourceId);
+        if (fileName == null) {
+            return null;
+        }
+
+        if (this.fileNamesByResourceId.has(referrer)) {
+            return fileName;
+        }
+
+        return this.assetUrlPrefix + fileName;
+    }
+
+    saveExternal(resourceId, entityData) {
+        let fileName = this.fileNamesByResourceId.get(resourceId);
+        if (fileName == null) {
+            throw new Error("Resource " + resourceId + " was not registered for external storage.");
+        }
+
+        if (entityData == null || entityData.length === 0) {
+            throw new Error("Resource " + resourceId + " contains no data and cannot be saved.");
+        }
+
+        fs.mkdirSync(this.assetDirectory, { recursive: true });
+
+        let filePath = path.join(this.assetDirectory, fileName);
+        let fileData = Buffer.from(entityData);
+        fs.writeFileSync(filePath, fileData);
+    }
+}
+
+function createExtensionsByContentType() {
+    let extensionsByContentType = new Map();
+    extensionsByContentType.set("image/jpeg", ".jpg");
+    extensionsByContentType.set("image/png", ".png");
+    extensionsByContentType.set("image/gif", ".gif");
+    extensionsByContentType.set("image/bmp", ".bmp");
+    extensionsByContentType.set("image/svg+xml", ".svg");
+    extensionsByContentType.set("image/tiff", ".tiff");
+    extensionsByContentType.set("image/x-emf", ".emf");
+    extensionsByContentType.set("image/x-wmf", ".wmf");
+    extensionsByContentType.set("font/woff", ".woff");
+    extensionsByContentType.set("font/woff2", ".woff2");
+    extensionsByContentType.set("font/ttf", ".ttf");
+    extensionsByContentType.set("application/font-woff", ".woff");
+    extensionsByContentType.set("application/vnd.ms-fontobject", ".eot");
+    extensionsByContentType.set("application/x-font-ttf", ".ttf");
+    extensionsByContentType.set("text/css", ".css");
+    extensionsByContentType.set("audio/mpeg", ".mp3");
+    extensionsByContentType.set("audio/mp4", ".m4a");
+    extensionsByContentType.set("audio/wav", ".wav");
+    extensionsByContentType.set("video/mp4", ".mp4");
+    extensionsByContentType.set("video/webm", ".webm");
+    return extensionsByContentType;
+}
+
+let extensionsByContentType = createExtensionsByContentType();
+
+function resolveExtension(contentType, recommendedExtension) {
+    if (contentType != null && contentType.trim().length > 0) {
+        let mappedExtension = extensionsByContentType.get(contentType);
+        if (mappedExtension != null) {
+            return mappedExtension;
+        }
+    }
+
+    if (!isSupportedContentType(contentType)) {
+        return null;
+    }
+
+    return normalizeExtension(recommendedExtension);
+}
+
+function isSupportedContentType(contentType) {
+    if (contentType == null) {
+        return false;
+    }
+
+    let normalizedContentType = contentType.toLowerCase();
+    return normalizedContentType.startsWith("image/") ||
+        normalizedContentType.startsWith("font/") ||
+        normalizedContentType.startsWith("audio/") ||
+        normalizedContentType.startsWith("video/");
+}
+
+function normalizeExtension(extension) {
+    if (extension == null || extension.trim().length === 0) {
+        return null;
+    }
+
+    let extensionCharacters = extension.trim();
+    while (extensionCharacters.startsWith(".")) {
+        extensionCharacters = extensionCharacters.substring(1);
+    }
+
+    if (extensionCharacters.length === 0) {
+        return null;
+    }
+
+    for (let index = 0; index < extensionCharacters.length; index++) {
+        let character = extensionCharacters[index];
+        if (!/[A-Za-z0-9]/.test(character)) {
+            return null;
+        }
+    }
+
+    return "." + extensionCharacters.toLowerCase();
+}
+
+function normalizeUrlPrefix(urlPrefix) {
+    if (urlPrefix == null || urlPrefix.length === 0) {
+        return "";
+    }
+
+    let normalizedUrlPrefix = urlPrefix.replace(/\\/g, "/");
+    return normalizedUrlPrefix.endsWith("/")
+        ? normalizedUrlPrefix
+        : normalizedUrlPrefix + "/";
+}
+
+let inputFilePath = "presentation.pptx";
+let outputDirectory = "html-output";
+let assetDirectoryName = "assets";
+let assetDirectory = path.join(outputDirectory, assetDirectoryName);
+
+fs.mkdirSync(outputDirectory, { recursive: true });
+fs.mkdirSync(assetDirectory, { recursive: true });
+
+let assetUrlPrefix = assetDirectoryName + "/";
+let controllerWrapper = new ExternalResourceController(assetDirectory, assetUrlPrefix);
+let controller = controllerWrapper.createProxy();
+let svgOptions = new aspose.slides.SVGOptions(controller);
+let slideImageFormat = aspose.slides.SlideImageFormat.svg(svgOptions);
+
+let htmlOptions = new aspose.slides.HtmlOptions(controller);
+htmlOptions.setHtmlFormatter(aspose.slides.HtmlFormatter.createDocumentFormatter("", false));
+htmlOptions.setSlideImageFormat(slideImageFormat);
+
+let presentation = new aspose.slides.Presentation(inputFilePath);
+try {
+    let htmlFilePath = path.join(outputDirectory, "presentation.html");
+    presentation.save(htmlFilePath, aspose.slides.SaveFormat.Html, htmlOptions);
+} finally {
+    if (presentation != null) {
+        presentation.dispose();
+    }
+}
+```
+
+After the export, the output folder has this structure:
+
+```text
+html-output/
+  presentation.html
+  assets/
+    resource-1.svg
+    resource-2.svg
+    resource-3.svg
+    resource-4.jpg
+    resource-5.png
+```
+
+The exact files depend on the presentation content and export options. For example, raster images are commonly exported as JPEG or PNG. Aspose.Slides may choose a different image codec than the one used in the source presentation when that produces a smaller or more suitable file. Images with transparency are exported as PNG.
+
+## **Choosing URLs for Deployment**
+
+The sample uses a relative URL prefix: `assets/`. If `presentation.html` is opened from `html-output/presentation.html`, the browser loads `html-output/assets/resource-1.svg`.
+
+When one linked resource refers to another linked resource, the sample uses the `referrer` parameter in [ILinkEmbedController.getUrl](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/) and returns only the file name. For example, if `resource-1.svg` and `resource-4.jpg` are both in the `assets` folder, the SVG file should refer to `resource-4.jpg`, not to `assets/resource-4.jpg`.
+
+Use a different URL prefix when the files are deployed elsewhere:
+
+- Use `assets/` when the asset directory is next to the HTML file.
+- Use `../assets/` when the asset directory is one level above the HTML file.
+- Use `https://cdn.example.com/presentations/job-123/assets/` when the files are uploaded to a CDN or static file server.
+
+The URL returned by [ILinkEmbedController.getUrl](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/) must match the final deployed location of the file written by [ILinkEmbedController.saveExternal](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/). In server applications, use a unique output directory or object-storage prefix for each conversion job to avoid overwriting files from another export.
+
+## **When to Embed Instead**
+
+Embedded Base64 HTML is still useful when the output must be a single file, such as an email attachment, an offline preview, or a document that will be moved without a supporting asset folder. Linked resources are a better fit when the HTML will be served by a web application, stored in a CMS, optimized by a build pipeline, or cached by browsers independently from the HTML.
+
+## **FAQ**
+
+**Can I externalize only images and keep other resources embedded?**
+
+Yes. In [ILinkEmbedController.getObjectStoringLocation](https://reference.aspose.com/slides/java/com.aspose.slides/ilinkembedcontroller/), return `LinkEmbedDecision.Link` only for the content types you want to save as separate files, and return `LinkEmbedDecision.Embed` for everything else.
+
+**Why does the exported image extension differ from the source presentation?**
+
+Aspose.Slides may re-encode raster images during HTML export to improve size or browser compatibility. For example, an image from the source file may be written as JPEG or PNG depending on the rendered result.
+
+**Do relative URLs work after I move the HTML file?**
+
+Relative URLs work only when the same relative folder structure is preserved. If the HTML references `assets/resource-1.png`, the `assets` folder must stay next to the HTML file unless you generate a different URL prefix.
+
+**Should server applications reuse the same output folder?**
+
+No. Use a unique output directory or storage prefix for each conversion job. This avoids filename collisions and prevents one export from overwriting resources generated by another export.

--- a/en/php-java/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
+++ b/en/php-java/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
@@ -1,0 +1,310 @@
+---
+title: Export Presentations to HTML with Externally Linked Images
+type: docs
+weight: 100
+url: /php-java/exporting-presentations-to-html-with-externally-linked-images/
+keywords:
+- export PowerPoint
+- export OpenDocument
+- export presentation
+- export slide
+- export PPT
+- export PPTX
+- export ODP
+- PowerPoint to HTML
+- OpenDocument to HTML
+- presentation to HTML
+- slide to HTML
+- PPT to HTML
+- PPTX to HTML
+- ODP to HTML
+- linked image
+- externally linked image
+- linked resource
+- external resource
+- PHP
+- Aspose.Slides
+description: "Export PowerPoint and OpenDocument presentations to HTML in PHP via Java using Aspose.Slides with images and other resources saved as external linked files."
+---
+
+## **Overview**
+
+By default, Aspose.Slides exports a presentation to a self-contained HTML file. Images and other resources are written directly into the HTML, usually as Base64 data. This is convenient when you need one portable file, but it is not always the best format for a website, a CMS, or a server-side conversion pipeline.
+
+Use externally linked resources when you want to:
+
+- reduce the size of the HTML document;
+- cache images, fonts, audio, or video separately in a browser or CDN;
+- inspect, replace, compress, or post-process generated resources after export;
+- keep the output structure closer to what a web application expects.
+
+For the general HTML conversion workflow, see [Convert PowerPoint Presentations to HTML](/slides/php-java/convert-powerpoint-to-html/). This article focuses on the resource-linking part of the export.
+
+## **How Linked Resource Export Works**
+
+[HtmlOptions](https://reference.aspose.com/slides/php-java/aspose.slides/htmloptions/) can use a custom link/embed controller when Aspose.Slides exports a presentation to HTML. In PHP via Java, this scenario is usually implemented with a small Java helper class. Compile that helper, add it to the PHP Java Bridge classpath, and instantiate it from PHP with `new Java(...)`.
+
+The helper class decides, resource by resource, whether the exporter embeds the data in the HTML or saves it externally and writes a link. It needs three callback methods:
+
+- `ExternalResourceController.getObjectStoringLocation` decides whether a resource should be linked or embedded.
+- `ExternalResourceController.getUrl` returns the URL that will be written to the generated HTML or to another linked resource.
+- `ExternalResourceController.saveExternal` writes the linked resource data to disk or to another storage target.
+
+The file system path and the browser URL are separate concerns. For example, the sample below writes resource files to `html-output/assets` on disk, while the HTML contains relative URLs such as `assets/resource-1.svg`. A browser resolves those URLs relative to the file that contains the link. Therefore, a link from `presentation.html` to an SVG file uses `assets/resource-1.svg`, while a link from that SVG file to an image saved in the same `assets` folder uses `resource-4.jpg`.
+
+## **Create the Java Helper Class**
+
+Create a Java class such as `com.example.slides.ExternalResourceController`, compile it with Aspose.Slides for Java on the classpath, and make the compiled class or JAR available to PHP Java Bridge.
+
+The helper below links common image, font, audio, video, and CSS resources when Aspose.Slides provides or can infer a safe file extension. Resources that are not recognized remain embedded.
+
+```java
+package com.example.slides;
+
+import com.aspose.slides.ILinkEmbedController;
+import com.aspose.slides.LinkEmbedDecision;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public final class ExternalResourceController implements ILinkEmbedController {
+    private static final Map<String, String> EXTENSIONS_BY_CONTENT_TYPE = createExtensionMap();
+
+    private final Path assetDirectory;
+    private final String assetUrlPrefix;
+    private final Map<Integer, String> fileNamesByResourceId = new HashMap<>();
+
+    public ExternalResourceController(String assetDirectory, String assetUrlPrefix) {
+        if (assetDirectory == null || assetDirectory.trim().isEmpty()) {
+            throw new IllegalArgumentException("The asset output directory must not be empty.");
+        }
+
+        this.assetDirectory = Paths.get(assetDirectory);
+        this.assetUrlPrefix = normalizeUrlPrefix(assetUrlPrefix);
+    }
+
+    @Override
+    public int getObjectStoringLocation(
+            int resourceId,
+            byte[] entityData,
+            String semanticName,
+            String contentType,
+            String recommendedExtension) {
+        String extension = resolveExtension(contentType, recommendedExtension);
+        if (extension == null) {
+            return LinkEmbedDecision.Embed;
+        }
+
+        fileNamesByResourceId.put(resourceId, "resource-" + resourceId + extension);
+        return LinkEmbedDecision.Link;
+    }
+
+    @Override
+    public String getUrl(int resourceId, int referrer) {
+        String fileName = fileNamesByResourceId.get(resourceId);
+        if (fileName == null) {
+            return null;
+        }
+
+        if (fileNamesByResourceId.containsKey(referrer)) {
+            return fileName;
+        }
+
+        return assetUrlPrefix + fileName;
+    }
+
+    @Override
+    public void saveExternal(int resourceId, byte[] entityData) {
+        String fileName = fileNamesByResourceId.get(resourceId);
+        if (fileName == null) {
+            throw new IllegalStateException(
+                    "Resource " + resourceId + " was not registered for external storage.");
+        }
+
+        if (entityData == null || entityData.length == 0) {
+            throw new IllegalStateException(
+                    "Resource " + resourceId + " contains no data and cannot be saved.");
+        }
+
+        Path filePath = assetDirectory.resolve(fileName);
+        try {
+            Files.createDirectories(assetDirectory);
+            Files.write(filePath, entityData);
+        } catch (IOException exception) {
+            throw new IllegalStateException(
+                    "Could not save linked resource " + resourceId + " to " + filePath + ".",
+                    exception);
+        }
+    }
+
+    private static Map<String, String> createExtensionMap() {
+        Map<String, String> extensions = new HashMap<>();
+        extensions.put("image/jpeg", ".jpg");
+        extensions.put("image/png", ".png");
+        extensions.put("image/gif", ".gif");
+        extensions.put("image/bmp", ".bmp");
+        extensions.put("image/svg+xml", ".svg");
+        extensions.put("image/tiff", ".tiff");
+        extensions.put("image/x-emf", ".emf");
+        extensions.put("image/x-wmf", ".wmf");
+        extensions.put("font/woff", ".woff");
+        extensions.put("font/woff2", ".woff2");
+        extensions.put("font/ttf", ".ttf");
+        extensions.put("application/font-woff", ".woff");
+        extensions.put("application/vnd.ms-fontobject", ".eot");
+        extensions.put("application/x-font-ttf", ".ttf");
+        extensions.put("text/css", ".css");
+        extensions.put("audio/mpeg", ".mp3");
+        extensions.put("audio/mp4", ".m4a");
+        extensions.put("audio/wav", ".wav");
+        extensions.put("video/mp4", ".mp4");
+        extensions.put("video/webm", ".webm");
+        return extensions;
+    }
+
+    private static String resolveExtension(String contentType, String recommendedExtension) {
+        if (contentType != null && !contentType.trim().isEmpty()) {
+            String mappedExtension = EXTENSIONS_BY_CONTENT_TYPE.get(contentType);
+            if (mappedExtension != null) {
+                return mappedExtension;
+            }
+        }
+
+        if (!isSupportedContentType(contentType)) {
+            return null;
+        }
+
+        return normalizeExtension(recommendedExtension);
+    }
+
+    private static boolean isSupportedContentType(String contentType) {
+        return contentType != null &&
+                (contentType.regionMatches(true, 0, "image/", 0, 6) ||
+                 contentType.regionMatches(true, 0, "font/", 0, 5) ||
+                 contentType.regionMatches(true, 0, "audio/", 0, 6) ||
+                 contentType.regionMatches(true, 0, "video/", 0, 6));
+    }
+
+    private static String normalizeExtension(String extension) {
+        if (extension == null || extension.trim().isEmpty()) {
+            return null;
+        }
+
+        String extensionCharacters = extension.trim();
+        while (extensionCharacters.startsWith(".")) {
+            extensionCharacters = extensionCharacters.substring(1);
+        }
+
+        for (int characterIndex = 0; characterIndex < extensionCharacters.length(); characterIndex++) {
+            if (!Character.isLetterOrDigit(extensionCharacters.charAt(characterIndex))) {
+                return null;
+            }
+        }
+
+        return "." + extensionCharacters.toLowerCase(Locale.ROOT);
+    }
+
+    private static String normalizeUrlPrefix(String urlPrefix) {
+        if (urlPrefix == null || urlPrefix.isEmpty()) {
+            return "";
+        }
+
+        String normalizedUrlPrefix = urlPrefix.replace('\\', '/');
+        return normalizedUrlPrefix.endsWith("/")
+                ? normalizedUrlPrefix
+                : normalizedUrlPrefix + "/";
+    }
+}
+```
+
+## **Export HTML with Linked Resources**
+
+The following PHP code creates an output directory, saves the HTML file there, and stores linked resources in an `assets` subdirectory. It combines [HtmlOptions](https://reference.aspose.com/slides/php-java/aspose.slides/htmloptions/), [SVGOptions](https://reference.aspose.com/slides/php-java/aspose.slides/svgoptions/), [SlideImageFormat](https://reference.aspose.com/slides/php-java/aspose.slides/slideimageformat/), and [SaveFormat](https://reference.aspose.com/slides/php-java/aspose.slides/saveformat/) for the export.
+
+```php
+$inputFilePath = "presentation.pptx";
+$outputDirectory = "html-output";
+$assetDirectoryName = "assets";
+$assetDirectory = $outputDirectory . DIRECTORY_SEPARATOR . $assetDirectoryName;
+
+if (!is_dir($outputDirectory) && !mkdir($outputDirectory, 0777, true)) {
+    throw new RuntimeException("Could not create the HTML output directory: " . $outputDirectory);
+}
+
+if (!is_dir($assetDirectory) && !mkdir($assetDirectory, 0777, true)) {
+    throw new RuntimeException("Could not create the asset output directory: " . $assetDirectory);
+}
+
+$assetUrlPrefix = $assetDirectoryName . "/";
+$controller = new Java("com.example.slides.ExternalResourceController", $assetDirectory, $assetUrlPrefix);
+$svgOptions = new SVGOptions($controller);
+$slideImageFormat = SlideImageFormat::svg($svgOptions);
+
+$htmlOptions = new HtmlOptions($controller);
+$htmlFormatter = java("com.aspose.slides.HtmlFormatter")->createDocumentFormatter("", false);
+$htmlOptions->setHtmlFormatter($htmlFormatter);
+$htmlOptions->setSlideImageFormat($slideImageFormat);
+
+$presentation = new Presentation($inputFilePath);
+try {
+    $htmlFilePath = $outputDirectory . DIRECTORY_SEPARATOR . "presentation.html";
+    $presentation->save($htmlFilePath, SaveFormat::Html, $htmlOptions);
+} finally {
+    $presentation->dispose();
+}
+```
+
+After the export, the output folder has this structure:
+
+```text
+html-output/
+  presentation.html
+  assets/
+    resource-1.svg
+    resource-2.svg
+    resource-3.svg
+    resource-4.jpg
+    resource-5.png
+```
+
+The exact files depend on the presentation content and export options. For example, raster images are commonly exported as JPEG or PNG. Aspose.Slides may choose a different image codec than the one used in the source presentation when that produces a smaller or more suitable file. Images with transparency are exported as PNG.
+
+## **Choosing URLs for Deployment**
+
+The sample uses a relative URL prefix: `assets/`. If `presentation.html` is opened from `html-output/presentation.html`, the browser loads `html-output/assets/resource-1.svg`.
+
+When one linked resource refers to another linked resource, the sample uses the `referrer` parameter in `ExternalResourceController.getUrl` and returns only the file name. For example, if `resource-1.svg` and `resource-4.jpg` are both in the `assets` folder, the SVG file should refer to `resource-4.jpg`, not to `assets/resource-4.jpg`.
+
+Use a different URL prefix when the files are deployed elsewhere:
+
+- Use `assets/` when the asset directory is next to the HTML file.
+- Use `../assets/` when the asset directory is one level above the HTML file.
+- Use `https://cdn.example.com/presentations/job-123/assets/` when the files are uploaded to a CDN or static file server.
+
+The URL returned by `ExternalResourceController.getUrl` must match the final deployed location of the file written by `ExternalResourceController.saveExternal`. In server applications, use a unique output directory or object-storage prefix for each conversion job to avoid overwriting files from another export.
+
+## **When to Embed Instead**
+
+Embedded Base64 HTML is still useful when the output must be a single file, such as an email attachment, an offline preview, or a document that will be moved without a supporting asset folder. Linked resources are a better fit when the HTML will be served by a web application, stored in a CMS, optimized by a build pipeline, or cached by browsers independently from the HTML.
+
+## **FAQ**
+
+**Can I externalize only images and keep other resources embedded?**
+
+Yes. In `ExternalResourceController.getObjectStoringLocation`, return the `Link` value from [LinkEmbedDecision](https://reference.aspose.com/slides/php-java/aspose.slides/linkembeddecision/) only for the content types you want to save as separate files, and return the `Embed` value for everything else.
+
+**Why does the exported image extension differ from the source presentation?**
+
+Aspose.Slides may re-encode raster images during HTML export to improve size or browser compatibility. For example, an image from the source file may be written as JPEG or PNG depending on the rendered result.
+
+**Do relative URLs work after I move the HTML file?**
+
+Relative URLs work only when the same relative folder structure is preserved. If the HTML references `assets/resource-1.png`, the `assets` folder must stay next to the HTML file unless you generate a different URL prefix.
+
+**Should server applications reuse the same output folder?**
+
+No. Use a unique output directory or storage prefix for each conversion job. This avoids filename collisions and prevents one export from overwriting resources generated by another export.

--- a/en/python-net/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
+++ b/en/python-net/developer-guide/technical-articles/exporting-presentations-to-html-with-externally-linked-images/_index.md
@@ -21,51 +21,179 @@ keywords:
 - ODP to HTML
 - linked image
 - externally linked image
+- linked resource
+- external resource
 - Python
 - Aspose.Slides
-description: "Learn how to export presentations to HTML with externally linked images in Aspose.Slides for Python via .NET, covering PowerPoint and OpenDocument formats."
+description: "Export PowerPoint and OpenDocument presentations to HTML in Python using Aspose.Slides with images saved as external linked files."
 ---
 
-{{% alert color="primary" %}} 
+## **Overview**
 
-The presentation-to-HTML export process lets you specify:
+By default, Aspose.Slides exports a presentation to a self-contained HTML file. Images and other resources are written directly into the HTML, usually as Base64 data. This is convenient when you need one portable file, but it is not always the best format for a website, a CMS, or a server-side conversion pipeline.
 
-1. which resources are embedded in the resulting HTML file, and
-1. which resources are saved externally and referenced from the HTML file.
+Use externally linked images when you want to:
 
-{{% /alert %}} 
+- reduce the size of the HTML document;
+- cache images separately in a browser or CDN;
+- inspect, replace, compress, or post-process generated images after export;
+- keep the output structure closer to what a web application expects.
 
-## **Background**
+For the general HTML conversion workflow, see [Convert PowerPoint Presentations to HTML](/slides/python-net/convert-powerpoint-to-html/). This article focuses on the image-linking part of the export.
 
-By default, HTML export embeds all resources directly in the HTML using Base64 encoding. This produces a single, self-contained HTML file that’s convenient for viewing and distribution. However, this approach has drawbacks:
+## **How Linked Image Export Works**
 
-* The resulting file is significantly larger than the original resources because of Base64 overhead.
-* Embedded images and other assets are difficult to update or replace.
+In .NET and Java, [ILinkEmbedController](https://reference.aspose.com/slides/python-net/aspose.slides.export/ilinkembedcontroller/) represents the callback interface used by the exporter to decide whether a resource should be embedded or linked. In Python via .NET, Python classes cannot currently implement this .NET callback interface directly, so the practical workflow is:
 
-## **Alternative Approach**
+1. Export the presentation to HTML with [HtmlOptions](https://reference.aspose.com/slides/python-net/aspose.slides.export/htmloptions/).
+1. Use [SlideImageFormat](https://reference.aspose.com/slides/python-net/aspose.slides.export/slideimageformat/) with [SVGOptions](https://reference.aspose.com/slides/python-net/aspose.slides.export/svgoptions/) so the slides are represented as SVG in the HTML.
+1. Move Base64 image data from HTML `data:` URLs into separate files.
+1. Replace the original `data:` URLs with relative links such as `assets/resource-1.jpg`.
 
-An alternative approach using [ILinkEmbedController](https://reference.aspose.com/slides/python-net/aspose.slides.export/ilinkembedcontroller/) avoids these limitations.
+The file system path and the browser URL are separate concerns. For example, the sample below writes image files to `html-output/assets` on disk, while the HTML contains relative URLs such as `assets/resource-1.jpg`. A browser resolves those URLs relative to the HTML file that contains the link.
 
-The `LinkController` class below implements [ILinkEmbedController](https://reference.aspose.com/slides/python-net/aspose.slides.export/ilinkembedcontroller/) and is passed to the [HtmlOptions](https://reference.aspose.com/slides/python-net/aspose.slides.export/htmloptions/__init__/#ilinkembedcontroller) constructor. The class exposes three methods that control how resources are embedded or linked during HTML export:
+## **Export HTML with Linked Images**
 
-[get_object_storing_location(id, entity_data, semantic_name, content_type, recommended_extension)](https://reference.aspose.com/slides/python-net/aspose.slides.export/ilinkembedcontroller/get_object_storing_location/#int-bytes-str-str-str): Called when the exporter encounters a resource and must decide where to store it. The most important parameters are `id` (the resource’s unique identifier for this export run) and `content_type` (the resource MIME type). Return [LinkEmbedDecision.LINK](https://reference.aspose.com/slides/python-net/aspose.slides.export/linkembeddecision/) to link the resource, or [LinkEmbedDecision.EMBED](https://reference.aspose.com/slides/python-net/aspose.slides.export/linkembeddecision/) to embed it.
+The following Python example creates an output directory, saves the HTML file there, stores extracted images in an `assets` subdirectory, and rewrites Base64 image URLs to relative links. The example extracts common Base64 image formats when Aspose.Slides provides a safe file extension. Data URLs that are not recognized remain embedded.
 
-[get_url(id, referrer)](https://reference.aspose.com/slides/python-net/aspose.slides.export/ilinkembedcontroller/get_url/#int-int): Returns the URL that will appear in the resulting HTML for the resource identified by `id` (optionally considering the referrer object).
+```python
+import base64
+import os
+import re
 
-[save_external(id, entity_data)](https://reference.aspose.com/slides/python-net/aspose.slides.export/ilinkembedcontroller/save_external/#int-bytes): Called when a resource selected for linking needs to be written externally. Because the identifier and contents are provided (as a byte array), you can persist the resource however you like.
+import aspose.slides as slides
+import aspose.slides.export as slides_export
 
-The Python `LinkController` implementation of [ILinkEmbedController](https://reference.aspose.com/slides/python-net/aspose.slides.export/ilinkembedcontroller/) follows below.
 
-```py
-# [TODO[not_supported_yet]: python implementation of .NET interfaces]
+EXTENSIONS_BY_CONTENT_TYPE = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/bmp": ".bmp",
+    "image/svg+xml": ".svg",
+    "image/tiff": ".tiff",
+    "image/x-emf": ".emf",
+    "image/x-wmf": ".wmf",
+}
+
+DATA_URI_PATTERN = re.compile(
+    r"data:(?P<content_type>[-\w.+]+/[-\w.+]+);base64,(?P<data>[A-Za-z0-9+/=\r\n]+)"
+)
+
+
+def export_presentation_to_html_with_linked_images(
+    input_file_path,
+    output_directory,
+    asset_directory_name="assets",
+):
+    asset_directory = os.path.join(output_directory, asset_directory_name)
+
+    os.makedirs(output_directory, exist_ok=True)
+    os.makedirs(asset_directory, exist_ok=True)
+
+    html_options = slides_export.HtmlOptions()
+    html_options.html_formatter = slides_export.HtmlFormatter.create_document_formatter("", False)
+    html_options.slide_image_format = slides_export.SlideImageFormat.svg(
+        slides_export.SVGOptions()
+    )
+
+    html_file_path = os.path.join(output_directory, "presentation.html")
+
+    with slides.Presentation(input_file_path) as presentation:
+        presentation.save(html_file_path, slides_export.SaveFormat.HTML, html_options)
+
+    externalize_base64_images(html_file_path, asset_directory, asset_directory_name)
+
+
+def externalize_base64_images(html_file_path, asset_directory, asset_directory_name):
+    with open(html_file_path, "r", encoding="utf-8-sig") as html_file:
+        html_content = html_file.read()
+
+    saved_resource_names = {}
+    resource_index = 1
+
+    def replace_data_uri(match):
+        nonlocal resource_index
+
+        data_uri = match.group(0)
+        if data_uri in saved_resource_names:
+            return saved_resource_names[data_uri]
+
+        content_type = match.group("content_type").lower()
+        extension = EXTENSIONS_BY_CONTENT_TYPE.get(content_type)
+        if extension is None:
+            return data_uri
+
+        encoded_data = match.group("data")
+        image_data = base64.b64decode(encoded_data)
+        if len(image_data) == 0:
+            return data_uri
+
+        file_name = f"resource-{resource_index}{extension}"
+        resource_index += 1
+
+        file_path = os.path.join(asset_directory, file_name)
+        with open(file_path, "wb") as image_file:
+            image_file.write(image_data)
+
+        linked_url = f"{asset_directory_name}/{file_name}"
+        saved_resource_names[data_uri] = linked_url
+        return linked_url
+
+    updated_html_content = DATA_URI_PATTERN.sub(replace_data_uri, html_content)
+
+    with open(html_file_path, "w", encoding="utf-8", newline="\n") as html_file:
+        html_file.write(updated_html_content)
+
+
+input_file_path = "presentation.pptx"
+output_directory = "html-output"
+
+export_presentation_to_html_with_linked_images(input_file_path, output_directory)
 ```
 
-After implementing the `LinkController` class, you can use it with the [HtmlOptions](https://reference.aspose.com/slides/python-net/aspose.slides.export/htmloptions/) class to export the presentation to HTML with externally linked images, as shown below:
+After the export, the output folder may have this structure:
 
-```py
-# [TODO[not_supported_yet]: python implementation of .NET interfaces]
+```text
+html-output/
+  presentation.html
+  assets/
+    resource-1.jpg
+    resource-2.png
 ```
 
-We assigned `SlideImageFormat.SVG` to the `slide_image_format` property so that the resulting HTML file will contain SVG data to render the presentation’s contents.
+The exact files depend on the presentation content and export options. For example, raster images are commonly exported as JPEG or PNG. Aspose.Slides may choose a different image codec than the one used in the source presentation when that produces a smaller or more suitable file. Images with transparency are exported as PNG.
 
-Content types: If the presentation contains raster bitmaps, then the class code must be prepared to process both `image/jpeg` and `image/png` content types. The content of the exported bitmap images may not match what was stored in the presentation. Aspose.Slides’ internal algorithms perform size optimization and use either the JPEG or PNG codec (depending on which produces a smaller file size). Images containing an alpha channel (transparency) are always encoded as PNG.
+## **Choosing URLs for Deployment**
+
+The sample uses a relative URL prefix: `assets/`. If `presentation.html` is opened from `html-output/presentation.html`, the browser loads `html-output/assets/resource-1.jpg`.
+
+Use a different asset directory name or rewrite the generated links when the files are deployed elsewhere:
+
+- Use `assets/` when the asset directory is next to the HTML file.
+- Use `../assets/` when the asset directory is one level above the HTML file.
+- Use `https://cdn.example.com/presentations/job-123/assets/` when the files are uploaded to a CDN or static file server.
+
+In server applications, use a unique output directory or object-storage prefix for each conversion job to avoid overwriting files from another export.
+
+## **When to Embed Instead**
+
+Embedded Base64 HTML is still useful when the output must be a single file, such as an email attachment, an offline preview, or a document that will be moved without a supporting asset folder. Linked images are a better fit when the HTML will be served by a web application, stored in a CMS, optimized by a build pipeline, or cached by browsers independently from the HTML.
+
+## **FAQ**
+
+**Can I externalize only images and keep other resources embedded?**
+
+Yes. The sample extracts only `image/*` Base64 data URLs whose content types are listed in `EXTENSIONS_BY_CONTENT_TYPE`. Other data URLs remain embedded.
+
+**Why does the exported image extension differ from the source presentation?**
+
+Aspose.Slides may re-encode raster images during HTML export to improve size or browser compatibility. For example, an image from the source file may be written as JPEG or PNG depending on the rendered result.
+
+**Do relative URLs work after I move the HTML file?**
+
+Relative URLs work only when the same relative folder structure is preserved. If the HTML references `assets/resource-1.png`, the `assets` folder must stay next to the HTML file unless you generate a different URL prefix.
+
+**Should server applications reuse the same output folder?**
+
+No. Use a unique output directory or storage prefix for each conversion job. This avoids filename collisions and prevents one export from overwriting resources generated by another export.


### PR DESCRIPTION
Completely rewrote the article for .NET, C++, and Python via .NET, removing encoding artifacts, correcting the recommendedExtension, replacing the example with cleaner C# with portable paths, folder creation, understandable errors, assets/-structure, and an explanation of relative URLs.
Added the articles for Android via Java, Java, Node.js via Java, and PHP via Java.