### PR TITLE
ci: fail the check when a url: is removed without an alias

### DIFF
--- a/.github/scripts/check_url_removal.py
+++ b/.github/scripts/check_url_removal.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Fail the build when a `url:` front-matter key disappears without an alias.
+
+WHY THIS EXISTS
+    The live URL of every page on docs.aspose.com/slides comes from its `url:` front-matter key,
+    not from its file path. The Hugo build runs with --cleanDestinationDir and the deploy does
+    `sudo rm -rf` on the live directory, so the moment a `url:` value changes or vanishes, the old
+    URL returns a hard 404 with no redirect.
+
+    Measured 2026-07-28: 227 URLs carrying 62,287 impressions/year were 404ing, and the content repo
+    contained NO `aliases:` key anywhere in 43,566 files. Three URL-destroying renames landed in the
+    eight weeks before that measurement (SLIDESDOC-609, -731, -753).
+
+    Hugo 0.80 supports `aliases:` natively. This check makes forgetting it a build failure instead of
+    a silent traffic loss discovered a quarter later.
+
+USAGE
+    python check_url_removal.py <base-ref> <head-ref>
+
+    Exit 0  — no URL was removed, or every removed URL is covered by an alias somewhere in HEAD.
+    Exit 1  — at least one URL vanished with no alias. The offending URLs are printed.
+
+    Run it from inside the content repository (Aspose.Slides-Documentation).
+
+CI EXAMPLE (.github/workflows/url-stability.yml in the content repo)
+
+    name: URL stability
+    on: pull_request
+    jobs:
+      check:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+            with: { fetch-depth: 0 }
+          - run: python check_url_removal.py origin/${{ github.base_ref }} HEAD
+"""
+import re
+import subprocess
+import sys
+
+URL_KEY = re.compile(r'^url:\s*(\S+)', re.M)
+
+
+def _git(args):
+    """Run a git command and return stdout, tolerating the 'no matches' exit code from git grep."""
+    r = subprocess.run(['git'] + args, capture_output=True, text=True,
+                       encoding='utf-8', errors='replace')
+    return r.stdout
+
+
+def urls_at(ref):
+    """Every `url:` value declared anywhere in the tree at `ref`, normalised to a trailing slash."""
+    out = _git(['grep', '-h', '^url:', ref, '--', '*.md'])
+    found = set()
+    for m in URL_KEY.finditer(out):
+        u = m.group(1).strip().strip('"\'')
+        if u:
+            found.add(u.rstrip('/') + '/')
+    return found
+
+
+def aliases_at(ref):
+    """Every alias declared at `ref`.
+
+    Aliases are a YAML list, so the values sit on continuation lines after the `aliases:` key:
+
+        aliases:
+          - /python-net/manage-bullet-and-numbered-lists/
+
+    `git grep -A` gives us those continuation lines. We accept any line in that window that looks
+    like a list item pointing at an absolute path, which is deliberately permissive — a false
+    'covered' is a missed warning, while a false 'uncovered' would block a legitimate build.
+    """
+    out = _git(['grep', '-h', '-A', '10', '^aliases:', ref, '--', '*.md'])
+    found = set()
+    for line in out.split('\n'):
+        s = line.strip()
+        if s.startswith('- '):
+            v = s[2:].strip().strip('"\'')
+            if v.startswith('/'):
+                found.add(v.rstrip('/') + '/')
+    return found
+
+
+def main(argv):
+    if len(argv) != 3:
+        print(__doc__)
+        return 2
+    base, head = argv[1], argv[2]
+
+    before = urls_at(base)
+    if not before:
+        # A ref with no `url:` keys at all means the ref is wrong or the checkout is shallow.
+        # Failing here would block every build, so warn loudly and pass.
+        print('WARNING: no url: keys found at %s — is the checkout shallow? Skipping check.' % base)
+        return 0
+
+    lost = before - urls_at(head) - aliases_at(head)
+    if lost:
+        print('ERROR: %d URL(s) removed with no alias.\n' % len(lost))
+        for u in sorted(lost):
+            print('   ', u)
+        print('\nAdd the old URL to the new page\'s front matter:\n')
+        print('    aliases:')
+        print('      - %s' % sorted(lost)[0])
+        return 1
+
+    print('OK: no unaliased URL removals (%d URLs checked)' % len(before))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/.github/workflows/url-stability.yml
+++ b/.github/workflows/url-stability.yml
@@ -1,0 +1,31 @@
+name: URL stability
+
+# The live URL of every page comes from its `url:` front-matter key, not its file path.
+# The Hugo build runs --cleanDestinationDir and the deploy does `sudo rm -rf` on the live
+# directory, so the moment a `url:` changes or vanishes the old URL becomes a hard 404
+# with no redirect.
+#
+# Measured 2026-07-28: 227 URLs carrying 62,287 impressions/year were 404ing, and the repo
+# contained no `aliases:` key anywhere. Three URL-destroying renames landed in the eight
+# weeks before that (SLIDESDOC-609, -731, -753). This makes forgetting an alias a failed
+# check instead of a traffic loss discovered a quarter later.
+
+on:
+  pull_request:
+    paths:
+      - '**.md'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history: the check diffs the PR head against the base branch.
+          fetch-depth: 0
+
+      - name: Fetch the base branch
+        run: git fetch --no-tags origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - name: Check for unaliased URL removals
+        run: python .github/scripts/check_url_removal.py "origin/${{ github.base_ref }}" HEAD


### PR DESCRIPTION
The live URL of every page comes from its `url:` front-matter key, not its file path.
The build runs --cleanDestinationDir and the deploy replaces the live directory, so when
a `url:` changes or is removed the old URL 404s immediately with no redirect. Hugo
supports `aliases:` natively; this makes forgetting one a failed check rather than a
silent breakage.

Verified against this repository's own history. Replayed against 45f59eff0
("SLIDESDOC-609 Move the articles about paragraphs and text portions"), it reports the
14 URLs that commit removed without aliases and exits 1. On unchanged master it exits 0.
Tested directly as well: renaming a `url:` without an alias fails, and adding the alias
passes.

Design notes:
- Alias detection is deliberately permissive (any "- /path/" within 10 lines of an
  `aliases:` key). A missed warning is better than blocking a legitimate build.
- A base ref with no `url:` keys warns and passes, so a shallow checkout or a wrong ref
  cannot break every pull request. Hence fetch-depth: 0 plus an explicit base fetch.
- Compares URL sets rather than files, so moving a page between directories is fine as
  long as its `url:` is unchanged.