### PR TITLE
Update docs for forum topic 328943

### DIFF
--- a/en/net/developer-guide/presentation-via-vba/_index.md
+++ b/en/net/developer-guide/presentation-via-vba/_index.md
@@ -133,6 +133,16 @@ using (Presentation pres = new Presentation("VBA.pptm"))
 }
 ```
 
+### Access VBA Code in ActiveX Controls
+
+Code that belongs to an ActiveX control (for example, event-handler macros generated when you add a checkbox) is **not** exposed through `presentation.VbaProject.Modules`. To work with such code, access the control via the slide’s `Controls` collection.
+
+```c#
+// Access ActiveX controls on the first slide
+var presentation = new Presentation("PP_Acx_CheckBox_Status.pptm");
+var controls = presentation.Slides[0].Controls;
+```
+
 ## **Check Whether a VBA Project Is Password-Protected**
 
 Using the [IVbaProject.IsPasswordProtected](https://reference.aspose.com/slides/net/aspose.slides.vba/ivbaproject/ispasswordprotected/) property, you can determine whether a project’s properties are password-protected.


### PR DESCRIPTION
Forum topic: [328943](https://forum.aspose.com/t/vbaproject-modules-is-empty-even-though-there-is-code/328943) - VbaProject.Modules Is Empty Even Though There Is Code

Summary:
- Add note that ActiveX‑related VBA code is not listed in VbaProject.Modules
- Show how to access ActiveX controls via Slides[0].Controls

Updated documentation:
- Added section: Access VBA Code in ActiveX Controls