### PR TITLE
fix(docs): lowercase the url: keys that declared capital letters

### DIFF
--- a/ar/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ar/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: تحويل عروض PowerPoint إلى وضع النشرة على Android
 linktitle: وضع النشرة
 type: docs
 weight: 150
-url: /ar/androidjava/convert-powerpoint-in-Handout-mode/
+url: /ar/androidjava/convert-powerpoint-in-handout-mode/
 keywords:
 - تحويل PowerPoint
 - تحويل العرض

--- a/ar/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/ar/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: إضافة أشكال الخط إلى العروض التقديمية ع�
 linktitle: خط
 type: docs
 weight: 50
-url: /ar/androidjava/Line/
+url: /ar/androidjava/line/
 keywords:
 - خط
 - إنشاء خط

--- a/ar/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ar/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: تحويل عروض PowerPoint في وضع النشرة باستخدام 
 linktitle: وضع النشرة
 type: docs
 weight: 150
-url: /ar/cpp/convert-powerpoint-in-Handout-mode/
+url: /ar/cpp/convert-powerpoint-in-handout-mode/
 keywords:
 - تحويل PowerPoint
 - تحويل العرض

--- a/ar/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ar/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: تحويل عروض PowerPoint إلى وضع Handout في جافا
 linktitle: وضع Handout
 type: docs
 weight: 150
-url: /ar/java/convert-powerpoint-in-Handout-mode/
+url: /ar/java/convert-powerpoint-in-handout-mode/
 keywords:
 - تحويل PowerPoint
 - تحويل العرض التقديمي

--- a/ar/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/ar/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: إضافة أشكال الخطوط إلى العروض التقديمية
 linktitle: خط
 type: docs
 weight: 50
-url: /ar/java/Line/
+url: /ar/java/line/
 keywords:
 - خط
 - إنشاء خط

--- a/ar/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ar/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: تحويل عروض PowerPoint التقديمية إلى وضع النش�
 linktitle: وضع النشرة
 type: docs
 weight: 150
-url: /ar/net/convert-powerpoint-in-Handout-mode/
+url: /ar/net/convert-powerpoint-in-handout-mode/
 keywords:
 - تحويل PowerPoint
 - تحويل العرض التقديمي

--- a/ar/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/ar/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: إضافة أشكال الخط إلى العروض التقديمية ف�
 linktitle: خط
 type: docs
 weight: 50
-url: /ar/net/Line/
+url: /ar/net/line/
 keywords:
 - خط
 - إنشاء خط

--- a/ar/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ar/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -2,7 +2,7 @@
 title: تحويل العروض التقديمية في وضع النشرة في JavaScript
 type: docs
 weight: 150
-url: /ar/nodejs-java/convert-powerpoint-in-Handout-mode/
+url: /ar/nodejs-java/convert-powerpoint-in-handout-mode/
 keywords:
 - تحويل PowerPoint
 - وضع النشرة

--- a/ar/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ar/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: تحويل عروض PowerPoint في وضع النشرة باستخدام 
 linktitle: وضع النشرة
 type: docs
 weight: 150
-url: /ar/php-java/convert-powerpoint-in-Handout-mode/
+url: /ar/php-java/convert-powerpoint-in-handout-mode/
 keywords:
 - تحويل PowerPoint
 - تحويل عرض تقديمي

--- a/ar/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/ar/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: إضافة أشكال الخط إلى العروض التقديمية ف�
 linktitle: خط
 type: docs
 weight: 50
-url: /ar/php-java/Line/
+url: /ar/php-java/line/
 keywords:
 - خط
 - إنشاء خط

--- a/ar/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ar/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: تحويل العروض التقديمية في وضع النشرة با�
 linktitle: وضع النشرة
 type: docs
 weight: 150
-url: /ar/python-net/convert-powerpoint-in-Handout-mode/
+url: /ar/python-net/convert-powerpoint-in-handout-mode/
 keywords:
 - تحويل PowerPoint
 - تحويل عرض تقديمي

--- a/de/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/de/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: PowerPoint-Präsentationen im Handout-Modus auf Android konvertieren
 linktitle: Handout-Modus
 type: docs
 weight: 150
