### PR TITLE
SLIDESDOC-637 Add the section "Compress Image" to articles for other platforms

### DIFF
--- a/en/androidjava/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/en/androidjava/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -362,6 +362,61 @@ This method converts WMF/EMF metafiles to raster PNG image in the cropping opera
 
 {{% /alert %}}
 
+## **Compress Images**
+
+You can compress a picture in a presentation using the [IPictureFillFormat.compressImage](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ipicturefillformat/#compressImage-boolean-int-) method.
+This method compresses an image by reducing its size based on the shape size and specified resolution, with the option to delete cropped areas.
+
+It adjusts the picture's size and resolution similarly to PowerPoint's **Picture Format > Compress Pictures > Resolution** feature.
+
+The following Java examples demonstrate how to compress an image in a presentation by specifying a target resolution and optionally removing cropped areas:
+
+```java
+Presentation presentation = new Presentation("demo.pptx");
+try {
+    ISlide slide = presentation.getSlides().get_Item(0);
+    IPictureFrame pictureFrame = (IPictureFrame)slide.getShapes().get_Item(0);
+
+    // Compress the image with a target resolution of 150 DPI (Web resolution) and remove cropped areas.
+    boolean result = pictureFrame.getPictureFormat().compressImage(true, PicturesCompression.Dpi150);
+
+    // Check the result of the compression.
+    if (result) {
+        System.out.println("Image successfully compressed.");
+    } else {
+        System.out.println("Image compression failed or no changes were necessary.");
+    }
+
+    presentation.save("CompressedImage.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+Or using a custom DPI value directly:
+
+```java
+Presentation presentation = new Presentation("demo.pptx");
+try {
+    ISlide slide = presentation.getSlides().get_Item(0);
+    IPictureFrame pictureFrame = (IPictureFrame)slide.getShapes().get_Item(0);
+
+    // Compress the image to 150 DPI (web resolution), removing cropped areas.
+    pictureFrame.getPictureFormat().compressImage(true, 150f);
+
+    presentation.save("CompressedImage.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+{{% alert title="NOTE" color="warning" %}} 
+
+The method converts the image to a lower resolution based on the shape's size and provided DPI. Cropped regions can also be deleted to optimize file size.  
+If the image is a metafile (WMF/EMF) or SVG, compression will not be applied. Also, JPEG quality is preserved or slightly reduced based on resolution, similarly to how PowerPoint handles high-resolution JPEGs.
+
+{{% /alert %}}
+
 ## **Lock Aspect Ratio**
 
 If you want a shape containing an image to retain its aspect ratio even after you change the image dimensions, you can use the [setAspectRatioLocked](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ipictureframelock/#setAspectRatioLocked-boolean-) method to set the *Lock Aspect Ratio* setting.

--- a/en/cpp/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/en/cpp/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -356,6 +356,58 @@ This method converts WMF/EMF metafiles to raster PNG image in the cropping opera
 
 {{% /alert %}}
 
+## **Compress Images**
+
+You can compress a picture in a presentation using the [IPictureFillFormat::CompressImage()](https://reference.aspose.com/slides/cpp/aspose.slides/ipicturefillformat/compressimage/) method.
+This method compresses an image by reducing its size based on the shape size and specified resolution, with the option to delete cropped areas.
+
+It adjusts the picture's size and resolution similarly to PowerPoint's **Picture Format -> Compress Pictures -> Resolution** feature.
+
+The following C++ examples demonstrate how to compress an image in a presentation by specifying a target resolution and optionally removing cropped areas:
+
+```c++
+auto presentation = System::MakeObject<Presentation>(u"demo.pptx");
+auto slide = presentation->get_Slide(0);
+auto pictureFrame = System::AsCast<IPictureFrame>(slide->get_Shape(0));
+
+// Compress the image with a target resolution of 150 DPI (Web resolution) and remove cropped areas.
+bool result = pictureFrame->get_PictureFormat()->CompressImage(true, PicturesCompression::Dpi150);
+
+// Check the result of the compression.
+if (result)
+{
+    System::Console::WriteLine(u"Image successfully compressed.");
+}
+else
+{
+    System::Console::WriteLine(u"Image compression failed or no changes were necessary.");
+}
+
+presentation->Save(u"CompressedImage.pptx", SaveFormat::Pptx);
+presentation->Dispose();
+```
+
+Or using a custom DPI value directly:
+
+```c++
+auto presentation = System::MakeObject<Presentation>(u"demo.pptx");
+auto slide = presentation->get_Slide(0);
+auto pictureFrame = System::AsCast<IPictureFrame>(slide->get_Shape(0));
+
+// Compress the image to 150 DPI (web resolution), removing cropped areas.
+pictureFrame->get_PictureFormat()->CompressImage(true, 150.0f);
+
+presentation->Save(u"CompressedImage.pptx", SaveFormat::Pptx);
+presentation->Dispose();
+```
+
+{{% alert title="NOTE" color="warning" %}}
+
+The method converts the image to a lower resolution based on the shape's size and provided DPI. Cropped regions can also be deleted to optimize file size.
+If the image is a metafile (WMF/EMF) or SVG, compression will not be applied. Also, JPEG quality is preserved or slightly reduced based on resolution, similarly to how PowerPoint handles high-resolution JPEGs.
+
+{{% /alert %}}
+
 ## **Lock Aspect Ratio**
 
 If you want a shape containing an image to retain its aspect ratio even after you change the image dimensions, you can use the [set_AspectRatioLocked()](https://reference.aspose.com/slides/cpp/aspose.slides/ipictureframelock/set_aspectratiolocked/) method to set the *Lock Aspect Ratio* setting. 

--- a/en/java/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/en/java/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -367,6 +367,60 @@ This method converts WMF/EMF metafiles to raster PNG image in the cropping opera
 
 {{% /alert %}}
 
+## **Compress Images**
+
+You can compress a picture in a presentation using the [IPictureFillFormat.compressImage](https://reference.aspose.com/slides/java/com.aspose.slides/ipicturefillformat/#compressImage-boolean-int-) method. This method compresses an image by reducing its size based on the shape size and specified resolution, with the option to delete cropped areas.
+
+It adjusts the picture's size and resolution similarly to PowerPoint's **Picture Format -> Compress Pictures -> Resolution** feature.
+
+The following Java examples demonstrate how to compress an image in a presentation by specifying a target resolution and optionally removing cropped areas:
+
+```java
+Presentation presentation = new Presentation("demo.pptx");
+try {
+    ISlide slide = presentation.getSlides().get_Item(0);
+    IPictureFrame pictureFrame = (IPictureFrame)slide.getShapes().get_Item(0);
+
+    // Compress the image with a target resolution of 150 DPI (Web resolution) and remove cropped areas.
+    boolean result = pictureFrame.getPictureFormat().compressImage(true, PicturesCompression.Dpi150);
+
+    // Check the result of the compression.
+    if (result) {
+        System.out.println("Image successfully compressed.");
+    } else {
+        System.out.println("Image compression failed or no changes were necessary.");
+    }
+
+    presentation.save("CompressedImage.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+Or using a custom DPI value directly:
+
+```java
+Presentation presentation = new Presentation("demo.pptx");
+try {
+    ISlide slide = presentation.getSlides().get_Item(0);
+    IPictureFrame pictureFrame = (IPictureFrame)slide.getShapes().get_Item(0);
+
+    // Compress the image to 150 DPI (web resolution), removing cropped areas.
+    pictureFrame.getPictureFormat().compressImage(true, 150f);
+
+    presentation.save("CompressedImage.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+{{% alert title="NOTE" color="warning" %}} 
+
+The method converts the image to a lower resolution based on the shape's size and provided DPI. Cropped regions can also be deleted to optimize file size.  
+If the image is a metafile (WMF/EMF) or SVG, compression will not be applied. Also, JPEG quality is preserved or slightly reduced based on resolution, similarly to how PowerPoint handles high-resolution JPEGs.
+
+{{% /alert %}}
+
 ## **Lock Aspect Ratio**
 
 If you want a shape containing an image to retain its aspect ratio even after you change the image dimensions, you can use the [setAspectRatioLocked](https://reference.aspose.com/slides/java/com.aspose.slides/ipictureframelock/#setAspectRatioLocked-boolean-) method to set the *Lock Aspect Ratio* setting. 

--- a/en/net/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/en/net/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -350,7 +350,7 @@ This method converts WMF/EMF metafiles to raster PNG image in the cropping opera
 
 ## **Compress Images**
 
-You can compress a picture in a presentation using the [`IPictureFillFormat.CompressImage`](https://reference.aspose.com/slides/net/aspose.slides/ipicturefillformat/compressimage/) method. 
+You can compress a picture in a presentation using the [IPictureFillFormat.CompressImage](https://reference.aspose.com/slides/net/aspose.slides/ipicturefillformat/compressimage/) method.
 This method compresses an image by reducing its size based on the shape size and specified resolution, with the option to delete cropped areas. 
 
 It adjusts the picture’s size and resolution similarly to PowerPoint’s **Picture Format → Compress Pictures → Resolution** feature.
@@ -361,14 +361,12 @@ The following C# examples demonstrate how to compress an image in a presentation
 using (Presentation presentation = new Presentation("demo.pptx"))
 {
     ISlide slide = presentation.Slides[0];
+    IPictureFrame pictureFrame = slide.Shapes[0] as IPictureFrame;
 
-    // Get the PictureFrame from the slide
-    IPictureFrame picFrame = slide.Shapes[0] as IPictureFrame;
+    // Compress the image with a target resolution of 150 DPI (Web resolution) and remove cropped areas.
+    bool result = pictureFrame.PictureFormat.CompressImage(true, PicturesCompression.Dpi150);
 
-    // Compress the image with a target resolution of 150 DPI (Web resolution) and remove cropped areas
-    bool result = picFrame.PictureFormat.CompressImage(true, PicturesCompression.Dpi150);
-
-    // Check the result of the compression
+    // Check the result of the compression.
     if (result)
     {
         Console.WriteLine("Image successfully compressed.");
@@ -377,6 +375,8 @@ using (Presentation presentation = new Presentation("demo.pptx"))
     {
         Console.WriteLine("Image compression failed or no changes were necessary.");
     }
+
+    presentation.Save("CompressedImage.pptx", SaveFormat.Pptx);
 }
 ```
 
@@ -386,11 +386,12 @@ Or using a custom DPI value directly:
 using (Presentation presentation = new Presentation("demo.pptx"))
 {
     ISlide slide = presentation.Slides[0];
+    IPictureFrame pictureFrame = slide.Shapes[0] as IPictureFrame;
 
-    IPictureFrame picFrame = slide.Shapes[0] as IPictureFrame;
+    // Compress the image to 150 DPI (web resolution), removing cropped areas.
+    pictureFrame.PictureFormat.CompressImage(true, 150f);
 
-    // Compress the image to 150 DPI (web resolution), removing cropped areas
-    bool result = picFrame.PictureFormat.CompressImage(true, 150f);
+    presentation.Save("CompressedImage.pptx", SaveFormat.Pptx);
 }
 ```
 

--- a/en/nodejs-java/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/en/nodejs-java/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -340,6 +340,61 @@ This method converts WMF/EMF metafiles to raster PNG image in the cropping opera
 
 {{% /alert %}}
 
+## **Compress Images**
+
+You can compress a picture in a presentation using the [PictureFillFormat.compressImage](https://reference.aspose.com/slides/nodejs-java/aspose.slides/picturefillformat/#compressImage-boolean-int-) method.
+This method compresses an image by reducing its size based on the shape size and specified resolution, with the option to delete cropped areas.
+
+It adjusts the picture's size and resolution similarly to PowerPoint's **Picture Format → Compress Pictures → Resolution** feature.
+
+The following JavaScript examples demonstrate how to compress an image in a presentation by specifying a target resolution and optionally removing cropped areas:
+
+```javascript
+const presentation = new aspose.slides.Presentation("demo.pptx");
+try {
+    const slide = presentation.getSlides().get_Item(0);
+    const pictureFrame = slide.getShapes().get_Item(0);
+
+    // Compress the image with a target resolution of 150 DPI (Web resolution) and remove cropped areas.
+    const result = pictureFrame.getPictureFormat().compressImage(true, aspose.slides.PicturesCompression.Dpi150);
+
+    // Check the result of the compression.
+    if (result) {
+        console.log("Image successfully compressed.");
+    } else {
+        console.log("Image compression failed or no changes were necessary.");
+    }
+
+    presentation.save("CompressedImage.pptx", aspose.slides.SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+Or using another predefined DPI value:
+
+```javascript
+const presentation = new aspose.slides.Presentation("demo.pptx");
+try {
+    const slide = presentation.getSlides().get_Item(0);
+    const pictureFrame = slide.getShapes().get_Item(0);
+
+    // Compress the image to 96 DPI (email resolution), removing cropped areas.
+    pictureFrame.getPictureFormat().compressImage(true, aspose.slides.PicturesCompression.Dpi96);
+
+    presentation.save("CompressedImage.pptx", aspose.slides.SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+{{% alert title="NOTE" color="warning" %}} 
+
+The method converts the image to a lower resolution based on the shape's size and provided DPI. Cropped regions can also be deleted to optimize file size.
+If the image is a metafile (WMF/EMF) or SVG, compression will not be applied. Also, JPEG quality is preserved or slightly reduced based on resolution, similarly to how PowerPoint handles high-resolution JPEGs.
+
+{{% /alert %}}
+
 ## **Lock Aspect Ratio**
 
 If you want a shape containing an image to retain its aspect ratio even after you change the image dimensions, you can use the [setAspectRatioLocked](https://reference.aspose.com/slides/nodejs-java/aspose.slides/pictureframelock/#setAspectRatioLocked-boolean-) method to set the *Lock Aspect Ratio* setting.

--- a/en/php-java/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/en/php-java/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -339,6 +339,60 @@ This method converts WMF/EMF metafiles to raster PNG image in the cropping opera
 
 {{% /alert %}}
 
+## **Compress Images**
+
+You can compress a picture in a presentation using the [PictureFillFormat::compressImage()](https://reference.aspose.com/slides/php-java/aspose.slides/picturefillformat/#compressImage_boolean_int_) method. This method compresses an image by reducing its size based on the shape size and specified resolution, with the option to delete cropped areas.
+
+It adjusts the picture's size and resolution similarly to PowerPoint's **Picture Format -> Compress Pictures -> Resolution** feature.
+
+The following PHP examples demonstrate how to compress an image in a presentation by specifying a target resolution and optionally removing cropped areas:
+
+```php
+$presentation = new Presentation("demo.pptx");
+try {
+    $slide = $presentation->getSlides()->get_Item(0);
+    $pictureFrame = $slide->getShapes()->get_Item(0);
+
+    # Compress the image with a target resolution of 150 DPI (Web resolution) and remove cropped areas.
+    $result = $pictureFrame->getPictureFormat()->compressImage(true, PicturesCompression::Dpi150);
+
+    # Check the result of the compression.
+    if ($result) {
+        echo "Image successfully compressed.";
+    } else {
+        echo "Image compression failed or no changes were necessary.";
+    }
+
+    $presentation->save("CompressedImage.pptx", SaveFormat::Pptx);
+} finally {
+    $presentation->dispose();
+}
+```
+
+Or using a custom DPI value directly:
+
+```php
+$presentation = new Presentation("demo.pptx");
+try {
+    $slide = $presentation->getSlides()->get_Item(0);
+    $pictureFrame = $slide->getShapes()->get_Item(0);
+
+    # Compress the image to 150 DPI (web resolution), removing cropped areas.
+    $pictureFrame->getPictureFormat()->compressImage(true, 150.0);
+
+    $presentation->save("CompressedImage.pptx", SaveFormat::Pptx);
+} finally {
+    $presentation->dispose();
+}
+```
+
+{{% alert title="NOTE" color="warning" %}} 
+
+The method converts the image to a lower resolution based on the shape's size and provided DPI. Cropped regions can also be deleted to optimize file size.  
+If the image is a metafile (WMF/EMF) or SVG, compression will not be applied. Also, JPEG quality is preserved or slightly reduced based on resolution, similarly to how PowerPoint handles high-resolution JPEGs.
+
+{{% /alert %}}
+
 ## **Lock Aspect Ratio**
 
 If you want a shape containing an image to retain its aspect ratio even after you change the image dimensions, you can use the [setAspectRatioLocked](https://reference.aspose.com/slides/php-java/aspose.slides/pictureframelock/setaspectratiolocked/) method to set the *Lock Aspect Ratio* setting.

--- a/en/python-net/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
+++ b/en/python-net/developer-guide/presentation-content/manage-media-files/picture-frame/_index.md
@@ -312,6 +312,56 @@ During cropping, this method converts WMF/EMF metafiles to a raster PNG image.
 
 {{% /alert %}}
 
+## **Compress Images**
+
+You can compress a picture in a presentation using the [PictureFillFormat.compress_image](https://reference.aspose.com/slides/python-net/aspose.slides/picturefillformat/compress_image/) method.
+This method compresses an image by reducing its size based on the shape size and specified resolution, with the option to delete cropped areas.
+
+It adjusts the picture's size and resolution similarly to PowerPoint's **Picture Format -> Compress Pictures -> Resolution** feature.
+
+The following Python examples demonstrate how to compress an image in a presentation by specifying a target resolution and optionally removing cropped areas:
+
+```python
+import aspose.slides as slides
+
+with slides.Presentation("demo.pptx") as presentation:
+    slide = presentation.slides[0]
+    picture_frame = slide.shapes[0]
+
+    # Compress the image with a target resolution of 150 DPI (Web resolution) and remove cropped areas.
+    result = picture_frame.picture_format.compress_image(True, slides.export.PicturesCompression.DPI150)
+
+    # Check the result of the compression.
+    if result:
+        print("Image successfully compressed.")
+    else:
+        print("Image compression failed or no changes were necessary.")
+
+    presentation.save("compressed_image.pptx", slides.export.SaveFormat.PPTX)
+```
+
+Or using a custom DPI value directly:
+
+```python
+import aspose.slides as slides
+
+with slides.Presentation("demo.pptx") as presentation:
+    slide = presentation.slides[0]
+    picture_frame = slide.shapes[0]
+
+    # Compress the image to 150 DPI (web resolution), removing cropped areas.
+    picture_frame.picture_format.compress_image(True, 150)
+
+    presentation.save("compressed_image.pptx", slides.export.SaveFormat.PPTX)
+```
+
+{{% alert title="NOTE" color="warning" %}}
+
+The method converts the image to a lower resolution based on the shape's size and provided DPI. Cropped regions can also be deleted to optimize file size.
+If the image is a metafile (WMF/EMF) or SVG, compression will not be applied. Also, JPEG quality is preserved or slightly reduced based on resolution, similarly to how PowerPoint handles high-resolution JPEGs.
+
+{{% /alert %}}
+
 ## **Lock the Aspect Ratio**
 
 If you want a shape that contains an image to retain its aspect ratio after you change the image’s dimensions, set the [aspect_ratio_locked](https://reference.aspose.com/slides/python-net/aspose.slides/pictureframelock/aspect_ratio_locked/) property to `True`.


### PR DESCRIPTION
Added Compress Images documentation for picture frames across Java, C++, Android Java, Node.js via Java, PHP via Java, and Python via .NET, including platform-specific examples for CompressImage/compressImage, custom DPI usage, save calls, disposal patterns, and notes about unsupported image types; also refined the .NET section with cleaner API linking and updated sample code.