### PR TITLE
Update docs for forum topic 329136

### DIFF
--- a/en/cpp/developer-guide/presentation-content/powerpoint-smartart/manage-smartart-shape-node/_index.md
+++ b/en/cpp/developer-guide/presentation-content/powerpoint-smartart/manage-smartart-shape-node/_index.md
@@ -125,6 +125,7 @@ Now Aspose.Slides support for setting SmartArtShape X and Y properties. The cod
 
 {{< gist "aspose-slides" "a690df625dc0b1fff869ab198affe7a4" "Examples-SlidesCPP-CustomChildNodesInSmartArt-CustomChildNodesInSmartArt.cpp" >}}
 
+**Note:** When a SmartArt shape is placed inside a group, the coordinates returned for its child shapes may be incorrect. This behavior was fixed in Aspose.Slides for C++ version 26.7. Update to this version to obtain correct positions.
 
 ## **Check an Assistant Node**
 In the following sample code we will investigate how to identify Assistant Nodes in the SmartArt nodes collection and changing them.


### PR DESCRIPTION
Forum topic: [329136](https://forum.aspose.com/t/incorrect-position-of-shapes-within-smartart-when-smartart-is-placed-inside-a-group/329136) - Incorrect Position of Shapes Within SmartArt When SmartArt Is Placed Inside a Group

Summary:
- Added note about incorrect SmartArt child shape coordinates when SmartArt is inside a group
- Mentioned the fix in Aspose.Slides for C++ version 26.7

Updated documentation:
- Updated section: Set a Custom Position for a SmartArt Child Node