### PR TITLE
Update docs for forum topic 319583

### DIFF
--- a/en/cpp/developer-guide/manage-presentation/convert-presentation/export-to-html5/_index.md
+++ b/en/cpp/developer-guide/manage-presentation/convert-presentation/export-to-html5/_index.md
@@ -58,6 +58,10 @@ options->set_AnimateTransitions(true);
 pres->Save(u"pres.html", SaveFormat::Html5, options);
 ```
 
+{{% alert title="Known Issue" color="warning" %}}
+In Aspose.Slides for C++ 25.4, HTML5 conversion may produce overlapping shapes for some PPTX files. This behavior has been fixed in version 26.7. Upgrade to 26.7 or later to obtain the correct layout.
+{{% /alert %}}
+
 ## **Export PowerPoint to HTML**
 
 This C++ demonstrates the standard PowerPoint to HTML process:


### PR DESCRIPTION
Forum topic: [319583](https://forum.aspose.com/t/aspose-slides-for-c-does-not-convert-a-pptx-file-to-html5-correctly/319583) - Aspose.Slides for C++ Does Not Convert a PPTX File to HTML5 Correctly

Summary:
- Add note about overlapping boxes bug in version 25.4 and upgrade to 26.7

Updated documentation:
- Updated section: Export PowerPoint to HTML5