-url: /de/androidjava/convert-powerpoint-in-Handout-mode/
+url: /de/androidjava/convert-powerpoint-in-handout-mode/
 keywords:
 - PowerPoint konvertieren
 - Präsentation konvertieren

--- a/de/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/de/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Linienformen zu Präsentationen auf Android hinzufügen
 linktitle: Linie
 type: docs
 weight: 50
-url: /de/androidjava/Line/
+url: /de/androidjava/line/
 keywords:
 - Linie
 - Linie erstellen

--- a/de/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/de/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Präsentationen im Handout‑Modus mit C++ konvertieren
 linktitle: Handout‑Modus
 type: docs
 weight: 150
-url: /de/cpp/convert-powerpoint-in-Handout-mode/
+url: /de/cpp/convert-powerpoint-in-handout-mode/
 keywords:
 - PowerPoint konvertieren
 - Präsentation konvertieren

--- a/de/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/de/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: PowerPoint-Präsentationen im Handout-Modus in Java konvertieren
 linktitle: Handout-Modus
 type: docs
 weight: 150
-url: /de/java/convert-powerpoint-in-Handout-mode/
+url: /de/java/convert-powerpoint-in-handout-mode/
 keywords:
 - PowerPoint konvertieren
 - Präsentation konvertieren

--- a/de/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/de/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: "Linienformen zu Präsentationen in Java hinzufügen"
 linktitle: "Linie"
 type: docs
 weight: 50
-url: /de/java/Line/
+url: /de/java/line/
 keywords:
 - Linie
 - Linie erstellen

--- a/de/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/de/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: PowerPoint-Präsentationen im Handout-Modus in .NET konvertieren
 linktitle: Handout-Modus
 type: docs
 weight: 150
-url: /de/net/convert-powerpoint-in-Handout-mode/
+url: /de/net/convert-powerpoint-in-handout-mode/
 keywords:
 - PowerPoint konvertieren
 - Präsentation konvertieren

--- a/de/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/de/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Linienformen zu Präsentationen in .NET hinzufügen
 linktitle: Linie
 type: docs
 weight: 50
-url: /de/net/Line/
+url: /de/net/line/
 keywords:
 - "Linie"
 - "Linie erstellen"

--- a/de/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/de/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -2,7 +2,7 @@
 title: Präsentationen im Handout-Modus in JavaScript konvertieren
 type: docs
 weight: 150
-url: /de/nodejs-java/convert-powerpoint-in-Handout-mode/
+url: /de/nodejs-java/convert-powerpoint-in-handout-mode/
 keywords:
 - PowerPoint konvertieren
 - Handout-Modus

--- a/de/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/de/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: PowerPoint-Präsentationen im Handout-Modus mit PHP konvertieren
 linktitle: Handout-Modus
 type: docs
 weight: 150
-url: /de/php-java/convert-powerpoint-in-Handout-mode/
+url: /de/php-java/convert-powerpoint-in-handout-mode/
 keywords:
 - PowerPoint konvertieren
 - Präsentation konvertieren

--- a/de/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/de/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: "Linienformen zu Präsentationen in PHP hinzufügen"
 linktitle: "Linie"
 type: docs
 weight: 50
-url: /de/php-java/Line/
+url: /de/php-java/line/
 keywords:
 - Linie
 - Linie erstellen

--- a/de/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/de/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Präsentationen im Handout-Modus mit Python konvertieren
 linktitle: Handout-Modus
 type: docs
 weight: 150
-url: /de/python-net/convert-powerpoint-in-Handout-mode/
+url: /de/python-net/convert-powerpoint-in-handout-mode/
 keywords:
 - PowerPoint konvertieren
 - Präsentation konvertieren

--- a/en/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/en/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convert PowerPoint Presentations in Handout Mode on Android
 linktitle: Handout Mode
 type: docs
 weight: 150
-url: /androidjava/convert-powerpoint-in-Handout-mode/
+url: /androidjava/convert-powerpoint-in-handout-mode/
 keywords:
 - convert PowerPoint
 - convert presentation

--- a/en/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/en/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Add Line Shapes to Presentations on Android
 linktitle: Line
 type: docs
 weight: 50
