### PR TITLE
fix(seo): add aliases for 39 URLs that currently 404

### DIFF
--- a/de/androidjava/developer-guide/manage-presentation/convert-presentation/export-to-html5/_index.md
+++ b/de/androidjava/developer-guide/manage-presentation/convert-presentation/export-to-html5/_index.md
@@ -4,6 +4,8 @@ linktitle: Präsentation nach HTML5
 type: docs
 weight: 40
 url: /de/androidjava/export-to-html5/
+aliases:
+  - /de/androidjava/export-nach-html5/
 keywords:
 - PowerPoint nach HTML5
 - OpenDocument nach HTML5

--- a/de/net/plugins/aspose-slides-for-openxml/missing-features-in-openxml/get-the-file-format-of-presentation/_index.md
+++ b/de/net/plugins/aspose-slides-for-openxml/missing-features-in-openxml/get-the-file-format-of-presentation/_index.md
@@ -3,6 +3,8 @@ title: Dateiformat der Präsentation abrufen
 type: docs
 weight: 50
 url: /de/net/get-the-file-format-of-presentation/
+aliases:
+  - /de/net/presentation-format/
 ---
 
 Um das Dateiformat zu erhalten, folgen Sie bitte den untenstehenden Schritten:

--- a/de/reportingservices/getting-started/sharepoint-adventures-setting-up-reporting-services-with-sharepoint-integration/introduction-and-environment-setup/_index.md
+++ b/de/reportingservices/getting-started/sharepoint-adventures-setting-up-reporting-services-with-sharepoint-integration/introduction-and-environment-setup/_index.md
@@ -3,6 +3,8 @@ title: Einführung und Umgebungssetup
 type: docs  
 weight: 10  
 url: /de/reportingservices/introduction-and-environment-setup/  
+aliases:
+  - /de/reportingservices/introduction-amp-environment-setup/
 ---  
   
 {{% alert color="primary" %}}  

--- a/en/androidjava/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
+++ b/en/androidjava/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
@@ -4,6 +4,8 @@ linktitle: Manage Paragraph
 type: docs
 weight: 40
 url: /androidjava/manage-paragraph/
+aliases:
+  - /androidjava/paragraph/
 keywords:
 - add text
 - add paragraph

--- a/en/cpp/developer-guide/presentation-content/manage-text/extract-text-from-presentation/_index.md
+++ b/en/cpp/developer-guide/presentation-content/manage-text/extract-text-from-presentation/_index.md
@@ -4,6 +4,8 @@ linktitle: Extract Text
 type: docs
 weight: 90
 url: /cpp/extract-text-from-presentation/
+aliases:
+  - /cpp/extracting-text-from-the-presentation/
 keywords:
 - extract text
 - extract text from slide

--- a/en/cpp/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
+++ b/en/cpp/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
@@ -4,6 +4,9 @@ linktitle: Manage Paragraph
 type: docs
 weight: 40
 url: /cpp/manage-paragraph/
+aliases:
+  - /cpp/paragraph/
+  - /cpp/portion/
 keywords:
 - add text
 - add paragraph

--- a/en/cpp/developer-guide/presentation-content/powerpoint-charts/create-chart/_index.md
+++ b/en/cpp/developer-guide/presentation-content/powerpoint-charts/create-chart/_index.md
@@ -4,6 +4,8 @@ linktitle: Create or Update Charts
 type: docs
 weight: 10
 url: /cpp/create-chart/
+aliases:
+  - /cpp/update-chart/
 keywords:
 - add chart
 - create chart

--- a/en/cpp/getting-started/features-overview/_index.md
+++ b/en/cpp/getting-started/features-overview/_index.md
@@ -3,6 +3,8 @@ title: Features Overview
 type: docs
 weight: 10
 url: /cpp/features-overview/
+aliases:
+  - /cpp/aspose-slides-for-c-features/
 keywords:
 - features
 - supported platforms

--- a/en/java/developer-guide/migration-from-earlier-versions-of-aspose-slides-for-java/public-api-and-backwards-incompatible-changes-in-aspose-slides-for-java-15-6-0/_index.md
+++ b/en/java/developer-guide/migration-from-earlier-versions-of-aspose-slides-for-java/public-api-and-backwards-incompatible-changes-in-aspose-slides-for-java-15-6-0/_index.md
@@ -4,6 +4,8 @@ linktitle: Aspose.Slides for Java 15.6.0
 type: docs
 weight: 140
 url: /java/public-api-and-backwards-incompatible-changes-in-aspose-slides-for-java-15-6-0/
