### PR TITLE
Update docs for forum topic 330498

### DIFF
--- a/en/java/developer-guide/technical-articles/getting-warning-callbacks-for-fonts-substitution-in-aspose-slides/_index.md
+++ b/en/java/developer-guide/technical-articles/getting-warning-callbacks-for-fonts-substitution-in-aspose-slides/_index.md
@@ -108,3 +108,31 @@ finally {
     presentation.dispose();
 }
 ```
+
+### Load External Fonts and Handle Warning Callback
+
+Load custom fonts before opening the presentation and ensure the warning callback does not abort the save operation.
+
+```java
+// Load custom fonts from a folder that contains the Selawik font.
+FontsLoader.loadExternalFonts(new String[] { "C:/fonts" });
+
+Presentation presentation = new Presentation("Comments_withcustomefonts.pptx");
+try {
+    PdfOptions pdfOptions = new PdfOptions();
+    pdfOptions.setWarningCallback(new IWarningCallback() {
+        @Override
+        public int warning(IWarningInfo warning) {
+            System.out.println("Description: " + warning.getDescription());
+            // Continue the conversion even if a font substitution warning occurs.
+            return ReturnAction.Continue;
+        }
+    });
+
+    presentation.save("output.pdf", SaveFormat.Pdf, pdfOptions);
+} finally {
+    presentation.dispose();
+}
+```
+
+This ensures the Selawik font is available and the warning callback returns `ReturnAction.Continue`, preventing the `PptxException: Saving aborted` error.


### PR DESCRIPTION
Forum topic: [330498](https://forum.aspose.com/t/custom-fonts-are-not-working-when-using-aspose-slides-for-java/330498) - Custom Fonts Are Not Working When Using Aspose.Slides for Java

Summary:
- Added guidance for loading external fonts before opening a presentation
- Clarified that returning Abort in a warning callback aborts the save operation

Updated documentation:
- Added section: Load External Fonts and Handle Warning Callback