-url: /androidjava/Line/
+url: /androidjava/line/
 keywords:
 - line
 - create line

--- a/en/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/en/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convert PowerPoint Presentations in Handout Mode Using C++
 linktitle: Handout Mode
 type: docs
 weight: 150
-url: /cpp/convert-powerpoint-in-Handout-mode/
+url: /cpp/convert-powerpoint-in-handout-mode/
 keywords:
 - convert PowerPoint
 - convert presentation

--- a/en/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/en/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convert PowerPoint Presentations in Handout Mode Using Java
 linktitle: Handout Mode
 type: docs
 weight: 150
-url: /java/convert-powerpoint-in-Handout-mode/
+url: /java/convert-powerpoint-in-handout-mode/
 keywords:
 - convert PowerPoint
 - convert presentation

--- a/en/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/en/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Add Line Shapes to Presentations in Java
 linktitle: Line
 type: docs
 weight: 50
-url: /java/Line/
+url: /java/line/
 keywords:
 - line
 - create line

--- a/en/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/en/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Add Line Shapes to Presentations in .NET
 linktitle: Line
 type: docs
 weight: 50
-url: /net/Line/
+url: /net/line/
 keywords:
 - line
 - create line

--- a/en/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/en/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convert PowerPoint Presentations in Handout Mode Using JavaScript
 linktitle: Handout Mode
 type: docs
 weight: 150
-url: /nodejs-java/convert-powerpoint-in-Handout-mode/
+url: /nodejs-java/convert-powerpoint-in-handout-mode/
 keywords:
 - convert PowerPoint
 - convert presentation

--- a/en/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/en/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convert PowerPoint Presentations in Handout Mode Using PHP
 linktitle: Handout Mode
 type: docs
 weight: 150
-url: /php-java/convert-powerpoint-in-Handout-mode/
+url: /php-java/convert-powerpoint-in-handout-mode/
 keywords:
 - convert PowerPoint
 - convert presentation

--- a/en/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/en/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Add Line Shapes to Presentations in PHP
 linktitle: Line
 type: docs
 weight: 50
-url: /php-java/Line/
+url: /php-java/line/
 keywords:
 - line
 - create line

--- a/en/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/en/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convert Presentations in Handout Mode with Python
 linktitle: Handout Mode
 type: docs
 weight: 150
-url: /python-net/convert-powerpoint-in-Handout-mode/
+url: /python-net/convert-powerpoint-in-handout-mode/
 keywords:
 - convert PowerPoint
 - convert presentation

--- a/es/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/es/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convertir presentaciones de PowerPoint en modo Handout en Android
 linktitle: Modo Handout
 type: docs
 weight: 150
-url: /es/androidjava/convert-powerpoint-in-Handout-mode/
+url: /es/androidjava/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - convertir presentación

--- a/es/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/es/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Añadir formas de línea a presentaciones en Android
 linktitle: Línea
 type: docs
 weight: 50
-url: /es/androidjava/Line/
+url: /es/androidjava/line/
 keywords:
 - línea
 - crear línea

--- a/es/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/es/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convertir presentaciones de PowerPoint en modo Folleto usando C++
 linktitle: Modo Folleto
 type: docs
 weight: 150
-url: /es/cpp/convert-powerpoint-in-Handout-mode/
+url: /es/cpp/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - convertir presentación

--- a/es/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/es/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convertir presentaciones de PowerPoint en modo Folleto en Java
 linktitle: Modo Folleto
 type: docs
 weight: 150
-url: /es/java/convert-powerpoint-in-Handout-mode/
+url: /es/java/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - convertir presentación

--- a/es/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/es/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Añadir formas de línea a presentaciones en Java
 linktitle: Línea
 type: docs
 weight: 50
-url: /es/java/Line/
+url: /es/java/line/
 keywords:
 - línea
 - crear línea

--- a/es/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/es/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convertir presentaciones de PowerPoint en modo folleto en .NET
 linktitle: Modo Folleto
 type: docs
 weight: 150
-url: /es/net/convert-powerpoint-in-Handout-mode/
+url: /es/net/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - convertir presentación

--- a/es/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/es/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Agregar formas de línea a presentaciones en .NET
 linktitle: Línea
 type: docs
 weight: 50
