### PR TITLE
Update docs for forum topic 329786

### DIFF
--- a/en/net/developer-guide/presentation-design/powerpoint-fonts/custom-font/_index.md
+++ b/en/net/developer-guide/presentation-design/powerpoint-fonts/custom-font/_index.md
@@ -130,7 +130,7 @@ finally
 }
 ```
 
-## Troubleshoot Font Rendering Issues on Linux
+## **Troubleshoot Font Rendering Issues on Linux**
 
 If chart text appears blurry or the wrong font style when exporting to PDF on Linux, try the following steps:
 
@@ -139,13 +139,11 @@ If chart text appears blurry or the wrong font style when exporting to PDF on Li
   ```bash
   fc-cache -f -v
   ```
-- Verify which font file is selected for a given family:
+- Verify which font file is selected for a given family, for example:
   ```bash
   fc-match Arial
   fc-match Aptos
   ```
-  The command should point to the expected font file in your custom folder.
-- Optionally test with the latest Aspose.Slides for .NET version (e.g., 26.7) to rule out version-specific behavior.
 
 These steps help confirm that the correct fonts are loaded and that the rendering engine uses them with proper hinting, reducing blurriness in chart text.
 

--- a/en/net/developer-guide/presentation-design/powerpoint-fonts/custom-font/_index.md
+++ b/en/net/developer-guide/presentation-design/powerpoint-fonts/custom-font/_index.md
@@ -130,6 +130,25 @@ finally
 }
 ```
 
+## Troubleshoot Font Rendering Issues on Linux
+
+If chart text appears blurry or the wrong font style when exporting to PDF on Linux, try the following steps:
+
+- Ensure all required font variants (Regular, Bold, Italic, Bold Italic) are present in the custom fonts directory.
+- After adding or updating fonts, rebuild the Docker image without using the cache and run the font cache command:
+  ```bash
+  fc-cache -f -v
+  ```
+- Verify which font file is selected for a given family:
+  ```bash
+  fc-match Arial
+  fc-match Aptos
+  ```
+  The command should point to the expected font file in your custom folder.
+- Optionally test with the latest Aspose.Slides for .NET version (e.g., 26.7) to rule out version-specific behavior.
+
+These steps help confirm that the correct fonts are loaded and that the rendering engine uses them with proper hinting, reducing blurriness in chart text.
+
 ## **FAQ**
 
 **Do custom fonts affect export to all formats (PDF, PNG, SVG, HTML)?**


### PR DESCRIPTION
Forum topic: [329786](https://forum.aspose.com/t/chart-text-renders-blurry-unsharp-with-the-wrong-font-style-on-linux/329786) - Chart Text Renders Blurry/Unsharp with the Wrong Font Style on Linux

Summary:
- Added Linux font rendering troubleshooting section
- Included fc-cache, fc-match, and font variant checks

Updated documentation:
- Added section: Troubleshoot Font Rendering Issues on Linux