### PR TITLE
Update docs for forum topic 246280

### DIFF
--- a/en/net/developer-guide/manage-presentation/convert-presentation/export-to-html5/_index.md
+++ b/en/net/developer-guide/manage-presentation/convert-presentation/export-to-html5/_index.md
@@ -58,6 +58,10 @@ using (Presentation pres = new Presentation("pres.pptx"))
 }
 ```
 
+{{% alert title="Note" color="warning" %}} 
+When exporting to HTML5 using `Html5Options`, image compression is not supported. The `PicturesCompression` property is available only on `HtmlOptions`. To obtain compressed images, use `HtmlOptions` with `SaveFormat.Html` or compress the images after export.
+{{% /alert %}}
+
 ## **Export PowerPoint to HTML**
 
 This C# demonstrates the standard PowerPoint to HTML process:


### PR DESCRIPTION
Forum topic: [246280](https://forum.aspose.com/t/picturecompression-property-is-missing-from-html5options-in-aspose-slides-for-net/246280) - PictureCompression Property Is Missing from Html5Options in Aspose.Slides for .NET

Summary:
- Added note that Html5Options does not provide picture compression
- Directed users to HtmlOptions for image compression

Updated documentation:
- Updated section: Export PowerPoint to HTML5