-url: /es/net/Line/
+url: /es/net/line/
 keywords:
 - línea
 - crear línea

--- a/es/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/es/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -2,7 +2,7 @@
 title: Convertir presentaciones en modo Folleto en JavaScript
 type: docs
 weight: 150
-url: /es/nodejs-java/convert-powerpoint-in-Handout-mode/
+url: /es/nodejs-java/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - modo folleto

--- a/es/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/es/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convertir presentaciones de PowerPoint en modo de folleto usando PHP
 linktitle: Modo de folleto
 type: docs
 weight: 150
-url: /es/php-java/convert-powerpoint-in-Handout-mode/
+url: /es/php-java/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - convertir presentación

--- a/es/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/es/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Añadir formas de línea a presentaciones en PHP
 linktitle: Línea
 type: docs
 weight: 50
-url: /es/php-java/Line/
+url: /es/php-java/line/
 keywords:
 - línea
 - crear línea

--- a/es/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/es/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convertir presentaciones en modo Folleto con Python
 linktitle: Modo Folleto
 type: docs
 weight: 150
-url: /es/python-net/convert-powerpoint-in-Handout-mode/
+url: /es/python-net/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - convertir presentación

--- a/fr/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/fr/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convertir des présentations PowerPoint en mode distribution sur Android
 linktitle: Mode distribution
 type: docs
 weight: 150
-url: /fr/androidjava/convert-powerpoint-in-Handout-mode/
+url: /fr/androidjava/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - convertir présentation

--- a/fr/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/fr/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Ajouter des formes de ligne aux présentations sur Android
 linktitle: Ligne
 type: docs
 weight: 50
-url: /fr/androidjava/Line/
+url: /fr/androidjava/line/
 keywords:
 - ligne
 - créer une ligne

--- a/fr/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/fr/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convertir des présentations PowerPoint en mode Feuille de distribution a
 linktitle: Mode Feuille de distribution
 type: docs
 weight: 150
-url: /fr/cpp/convert-powerpoint-in-Handout-mode/
+url: /fr/cpp/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - convertir présentation

--- a/fr/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/fr/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convertir les présentations PowerPoint en mode Handout en Java
 linktitle: Mode Handout
 type: docs
 weight: 150
-url: /fr/java/convert-powerpoint-in-Handout-mode/
+url: /fr/java/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - convertir présentation

--- a/fr/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/fr/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Ajouter des formes de ligne aux présentations en Java
 linktitle: Ligne
 type: docs
 weight: 50
-url: /fr/java/Line/
+url: /fr/java/line/
 keywords:
 - ligne
 - créer une ligne

--- a/fr/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/fr/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convertir des présentations PowerPoint en mode Handout dans .NET
 linktitle: Mode Handout
 type: docs
 weight: 150
-url: /fr/net/convert-powerpoint-in-Handout-mode/
+url: /fr/net/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - convertir présentation

--- a/fr/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/fr/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Ajouter des formes de ligne aux présentations en .NET
 linktitle: Ligne
 type: docs
 weight: 50
-url: /fr/net/Line/
+url: /fr/net/line/
 keywords:
 - ligne
 - créer une ligne

--- a/fr/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/fr/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -2,7 +2,7 @@
 title: Convertir des présentations en mode Handout en JavaScript
 type: docs
 weight: 150
-url: /fr/nodejs-java/convert-powerpoint-in-Handout-mode/
+url: /fr/nodejs-java/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - mode Handout

--- a/fr/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/fr/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convertir des présentations PowerPoint en mode fiche avec PHP
 linktitle: Mode fiche
 type: docs
 weight: 150
-url: /fr/php-java/convert-powerpoint-in-Handout-mode/
+url: /fr/php-java/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - convertir présentation

--- a/fr/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/fr/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Ajouter des formes de ligne aux présentations en PHP
 linktitle: Ligne
 type: docs
 weight: 50
-url: /fr/php-java/Line/
+url: /fr/php-java/line/
 keywords:
 - ligne
 - créer une ligne

--- a/fr/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/fr/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Convertir des présentations en mode Dépliant avec Python
 linktitle: Mode Dépliant
 type: docs
 weight: 150