+aliases:
+  - /java/aspose-slides-for-java-15-6-0-release-notes/
 keywords:
 - migration
 - legacy code

--- a/en/java/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
+++ b/en/java/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
@@ -4,6 +4,9 @@ linktitle: Manage Paragraph
 type: docs
 weight: 40
 url: /java/manage-paragraph/
+aliases:
+  - /java/paragraph/
+  - /java/portion/
 keywords:
 - add text
 - add paragraph

--- a/en/java/developer-guide/technical-articles/common-errors-involving-fonts/_index.md
+++ b/en/java/developer-guide/technical-articles/common-errors-involving-fonts/_index.md
@@ -3,6 +3,8 @@ title: Common Exceptions and Errors Involving Fonts on Linux
 type: docs
 weight: 200
 url: /java/common-errors-involving-fonts/
+aliases:
+  - /java/technical-articles/common-errors-involving-fonts/
 keywords: "Font exception, Font error, Linux, Java, Aspose.Slides for Java"
 description: "Font exceptions and errors on Linux"
 ---

--- a/en/net/developer-guide/presentation-content/manage-text/extract-text-from-presentation/_index.md
+++ b/en/net/developer-guide/presentation-content/manage-text/extract-text-from-presentation/_index.md
@@ -4,6 +4,9 @@ linktitle: Extract Text
 type: docs
 weight: 90
 url: /net/extract-text-from-presentation/
+aliases:
+  - /net/slides-on-cloud-platforms/extracting-text/overview/
+  - /net/slides-on-cloud-platforms/extracting-text/slides/
 keywords:
 - extract text
 - extract text from slide

--- a/en/net/developer-guide/presentation-content/manage-text/manage-lists/_index.md
+++ b/en/net/developer-guide/presentation-content/manage-text/manage-lists/_index.md
@@ -4,6 +4,8 @@ linktitle: Manage Lists
 type: docs
 weight: 70
 url: /net/manage-lists/
+aliases:
+  - /net/manage-bullet-and-numbered-lists/
 keywords:
 - bullet
 - bulleted list

--- a/en/net/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
+++ b/en/net/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
@@ -4,6 +4,9 @@ linktitle: Manage Paragraph
 type: docs
 weight: 40
 url: /net/manage-paragraph/
+aliases:
+  - /net/paragraph/
+  - /net/portion/
 keywords:
 - add text
 - add paragraph

--- a/en/net/developer-guide/presentation-content/powerpoint-smartart/_index.md
+++ b/en/net/developer-guide/presentation-content/powerpoint-smartart/_index.md
@@ -4,6 +4,8 @@ linktitle: PowerPoint SmartArt
 type: docs
 weight: 100
 url: /net/powerpoint-smartart/
+aliases:
+  - /net/examples/elements/smartart/
 keywords:
 - SmartArt
 - manage SmartArt

--- a/en/net/developer-guide/slides-for-net-6-cross-platform-zip-package/_index.md
+++ b/en/net/developer-guide/slides-for-net-6-cross-platform-zip-package/_index.md
@@ -3,6 +3,8 @@ title: Aspose.Slides for .NET 6 Cross-Platform (ZIP Package)
 type: docs
 weight: 237
 url: /net/slides-for-net-6-cross-platform-zip-package/
+aliases:
+  - /net/slides-for-net-6-cross-platform/
 keywords:
 - cross-platform
 - .NET 6

--- a/en/net/developer-guide/technical-articles/excel-integration/_index.md
+++ b/en/net/developer-guide/technical-articles/excel-integration/_index.md
@@ -4,6 +4,8 @@ linktitle: Excel Integration
 type: docs
 weight: 330
 url: /net/excel-integration/
+aliases:
+  - /net/developer-guide/technical-articles/excel-integration/
 keywords:
 - Excel
 - workbook

--- a/en/net/examples/elements/header-footer/_index.md
+++ b/en/net/examples/elements/header-footer/_index.md
@@ -3,6 +3,8 @@ title: Header Footer
 type: docs
 weight: 220
 url: /net/examples/elements/header-footer/
