### PR TITLE
SLIDESDOC-723 PowerPoint to HTML: Why font sizes look "wrong"

### DIFF
--- a/en/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
+++ b/en/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
@@ -413,6 +413,12 @@ No. A single [Presentation](https://reference.aspose.com/slides/androidjava/com.
 
 The default export can embed resources directly in the HTML. Embedded fonts, high-DPI images, media, SVG content, and retained cropped image areas also increase size. Use external resources, exclude common fonts from embedding, and lower `PicturesCompression` when smaller output is more important than maximum fidelity.
 
+**Why does a PowerPoint font size such as 24 pt appear as 17.999819 pt in HTML?**
+
+This can happen because PowerPoint and HTML use different DPI models. PowerPoint stores text sizes in typographic points based on 72 DPI, while HTML layout is based on CSS pixels in a 96 DPI model. When Aspose.Slides exports a presentation to HTML, the font size is translated between these systems, and the conversion may introduce small rounding differences.
+
+These values do not indicate a real visual font-size change. They are only a mathematical side effect of converting text metrics between PowerPoint and HTML.
+
 **How should I choose baseUri for media export?**
 
 Choose `baseUri` from the browser's point of view and pass it as an absolute URI. For local preview, you can derive it from the output directory with `mediaDirectory.toUri().toString()`. For deployment, use the absolute URL of the published media directory. The file system `path` and browser `baseUri` do not have to be the same string, but they must describe the same resource location.

--- a/en/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
+++ b/en/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
@@ -395,6 +395,12 @@ No. A single [Presentation](https://reference.aspose.com/slides/cpp/aspose.slide
 
 The default export can embed resources directly in the HTML. Embedded fonts, high-DPI images, media, SVG content, and retained cropped image areas also increase size. Use external resources, exclude common fonts from embedding, and lower `PicturesCompression` when smaller output is more important than maximum fidelity.
 
+**Why does a PowerPoint font size such as 24 pt appear as 17.999819 pt in HTML?**
+
+This can happen because PowerPoint and HTML use different DPI models. PowerPoint stores text sizes in typographic points based on 72 DPI, while HTML layout is based on CSS pixels in a 96 DPI model. When Aspose.Slides exports a presentation to HTML, the font size is translated between these systems, and the conversion may introduce small rounding differences.
+
+These values do not indicate a real visual font-size change. They are only a mathematical side effect of converting text metrics between PowerPoint and HTML.
+
 **How should I choose baseUri for media export?**
 
 Choose `baseUri` from the browser's point of view and pass it as an absolute URI. For local preview, you can derive it from the output directory with `System::MakeObject<System::Uri>(mediaDirectory + System::IO::Path::DirectorySeparatorChar)->get_AbsoluteUri()`. For deployment, use the absolute URL of the published media directory. The file system `path` and browser `baseUri` do not have to be the same string, but they must describe the same resource location.

--- a/en/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
+++ b/en/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
@@ -407,6 +407,12 @@ No. A single [Presentation](https://reference.aspose.com/slides/java/com.aspose.
 
 The default export can embed resources directly in the HTML. Embedded fonts, high-DPI images, media, SVG content, and retained cropped image areas also increase size. Use external resources, exclude common fonts from embedding, and lower `PicturesCompression` when smaller output is more important than maximum fidelity.
 
+**Why does a PowerPoint font size such as 24 pt appear as 17.999819 pt in HTML?**
+
+This can happen because PowerPoint and HTML use different DPI models. PowerPoint stores text sizes in typographic points based on 72 DPI, while HTML layout is based on CSS pixels in a 96 DPI model. When Aspose.Slides exports a presentation to HTML, the font size is translated between these systems, and the conversion may introduce small rounding differences.
+
+These values do not indicate a real visual font-size change. They are only a mathematical side effect of converting text metrics between PowerPoint and HTML.
+
 **How should I choose baseUri for media export?**
 
 Choose `baseUri` from the browser's point of view and pass it as an absolute URI. For local preview, you can derive it from the output directory with `mediaDirectory.toUri().toString()`. For deployment, use the absolute URL of the published media directory. The file system `path` and browser `baseUri` do not have to be the same string, but they must describe the same resource location.

--- a/en/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
+++ b/en/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
@@ -396,6 +396,12 @@ No. A single [Presentation](https://reference.aspose.com/slides/net/aspose.slide
 
 The default export can embed resources directly in the HTML. Embedded fonts, high-DPI images, media, SVG content, and retained cropped image areas also increase size. Use external resources, exclude common fonts from embedding, and lower `PicturesCompression` when smaller output is more important than maximum fidelity.
 
+**Why does a PowerPoint font size such as 24 pt appear as 17.999819 pt in HTML?**
+
+This can happen because PowerPoint and HTML use different DPI models. PowerPoint stores text sizes in typographic points based on 72 DPI, while HTML layout is based on CSS pixels in a 96 DPI model. When Aspose.Slides exports a presentation to HTML, the font size is translated between these systems, and the conversion may introduce small rounding differences.
+
+These values do not indicate a real visual font-size change. They are only a mathematical side effect of converting text metrics between PowerPoint and HTML.
+
 **How should I choose baseUri for media export?**
 
 Choose `baseUri` from the browser's point of view and pass it as an absolute URI. For local preview, you can derive it from the output directory with `new Uri(mediaDirectory + Path.DirectorySeparatorChar).AbsoluteUri`. For deployment, use the absolute URL of the published media directory. The file system `path` and browser `baseUri` do not have to be the same string, but they must describe the same resource location.

--- a/en/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
+++ b/en/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
@@ -324,6 +324,12 @@ No. A single [Presentation](https://reference.aspose.com/slides/nodejs-java/aspo
 
 The default export can embed resources directly in the HTML. Embedded fonts, high-DPI images, media, SVG content, and retained cropped image areas also increase size. Use external resources, exclude common fonts from embedding, and lower `PicturesCompression` when smaller output is more important than maximum fidelity.
 
+**Why does a PowerPoint font size such as 24 pt appear as 17.999819 pt in HTML?**
+
+This can happen because PowerPoint and HTML use different DPI models. PowerPoint stores text sizes in typographic points based on 72 DPI, while HTML layout is based on CSS pixels in a 96 DPI model. When Aspose.Slides exports a presentation to HTML, the font size is translated between these systems, and the conversion may introduce small rounding differences.
+
+These values do not indicate a real visual font-size change. They are only a mathematical side effect of converting text metrics between PowerPoint and HTML.
+
 **How should I choose baseUri for media export?**
 
 Choose `baseUri` from the browser's point of view and pass it as an absolute URI. For local preview, you can derive it from the output directory with a `file:///` URI. For deployment, use the absolute URL of the published media directory. The file system `path` and browser `baseUri` do not have to be the same string, but they must describe the same resource location.

--- a/en/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
+++ b/en/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
@@ -340,6 +340,12 @@ No. A single [Presentation](https://reference.aspose.com/slides/php-java/aspose.
 
 The default export can embed resources directly in the HTML. Embedded fonts, high-DPI images, media, SVG content, and retained cropped image areas also increase size. Use external resources, exclude common fonts from embedding, and lower `PicturesCompression` when smaller output is more important than maximum fidelity.
 
+**Why does a PowerPoint font size such as 24 pt appear as 17.999819 pt in HTML?**
+
+This can happen because PowerPoint and HTML use different DPI models. PowerPoint stores text sizes in typographic points based on 72 DPI, while HTML layout is based on CSS pixels in a 96 DPI model. When Aspose.Slides exports a presentation to HTML, the font size is translated between these systems, and the conversion may introduce small rounding differences.
+
+These values do not indicate a real visual font-size change. They are only a mathematical side effect of converting text metrics between PowerPoint and HTML.
+
 **How should I choose baseUri for media export?**
 
 Choose `baseUri` from the browser's point of view and pass it as an absolute URI. For local preview, you can derive it from the output directory with a Java file URI. For deployment, use the absolute URL of the published media directory. The file system `path` and browser `baseUri` do not have to be the same string, but they must describe the same resource location.

--- a/en/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
+++ b/en/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-html/_index.md
@@ -316,6 +316,12 @@ No. A single [Presentation](https://reference.aspose.com/slides/python-net/aspos
 
 The default export can embed resources directly in the HTML. Embedded fonts, high-DPI images, media, SVG content, and retained cropped image areas also increase size. Use external resources, exclude common fonts from embedding, and lower `pictures_compression` when smaller output is more important than maximum fidelity.
 
+**Why does a PowerPoint font size such as 24 pt appear as 17.999819 pt in HTML?**
+
+This can happen because PowerPoint and HTML use different DPI models. PowerPoint stores text sizes in typographic points based on 72 DPI, while HTML layout is based on CSS pixels in a 96 DPI model. When Aspose.Slides exports a presentation to HTML, the font size is translated between these systems, and the conversion may introduce small rounding differences.
+
+These values do not indicate a real visual font-size change. They are only a mathematical side effect of converting text metrics between PowerPoint and HTML.
+
 **How should I choose base_uri for media export?**
 
 Choose `base_uri` from the browser's point of view and pass it as an absolute URI. For local preview, you can derive it from the output directory with `Path(media_directory).as_uri() + "/"`. For deployment, use the absolute URL of the published media directory. The file system `path` and browser `base_uri` do not have to be the same string, but they must describe the same resource location.


### PR DESCRIPTION
Added FAQ entries to the PowerPoint-to-HTML conversion articles for .NET, Android via Java, C++, Java, Node.js via Java, PHP via Java, and Python via .NET explaining why exported HTML may show small font-size differences such as 24 pt appearing as 17.999819 pt due to conversion between PowerPoint’s 72 DPI point model and HTML’s 96 DPI CSS pixel model.