-url: /fr/python-net/convert-powerpoint-in-Handout-mode/
+url: /fr/python-net/convert-powerpoint-in-handout-mode/
 keywords:
 - convertir PowerPoint
 - convertir présentation

--- a/ja/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ja/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: AndroidでハンドアウトモードのPowerPointプレゼンテーシ�
 linktitle: ハンドアウトモード
 type: docs
 weight: 150
-url: /ja/androidjava/convert-powerpoint-in-Handout-mode/
+url: /ja/androidjava/convert-powerpoint-in-handout-mode/
 keywords:
 - PowerPointを変換
 - プレゼンテーションを変換

--- a/ja/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/ja/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Android 上のプレゼンテーションに線形状を追加
 linktitle: 線
 type: docs
 weight: 50
-url: /ja/androidjava/Line/
+url: /ja/androidjava/line/
 keywords:
 - 線
 - 線の作成

--- a/ja/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ja/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: C++ を使用したハンドアウトモードで PowerPoint プレゼン
 linktitle: ハンドアウトモード
 type: docs
 weight: 150
-url: /ja/cpp/convert-powerpoint-in-Handout-mode/
+url: /ja/cpp/convert-powerpoint-in-handout-mode/
 keywords:
 - PowerPoint を変換
 - プレゼンテーションを変換

--- a/ja/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ja/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: JavaでハンドアウトモードでPowerPointプレゼンテーショ�
 linktitle: ハンドアウトモード
 type: docs
 weight: 150
-url: /ja/java/convert-powerpoint-in-Handout-mode/
+url: /ja/java/convert-powerpoint-in-handout-mode/
 keywords:
 - PowerPointを変換
 - プレゼンテーションを変換

--- a/ja/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/ja/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Javaでプレゼンテーションにラインシェイプを追加
 linktitle: ライン
 type: docs
 weight: 50
-url: /ja/java/Line/
+url: /ja/java/line/
 keywords:
 - 線
 - 線の作成

--- a/ja/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ja/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: ".NET でハンドアウトモードの PowerPoint プレゼンテーシ�
 linktitle: "ハンドアウトモード"
 type: docs
 weight: 150
-url: /ja/net/convert-powerpoint-in-Handout-mode/
+url: /ja/net/convert-powerpoint-in-handout-mode/
 keywords:
 - "PowerPoint を変換"
 - "プレゼンテーションを変換"

--- a/ja/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/ja/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: ".NET でプレゼンテーションに線形図形を追加"
 linktitle: "線"
 type: docs
 weight: 50
-url: /ja/net/Line/
+url: /ja/net/line/
 keywords:
   - "線"
   - "線の作成"

--- a/ja/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ja/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -2,7 +2,7 @@
 title: JavaScript でハンドアウトモードでプレゼンテーションを変換する
 type: docs
 weight: 150
-url: /ja/nodejs-java/convert-powerpoint-in-Handout-mode/
+url: /ja/nodejs-java/convert-powerpoint-in-handout-mode/
 keywords:
 - PowerPoint を変換
 - ハンドアウトモード

--- a/ja/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ja/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: PHP を使用した Handout モードで PowerPoint プレゼンテーシ
 linktitle: Handout モード
 type: docs
 weight: 150
-url: /ja/php-java/convert-powerpoint-in-Handout-mode/
+url: /ja/php-java/convert-powerpoint-in-handout-mode/
 keywords:
 - PowerPoint を変換
 - プレゼンテーションを変換

--- a/ja/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/ja/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: PHP でプレゼンテーションに線形状を追加する
 linktitle: 線
 type: docs
 weight: 50
-url: /ja/php-java/Line/
+url: /ja/php-java/line/
 keywords:
 - 線
 - 線の作成

--- a/ja/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ja/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Pythonでハンドアウトモードのプレゼンテーションを変�
 linktitle: ハンドアウトモード
 type: docs
 weight: 150
-url: /ja/python-net/convert-powerpoint-in-Handout-mode/
+url: /ja/python-net/convert-powerpoint-in-handout-mode/
 keywords:
 - PowerPointを変換
 - プレゼンテーションを変換

--- a/ru/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ru/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Конвертировать презентации PowerPoint в реж�
 linktitle: Режим Handout
 type: docs
 weight: 150
