### PR TITLE
Update docs for forum topic 327194

### DIFF
--- a/en/java/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
+++ b/en/java/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
@@ -290,6 +290,10 @@ try {
 }
 ```
 
+## **PDF to PPTX Conversion Limitations**
+
+When an Excel chart that uses a gradient fill is first saved as a PDF and then imported into a presentation using `Presentation.slides.addFromPdf`, the gradient fill may be lost and the Y-axis text may not be rotated correctly. This behavior has been observed with Aspose.Slides for Java 26.2. A future release may address this issue.
+
 ## **FAQ**
 
 **Can I determine whether a specific chart is linked to an external or an embedded workbook?**


### PR DESCRIPTION
Forum topic: [327194](https://forum.aspose.com/t/the-gradient-color-disappears-after-xlsx-to-pdf-to-pptx-conversion-in-java/327194) - The Gradient Color Disappears After XLSX-to-PDF-to-PPTX Conversion in Java

Summary:
- Added a section describing gradient fill loss and axis rotation issues after PDF‑to‑PPTX conversion
- Documented that the behavior is observed in Aspose.Slides for Java 26.2

Updated documentation:
- Added section: PDF to PPTX Conversion Limitations