### PR TITLE
Update docs for forum topic 329370

### DIFF
--- a/en/cpp/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
+++ b/en/cpp/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
@@ -247,3 +247,7 @@ Yes. You can swap the [video content](https://reference.aspose.com/slides/cpp/as
 **Can the content type (MIME) of an embedded video be determined?**
 
 Yes. An embedded video has a [content type](https://reference.aspose.com/slides/cpp/aspose.slides/video/get_contenttype/) that you can read and use, for example when saving it to disk.
+
+**How can I retrieve the video volume setting?**
+
+The `IVideoFrame` interface provides `get_Volume()` which returns the raw volume value stored in the presentation (the `vol` attribute of `p:cMediaNode`). The API does not convert this value to a percentage; you must interpret the raw value yourself according to the presentation markup.


### PR DESCRIPTION
Forum topic: [329370](https://forum.aspose.com/t/how-to-get-volume-percentage-of-the-video-using-aspose-slides-for-c/329370) - How to Get Volume Percentage of the Video Using Aspose.Slides for C++?

Summary:
- Added FAQ entry explaining how to get video volume via IVideoFrame::get_Volume
- Clarified that the API returns raw volume value, not a percentage

Updated documentation:
- Updated section: FAQ