### PR TITLE
Update docs for forum topic 327801

### DIFF
--- a/en/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-pdf/_index.md
+++ b/en/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-pdf/_index.md
@@ -85,6 +85,8 @@ Aspose offers a free online [**PowerPoint to PDF converter**](https://products.a
 
 {{% /alert %}}
 
+> **Note:** In Aspose.Slides for Java versions 25.8 and 26.4, the text on the first slide may shift when converting a PPTX to PDF. This issue was resolved in Aspose.Slides for Java 26.6.
+
 ## **Convert PowerPoint to PDF with Options**
 
 Aspose.Slides provides custom options—properties under the [PdfOptions](https://reference.aspose.com/slides/java/com.aspose.slides/pdfoptions/) class—that allow you to customize the resulting PDF, lock the PDF with a password, or specify how the conversion process should proceed.


### PR DESCRIPTION
Forum topic: [327801](https://forum.aspose.com/t/text-on-the-first-page-is-shifted-when-converting-pptx-to-pdf-in-java/327801) - Text on the First Page Is Shifted When Converting PPTX to PDF in Java

Summary:
- Added note about first‑slide text shift in certain versions
- Documented fix availability in version 26.6

Updated documentation:
- Updated section: Convert PowerPoint to PDF