-url: /ru/androidjava/convert-powerpoint-in-Handout-mode/
+url: /ru/androidjava/convert-powerpoint-in-handout-mode/
 keywords:
 - конвертировать PowerPoint
 - конвертировать презентацию

--- a/ru/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/ru/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Добавление фигур линий в презентации на
 linktitle: Линия
 type: docs
 weight: 50
-url: /ru/androidjava/Line/
+url: /ru/androidjava/line/
 keywords:
 - линия
 - создать линию

--- a/ru/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ru/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Конвертировать презентации PowerPoint в реж�
 linktitle: Режим раздаточного материала
 type: docs
 weight: 150
-url: /ru/cpp/convert-powerpoint-in-Handout-mode/
+url: /ru/cpp/convert-powerpoint-in-handout-mode/
 keywords:
 - конвертировать PowerPoint
 - конвертировать презентацию

--- a/ru/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ru/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Конвертация презентаций PowerPoint в режиме 
 linktitle: Режим раздатки
 type: docs
 weight: 150
-url: /ru/java/convert-powerpoint-in-Handout-mode/
+url: /ru/java/convert-powerpoint-in-handout-mode/
 keywords:
 - конвертировать PowerPoint
 - конвертировать презентацию

--- a/ru/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/ru/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Добавление линейных фигур в презентаци�
 linktitle: Линия
 type: docs
 weight: 50
-url: /ru/java/Line/
+url: /ru/java/line/
 keywords:
 - линия
 - создать линию

--- a/ru/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ru/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Конвертировать презентации PowerPoint в реж�
 linktitle: Режим раздаточного листа
 type: docs
 weight: 150
-url: /ru/net/convert-powerpoint-in-Handout-mode/
+url: /ru/net/convert-powerpoint-in-handout-mode/
 keywords:
 - конвертировать PowerPoint
 - конвертировать презентацию

--- a/ru/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/ru/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Добавить линейные фигуры в презентации 
 linktitle: Линия
 type: docs
 weight: 50
-url: /ru/net/Line/
+url: /ru/net/line/
 keywords:
 - линия
 - создать линию

--- a/ru/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ru/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -2,7 +2,7 @@
 title: Конвертировать презентации в режиме раздаточного листа в JavaScript
 type: docs
 weight: 150
-url: /ru/nodejs-java/convert-powerpoint-in-Handout-mode/
+url: /ru/nodejs-java/convert-powerpoint-in-handout-mode/
 keywords:
 - конвертировать PowerPoint
 - режим раздаточного листа

--- a/ru/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ru/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Конвертация презентаций PowerPoint в режиме 
 linktitle: Режим раздаточного материала
 type: docs
 weight: 150
-url: /ru/php-java/convert-powerpoint-in-Handout-mode/
+url: /ru/php-java/convert-powerpoint-in-handout-mode/
 keywords:
 - конвертировать PowerPoint
 - конвертировать презентацию

--- a/ru/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/ru/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: Добавить линии в презентации в PHP
 linktitle: Линия
 type: docs
 weight: 50
-url: /ru/php-java/Line/
+url: /ru/php-java/line/
 keywords:
 - линия
 - создать линию

--- a/ru/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/ru/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: Конвертировать презентации в режиме ра�
 linktitle: Режим раздаточного листа
 type: docs
 weight: 150
-url: /ru/python-net/convert-powerpoint-in-Handout-mode/
+url: /ru/python-net/convert-powerpoint-in-handout-mode/
 keywords:
 - конвертировать PowerPoint
 - конвертировать презентацию

--- a/zh/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/zh/androidjava/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: 在 Android 上以讲义模式转换 PowerPoint 演示文稿
 linktitle: 讲义模式
 type: docs
 weight: 150
-url: /zh/androidjava/convert-powerpoint-in-Handout-mode/
+url: /zh/androidjava/convert-powerpoint-in-handout-mode/
 keywords:
 - 转换 PowerPoint
 - 转换 演示文稿

--- a/zh/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/zh/androidjava/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: 在 Android 上向演示文稿添加线形状
 linktitle: 线条
 type: docs
 weight: 50