+aliases:
+  - /net/examples/elements/elements/header-footer/
 keywords:
 - header footer
 - add header footer

--- a/en/net/examples/elements/note/_index.md
+++ b/en/net/examples/elements/note/_index.md
@@ -3,6 +3,8 @@ title: Note
 type: docs
 weight: 240
 url: /net/examples/elements/note/
+aliases:
+  - /net/examples/elements/elements/note/
 keywords:
 - note
 - add notes slide

--- a/en/net/getting-started/why-not-open-xml-sdk/_index.md
+++ b/en/net/getting-started/why-not-open-xml-sdk/_index.md
@@ -3,6 +3,8 @@ title: Why Not Open XML SDK
 type: docs
 weight: 50
 url: /net/why-not-open-xml-sdk/
+aliases:
+  - /net/slides-on-cloud-platforms/extracting-text/open-xml-sdk/
 keywords:
 - Open XML SDK
 - comparing

--- a/en/net/plugins/aspose-slides-for-openxml/missing-features-in-openxml/get-the-file-format-of-presentation/_index.md
+++ b/en/net/plugins/aspose-slides-for-openxml/missing-features-in-openxml/get-the-file-format-of-presentation/_index.md
@@ -3,6 +3,8 @@ title: Get the File Format of Presentation
 type: docs
 weight: 50
 url: /net/get-the-file-format-of-presentation/
+aliases:
+  - /net/presentation-format/
 ---
 
 In order to get the file format. Please follow the steps below:

--- a/en/nodejs-java/developer-guide/known-issues/object-preview-issue-when-adding-oleobjectframe/_index.md
+++ b/en/nodejs-java/developer-guide/known-issues/object-preview-issue-when-adding-oleobjectframe/_index.md
@@ -4,6 +4,8 @@ linktitle: OLE Object Issue
 type: docs
 weight: 10
 url: /nodejs-java/object-preview-issue-when-adding-oleobjectframe/
+aliases:
+  - /nodejs-java/object-changed-issue-when-adding-oleobjectframe/
 keywords:
 - OLE
 - preview issue

--- a/en/nodejs-java/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
+++ b/en/nodejs-java/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
@@ -4,6 +4,9 @@ linktitle: Manage Paragraph
 type: docs
 weight: 40
 url: /nodejs-java/manage-paragraph/
+aliases:
+  - /nodejs-java/paragraph/
+  - /nodejs-java/portion/
 keywords:
 - add text
 - add paragraph

--- a/en/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/_index.md
+++ b/en/php-java/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/_index.md
@@ -4,6 +4,8 @@ linktitle: Convert PowerPoint
 type: docs
 weight: 20
 url: /php-java/convert-powerpoint/
+aliases:
+  - /php-java/convert-powerpoint-to-word/
 keywords:
 - convert PowerPoint
 - convert presentation

--- a/en/php-java/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
+++ b/en/php-java/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
@@ -4,6 +4,8 @@ linktitle: Manage Paragraph
 type: docs
 weight: 40
 url: /php-java/manage-paragraph/
+aliases:
+  - /php-java/paragraph/
 keywords:
 - add text
 - add paragraph

--- a/en/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-pdf/_index.md
+++ b/en/python-net/developer-guide/manage-presentation/convert-presentation/convert-powerpoint/convert-powerpoint-to-pdf/_index.md
@@ -4,6 +4,8 @@ linktitle: PowerPoint to PDF
 type: docs
 weight: 40
 url: /python-net/convert-powerpoint-to-pdf/
+aliases:
+  - /python-net/convert-to-pdf/
 keywords:
 - convert PowerPoint
 - presentation

--- a/en/python-net/developer-guide/presentation-content/manage-text/manage-lists/_index.md
+++ b/en/python-net/developer-guide/presentation-content/manage-text/manage-lists/_index.md
@@ -4,6 +4,8 @@ linktitle: Manage Lists
 type: docs
 weight: 70
 url: /python-net/manage-lists/
+aliases:
+  - /python-net/manage-bullet-and-numbered-lists/
 keywords:
 - bullet
 - bulleted list

--- a/en/python-net/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
+++ b/en/python-net/developer-guide/presentation-content/manage-text/manage-paragraph/_index.md
@@ -4,6 +4,9 @@ linktitle: Manage Paragraph
 type: docs
 weight: 40
 url: /python-net/manage-paragraph/
