### PR TITLE
Update docs for forum topic 330501

### DIFF
--- a/en/java/getting-started/how-to-run-aspose-slides-java-in-docker/_index.md
+++ b/en/java/getting-started/how-to-run-aspose-slides-java-in-docker/_index.md
@@ -118,6 +118,10 @@ RUN apt-get install -y openjdk-11-jdk wget fontconfig ttf-mscorefonts-installer
 - **OpenJDK 11**: Java runtime environment
 - **Font packages**: Includes Microsoft Core Fonts
 
+### Emoji Font Support
+
+To render color emojis correctly when converting slides to images, the **Segoe UI Emoji** font must be installed in the container. Install it via the package manager or copy the font file into the image (e.g., add `apt-get install -y fonts-segoe-ui-emoji` or copy the `.ttf` file and run `fc-cache`). Using other fonts such as Noto Color Emoji or Symbola may result in overlapped or monochrome emojis.
+
 ### **Aspose.Slides Setup**
 
 ```dockerfile


### PR DESCRIPTION
Forum topic: [330501](https://forum.aspose.com/t/emojis-are-not-supported-when-converting-slides-to-images-in-java/330501) - Emojis Are Not Supported When Converting Slides to Images in Java

Summary:
- Add section on required emoji font for correct colored rendering
- Mention Segoe UI Emoji as the supported font and note alternatives cause issues

Updated documentation:
- Added section: Emoji Font Support