-url: /zh/androidjava/Line/
+url: /zh/androidjava/line/
 keywords:
 - 线条
 - 创建线条

--- a/zh/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/zh/cpp/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: 使用 C++ 将 PowerPoint 演示文稿转换为讲义模式
 linktitle: 讲义模式
 type: docs
 weight: 150
-url: /zh/cpp/convert-powerpoint-in-Handout-mode/
+url: /zh/cpp/convert-powerpoint-in-handout-mode/
 keywords:
 - 转换 PowerPoint
 - 转换 演示文稿

--- a/zh/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/zh/java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: 在 Java 中将 PowerPoint 演示文稿转换为讲义模式
 linktitle: 讲义模式
 type: docs
 weight: 150
-url: /zh/java/convert-powerpoint-in-Handout-mode/
+url: /zh/java/convert-powerpoint-in-handout-mode/
 keywords:
 - 转换 PowerPoint
 - 转换 演示文稿

--- a/zh/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/zh/java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: 在 Java 中向演示文稿添加线形状
 linktitle: 线
 type: docs
 weight: 50
-url: /zh/java/Line/
+url: /zh/java/line/
 keywords:
 - 线
 - 创建线

--- a/zh/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/zh/net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: 在 .NET 中以讲义模式转换 PowerPoint 演示文稿
 linktitle: 讲义模式
 type: docs
 weight: 150
-url: /zh/net/convert-powerpoint-in-Handout-mode/
+url: /zh/net/convert-powerpoint-in-handout-mode/
 keywords:
 - 转换 PowerPoint
 - 转换 演示文稿

--- a/zh/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/zh/net/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: 在 .NET 中向演示文稿添加线条形状
 linktitle: 线条
 type: docs
 weight: 50
-url: /zh/net/Line/
+url: /zh/net/line/
 keywords:
 - 线条
 - 创建线条

--- a/zh/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/zh/nodejs-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -2,7 +2,7 @@
 title: 在 JavaScript 中将演示文稿转换为讲义模式
 type: docs
 weight: 150
-url: /zh/nodejs-java/convert-powerpoint-in-Handout-mode/
+url: /zh/nodejs-java/convert-powerpoint-in-handout-mode/
 keywords:
 - 转换 PowerPoint
 - 讲义模式

--- a/zh/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/zh/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: 使用 PHP 在讲义模式下转换 PowerPoint 演示文稿
 linktitle: 讲义模式
 type: docs
 weight: 150
-url: /zh/php-java/convert-powerpoint-in-Handout-mode/
+url: /zh/php-java/convert-powerpoint-in-handout-mode/
 keywords:
 - 转换 PowerPoint
 - 转换 演示文稿

--- a/zh/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
+++ b/zh/php-java/developer-guide/presentation-content/powerpoint-shapes/shape-types/line/_index.md
@@ -3,7 +3,7 @@ title: 在 PHP 中向演示文稿添加线形状
 linktitle: 线条
 type: docs
 weight: 50
-url: /zh/php-java/Line/
+url: /zh/php-java/line/
 keywords:
 - 线条
 - 创建线条

--- a/zh/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
+++ b/zh/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-in-Handout-mode/_index.md
@@ -3,7 +3,7 @@ title: 使用 Python 将演示文稿转换为讲义模式
 linktitle: 讲义模式
 type: docs
 weight: 150
-url: /zh/python-net/convert-powerpoint-in-Handout-mode/
+url: /zh/python-net/convert-powerpoint-in-handout-mode/
 keywords:
 - 转换 PowerPoint
 - 转换 演示文稿


### PR DESCRIPTION
Ten English pages, 87 across the 8 published locales, declared a `url:` containing
capitals such as /net/Line/ and /cpp/convert-powerpoint-in-Handout-mode/.

No aliases are added and no live URL changes. Hugo lowercases every output path by
default (disablePathToLower is unset), so these keys never produced a capitalised live
URL: /net/Line/ returns 404 today while /net/line/ returns 200, and a full build emits
no directory containing an uppercase letter.

This is hygiene -- the repository currently declares a URL the site does not serve. It
also removes a latent risk for a future Hugo upgrade, where a change in path-casing
behaviour would silently move these URLs.

87 files, one `url:` line each.