+aliases:
+  - /python-net/paragraph/
+  - /python-net/portion/
 keywords:
 - add text
 - add paragraph

--- a/es/net/developer-guide/presentation-content/powerpoint-smartart/_index.md
+++ b/es/net/developer-guide/presentation-content/powerpoint-smartart/_index.md
@@ -4,6 +4,8 @@ linktitle: SmartArt de PowerPoint
 type: docs
 weight: 100
 url: /es/net/powerpoint-smartart/
+aliases:
+  - /es/net/examples/elements/smartart/
 keywords:
 - SmartArt
 - administrar SmartArt

--- a/es/net/examples/elements/header-footer/_index.md
+++ b/es/net/examples/elements/header-footer/_index.md
@@ -3,6 +3,8 @@ title: Encabezado y pie de página
 type: docs
 weight: 220
 url: /es/net/examples/elements/header-footer/
+aliases:
+  - /es/net/examples/elements/elements/header-footer/
 keywords:
 - encabezado y pie de página
 - agregar encabezado y pie de página

--- a/fr/net/developer-guide/presentation-content/powerpoint-smartart/_index.md
+++ b/fr/net/developer-guide/presentation-content/powerpoint-smartart/_index.md
@@ -4,6 +4,8 @@ linktitle: SmartArt PowerPoint
 type: docs
 weight: 100
 url: /fr/net/powerpoint-smartart/
+aliases:
+  - /fr/net/examples/elements/smartart/
 keywords:
 - SmartArt
 - gérer SmartArt

--- a/ru/net/developer-guide/presentation-content/powerpoint-smartart/_index.md
+++ b/ru/net/developer-guide/presentation-content/powerpoint-smartart/_index.md
@@ -4,6 +4,8 @@ linktitle: SmartArt в PowerPoint
 type: docs
 weight: 100
 url: /ru/net/powerpoint-smartart/
+aliases:
+  - /ru/net/examples/elements/smartart/
 keywords:
 - SmartArt
 - управление SmartArt

--- a/ru/net/plugins/aspose-slides-for-openxml/missing-features-in-openxml/get-the-file-format-of-presentation/_index.md
+++ b/ru/net/plugins/aspose-slides-for-openxml/missing-features-in-openxml/get-the-file-format-of-presentation/_index.md
@@ -3,6 +3,8 @@ title: Получить формат файла презентации
 type: docs
 weight: 50
 url: /ru/net/get-the-file-format-of-presentation/
+aliases:
+  - /ru/net/presentation-format/
 ---
 
 Чтобы получить формат файла, выполните следующие шаги:


### PR DESCRIPTION
Adds Hugo `aliases:` to 33 pages, restoring 39 URLs that return 404 today.

The repository previously contained no `aliases:` key anywhere. Because the build runs
--cleanDestinationDir and the deploy replaces the live directory, every past rename
started 404ing immediately.

Candidates were generated by slug matching and then reviewed by hand: 12 were dropped
and 9 retargeted. The notable corrections:

- /<family>/portion/ had been matched to /<family>/portion-bounds/, a narrow measuring
  API. Retargeted to /<family>/manage-paragraph/, where the paragraph and portion
  content actually moved.
- Two .../extracting-text/... URLs were matched on their last path segment and pointed
  at unrelated pages. Retargeted to the text-extraction article.
- /cpp/update-chart/ had been matched to a stub titled "Chart"; retargeted to
  /cpp/create-chart/ ("Create or Update PowerPoint Presentation Charts in C++").
- Five release-notes URLs had been matched to a Features page and were dropped. A 404 is
  a better answer than a confidently wrong page.

Five further candidates were dropped because they break the build. Hugo writes an alias
as <path>/index.html, so aliasing an indexed image URL such as
.../adding-picture-frame-with-animation_1.png/ creates a directory exactly where that
page's own image resource must be published:

  ERROR Failed to publish Resource for page ".../_index.md":
        open .../adding-picture-frame-with-animation_1.png: is a directory
  Error: Error building site: logged 4 error(s)

Verified on the vendored Hugo 0.80.0 with a full English build: 3,574 pages, 31 aliases
emitted (the remaining 8 are in non-English trees), no errors, target pages intact and
image resources still published.