### PR TITLE
Update docs for forum topic 330375

### DIFF
--- a/en/java/developer-guide/presentation-slide/convert-slide/_index.md
+++ b/en/java/developer-guide/presentation-slide/convert-slide/_index.md
@@ -202,6 +202,12 @@ try {
 } 
 ```
 
+## **Color Emoji Rendering**
+
+{{% alert title="Note" color="warning" %}} 
+To render color emojis correctly when converting PPTX slides to images, the **Segoe UI Emoji** font must be installed and available on the system performing the conversion. If this font is missing, emojis may appear in monochrome in the output images.
+{{% /alert %}}
+
 ## **FAQ**
 
 **Does Aspose.Slides support rendering slides with animations?**

--- a/en/java/developer-guide/presentation-slide/convert-slide/_index.md
+++ b/en/java/developer-guide/presentation-slide/convert-slide/_index.md
@@ -205,7 +205,7 @@ try {
 ## **Color Emoji Rendering**
 
 {{% alert title="Note" color="warning" %}} 
-To render color emojis correctly when converting PPTX slides to images, the **Segoe UI Emoji** font must be installed and available on the system performing the conversion. If this font is missing, emojis may appear in monochrome in the output images.
+To render color emojis correctly when converting presentation slides to images, the emoji fonts used in the presentation must be installed and available on the system performing the conversion. For example, if the presentation uses **Segoe UI Emoji** and this font is missing, emojis may appear in monochrome in the output images.
 {{% /alert %}}
 
 ## **FAQ**


### PR DESCRIPTION
Forum topic: [330375](https://forum.aspose.com/t/emojis-render-in-monochrome-when-converting-pptx-slides-to-images-in-java/330375) - Emojis Render in Monochrome When Converting PPTX Slides to Images in Java

Summary:
- Add note about required Segoe UI Emoji font for color emoji rendering
- Provide warning alert explaining monochrome output when font is absent

Updated documentation:
- Added section: Color Emoji Rendering