### PR TITLE
fix(seo): render the family name in the title suffix instead of "Documentation"

### DIFF
--- a/ar/androidjava/_index.md
+++ b/ar/androidjava/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides لـ Android عبر Java
-second_title: وثائق Aspose.Slides
+second_title: Aspose.Slides for Android
 description: يوفر Aspose.Slides لـ Android العديد من الميزات الرئيسية التي تتيح لك إضافة وتعديل والتلاعب بالنصوص والأشكال والجداول والرسوم المتحركة والصوتيات ومقاطع الفيديو في الشرائح.
 type: docs
 weight: 40

--- a/ar/cpp/_index.md
+++ b/ar/cpp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides لـ C++
-second_title: وثائق Aspose.Slides
+second_title: Aspose.Slides for C++
 description: Aspose.Slides لـ C++ هو العنصر الأول والوحيد الذي يوفر الوظائف لإدارة مستندات PowerPoint®.
 type: docs
 weight: 30

--- a/ar/jasperreports/_index.md
+++ b/ar/jasperreports/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides لـ JasperReports
-second_title: توثيق Aspose.Slides
+second_title: Aspose.Slides for JasperReports
 description: Aspose.Slides لـ JasperReports هي مكتبة مصممة ومطورة خصيصًا للمطورين الذين يحتاجون إلى تصدير التقارير بسهولة من JasperReports إلى صيغ Microsoft PowerPoint Presentation (PPT) وMicrosoft PowerPoint Show (PPS) في تطبيقاتهم المكتوبة بلغة Java.
 type: docs
 weight: 70

--- a/ar/java/_index.md
+++ b/ar/java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides لجافا
-second_title: وثائق Aspose.Slides
+second_title: Aspose.Slides for Java
 description: Aspose.Slides لجافا هو المكون الأول والوحيد الذي يقدم الوظائف اللازمة لإدارة مستندات PowerPoint®. يقدم Aspose.Slides لجافا العديد من الميزات الرئيسية مثل إدارة النصوص والأشكال، وتصدير الشرائح إلى SVG و PDF وصيغ أخرى.
 type: docs
 weight: 20

--- a/ar/net/_index.md
+++ b/ar/net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides لـ .NET
-second_title: "توثيق Aspose.Slides"
+second_title: Aspose.Slides for .NET
 type: docs
 weight: 10
 url: /ar/net/

--- a/ar/nodejs-java/_index.md
+++ b/ar/nodejs-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides لـ Node.js عبر Java
-second_title: "Aspose.Slides لـ Node.js عبر توثيق .NET"
+second_title: Aspose.Slides for Node.js
 description: يوفر Aspose.Slides لـ Node.js عبر Java العديد من الميزات الرئيسية مثل إدارة النصوص والأشكال والجداول والرسوم المتحركة، وإضافة الصوت والفيديو إلى الشرائح، ومعاينة الشرائح، وتصدير الشرائح إلى SVG و PDF والمزيد.
 type: docs
 weight: 47

--- a/ar/nodejs-net/_index.md
+++ b/ar/nodejs-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides لـ Node.js عبر .NET
-second_title: "توثيق Aspose.Slides لـ Node.js عبر .NET"
+second_title: Aspose.Slides for Node.js
 description: يوفر Aspose.Slides لـ Node.js عبر .NET الكثير من الميزات الرئيسية مثل إدارة النصوص والأشكال والجداول والرسوم المتحركة، وإضافة الصوت والفيديو إلى الشرائح، ومعاينة الشرائح، وتصدير الشرائح إلى SVG، وصيغة PDF والمزيد.
 type: docs
 weight: 47

--- a/ar/php-java/_index.md
+++ b/ar/php-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides لـ PHP عبر Java
-second_title: "توثيق Aspose.Slides لـ PHP"
+second_title: Aspose.Slides for PHP
 description: يوفر Aspose.Slides لـ PHP عبر Java العديد من الميزات الأساسية مثل إدارة النصوص والأشكال والجداول والرسوم المتحركة، وإضافة الصوت والفيديو إلى الشرائح، ومعاينة الشرائح، وتصدير الشرائح إلى تنسيق SVG وPDF والمزيد.
 type: docs
 weight: 45

--- a/ar/python-java/_index.md
+++ b/ar/python-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides لـ Python عبر Java
-second_title: "وثائق Aspose.Slides لـ Python"
+second_title: Aspose.Slides for Python
 description: توفر Aspose.Slides لـ Python عبر Java العديد من الميزات الرئيسية مثل إدارة النصوص والأشكال والجداول والرسوم المتحركة، وإضافة الصوت والفيديو إلى الشرائح، ومعاينة الشرائح، وتصدير الشرائح إلى تنسيق SVG و PDF والمزيد.
 type: docs
 weight: 47

--- a/ar/python-net/_index.md
+++ b/ar/python-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides لـ Python عبر .NET
-second_title: "وثائق Aspose.Slides لـ Python"
+second_title: Aspose.Slides for Python
 type: docs
 weight: 35
 url: /ar/python-net/

--- a/ar/reportingservices/_index.md
+++ b/ar/reportingservices/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides لخدمات التقارير
-second_title: وثائق Aspose.Slides
+second_title: Aspose.Slides for Reporting Services
 description: Aspose.Slides لخدمات التقارير هي الحل الوحيد في السوق الذي يجعل من الممكن إنشاء تقارير PPT و PPS حقيقية في Microsoft SQL Server 2005 و 2008 و 2012 و 2016 و 2017 (32-bit و 64-bit).
 type: docs
 weight: 50

--- a/ar/sharepoint/_index.md
+++ b/ar/sharepoint/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides لـ SharePoint
-second_title: توثيق Aspose.Slides
+second_title: Aspose.Slides for SharePoint
 description: Aspose.Slides لـ SharePoint هو حل مرن يجعل من الممكن تحويل مستندات PowerPoint® داخل مواقع Microsoft SharePoint.
 type: docs
 weight: 60

--- a/de/androidjava/_index.md
+++ b/de/androidjava/_index.md
@@ -1,6 +1,6 @@
 ---  
 title: Aspose.Slides für Android über Java  
-second_title: Aspose.Slides Dokumentation  
+second_title: Aspose.Slides for Android
 description: Aspose.Slides für Android bietet viele wichtige Funktionen, die es Ihnen ermöglichen, Texte, Formen, Tabellen und Animationen, Audios und Videos in Folien hinzuzufügen, zu ändern und zu manipulieren.  
 type: docs  
 weight: 40  

--- a/de/cpp/_index.md
+++ b/de/cpp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides für C++
-second_title: Aspose.Slides Dokumentation
+second_title: Aspose.Slides for C++
 description: Aspose.Slides für C++ ist die erste und einzige Komponente, die die Funktionalität zur Verwaltung von PowerPoint®-Dokumenten bereitstellt.
 type: docs
 weight: 30

--- a/de/jasperreports/_index.md
+++ b/de/jasperreports/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides für JasperReports
-second_title: Aspose.Slides Dokumentation
+second_title: Aspose.Slides for JasperReports
 description: Aspose.Slides für JasperReports ist eine Bibliothek, die speziell für Entwickler entwickelt wurde, die Berichte aus JasperReports einfach in Microsoft PowerPoint-Präsentationen (PPT) und Microsoft PowerPoint-Präsentationen (PPS) in ihren Java-Anwendungen exportieren müssen.
 type: docs
 weight: 70

--- a/de/java/_index.md
+++ b/de/java/_index.md
@@ -1,6 +1,6 @@
 ---  
 title: Aspose.Slides für Java  
-second_title: Aspose.Slides Dokumentation  
+second_title: Aspose.Slides for Java
 description: Aspose.Slides für Java ist die erste und einzige Komponente, die die Funktionalität zur Verwaltung von PowerPoint®-Dokumenten bereitstellt. Aspose.Slides für Java bietet viele Schlüsselmerkmale wie die Verwaltung von Text, Formen und das Exportieren von Folien in SVG, PDF und andere Formate.  
 type: docs  
 weight: 20  

--- a/de/net/_index.md
+++ b/de/net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides für .NET
-second_title: "Aspose.Slides Dokumentation"
+second_title: Aspose.Slides for .NET
 type: docs
 weight: 10
 url: /de/net/

--- a/de/nodejs-java/_index.md
+++ b/de/nodejs-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides für Node.js über Java
-second_title: "Aspose.Slides für Node.js über .NET Dokumentation"
+second_title: Aspose.Slides for Node.js
 description: Aspose.Slides für Node.js über Java bietet viele wichtige Funktionen wie das Verwalten von Text, Formen, Tabellen & Animationen, das Hinzufügen von Audio und Video zu Folien, das Vorschauen von Folien, das Exportieren von Folien in SVG-, PDF-Format und mehr.
 type: docs
 weight: 47

--- a/de/nodejs-net/_index.md
+++ b/de/nodejs-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides für Node.js über .NET
-second_title: "Aspose.Slides für Node.js über .NET Dokumentation"
+second_title: Aspose.Slides for Node.js
 description: Aspose.Slides für Node.js über .NET bietet viele wichtige Funktionen wie das Verwalten von Texten, Formen, Tabellen & Animationen, das Hinzufügen von Audio und Video zu Folien, das Vorschauen von Folien, das Exportieren von Folien in SVG-, PDF-Format und mehr.
 type: docs
 weight: 47

--- a/de/php-java/_index.md
+++ b/de/php-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides für PHP über Java
-second_title: "Aspose.Slides für PHP Dokumentation"
+second_title: Aspose.Slides for PHP
 description: Aspose.Slides für PHP über Java bietet viele wichtige Funktionen wie das Verwalten von Text, Formen, Tabellen & Animationen, das Hinzufügen von Audio und Video zu Folien, das Vorschauen von Folien, das Exportieren von Folien in SVG-, PDF-Format und mehr.
 type: docs
 weight: 45

--- a/de/python-java/_index.md
+++ b/de/python-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides für Python über Java
-second_title: "Aspose.Slides für Python Dokumentation"
+second_title: Aspose.Slides for Python
 description: Aspose.Slides für Python über Java bietet viele wichtige Funktionen wie das Verwalten von Text, Formen, Tabellen und Animationen, das Hinzufügen von Audio und Video zu Folien, das Vorschauen von Folien, das Exportieren von Folien in SVG-, PDF-Format und mehr.
 type: docs
 weight: 47

--- a/de/python-net/_index.md
+++ b/de/python-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides für Python via .NET
-second_title: "Aspose.Slides für Python Dokumentation"
+second_title: Aspose.Slides for Python
 type: docs
 weight: 35
 url: /de/python-net/

--- a/de/reportingservices/_index.md
+++ b/de/reportingservices/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides für Reporting Services
-second_title: Aspose.Slides Dokumentation
+second_title: Aspose.Slides for Reporting Services
 description: Aspose.Slides für Reporting Services ist die einzige Lösung auf dem Markt, die es ermöglicht, echte PPT- und PPS-Berichte in Microsoft SQL Server 2005, 2008, 2012, 2016 und 2017 Reporting Services (32-Bit und 64-Bit) zu erstellen.
 type: docs
 weight: 50

--- a/de/sharepoint/_index.md
+++ b/de/sharepoint/_index.md
@@ -1,6 +1,6 @@
 ---  
 title: Aspose.Slides für SharePoint  
-second_title: Aspose.Slides Dokumentation  
+second_title: Aspose.Slides for SharePoint
 description: Aspose.Slides für SharePoint ist eine flexible Lösung, die es ermöglicht, PowerPoint®-Dokumente innerhalb von Microsoft SharePoint-Seiten zu konvertieren.  
 type: docs  
 weight: 60  

--- a/en/androidjava/_index.md
+++ b/en/androidjava/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Android via Java
-second_title: Aspose.Slides Documentation
+second_title: Aspose.Slides for Android
 type: docs
 weight: 40
 url: /androidjava/

--- a/en/cpp/_index.md
+++ b/en/cpp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for C++
-second_title: Aspose.Slides Documentation
+second_title: Aspose.Slides for C++
 type: docs
 weight: 30
 url: /cpp/

--- a/en/jasperreports/_index.md
+++ b/en/jasperreports/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for JasperReports
-second_title: Aspose.Slides Documentation
+second_title: Aspose.Slides for JasperReports
 description: Aspose.Slides for JasperReports is a library specially designed and developed for developers who need to easily export reports from JasperReports to Microsoft PowerPoint Presentation (PPT) and Microsoft PowerPoint Show (PPS) formats in their Java applications.
 type: docs
 weight: 70

--- a/en/java/_index.md
+++ b/en/java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Java
-second_title: Aspose.Slides Documentation
+second_title: Aspose.Slides for Java
 type: docs
 weight: 20
 url: /java/

--- a/en/net/_index.md
+++ b/en/net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for .NET
-second_title: "Aspose.Slides Documentation"
+second_title: Aspose.Slides for .NET
 type: docs
 weight: 10
 url: /net/

--- a/en/nodejs-java/_index.md
+++ b/en/nodejs-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Node.js via Java
-second_title: "Aspose.Slides for Node.js via .NET Documentation"
+second_title: Aspose.Slides for Node.js
 type: docs
 weight: 47
 url: /nodejs-java/

--- a/en/nodejs-net/_index.md
+++ b/en/nodejs-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Node.js via .NET
-second_title: "Aspose.Slides for Node.js via .NET Documentation"
+second_title: Aspose.Slides for Node.js
 description: Aspose.Slides for Node.js via .NET provides a lot of key features such as managing text, shapes, tables & animations, adding audio and video to slides, previewing slides, exporting slides to SVG, PDF format and more.
 type: docs
 weight: 47

--- a/en/php-java/_index.md
+++ b/en/php-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for PHP via Java
-second_title: "Aspose.Slides for PHP Documentation"
+second_title: Aspose.Slides for PHP
 type: docs
 weight: 45
 url: /php-java/

--- a/en/python-java/_index.md
+++ b/en/python-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Python via Java
-second_title: "Aspose.Slides for Python Documentation"
+second_title: Aspose.Slides for Python
 description: Aspose.Slides for Python via Java provides a lot of key features such as managing text, shapes, tables & animations, adding audio and video to slides, previewing slides, exporting slides to SVG, PDF format and more.
 type: docs
 weight: 47

--- a/en/python-net/_index.md
+++ b/en/python-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Python via .NET
-second_title: "Aspose.Slides for Python Documentation"
+second_title: Aspose.Slides for Python
 type: docs
 weight: 35
 url: /python-net/

--- a/en/reportingservices/_index.md
+++ b/en/reportingservices/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Reporting Services
-second_title: Aspose.Slides Documentation
+second_title: Aspose.Slides for Reporting Services
 description: Aspose.Slides for Reporting Services is the only solution on the market that makes it possible to generate true PPT and PPS reports in Microsoft SQL Server 2005, 2008, 2012, 2016 and 2017 Reporting Services (32-bit and 64-bit).
 type: docs
 weight: 50

--- a/en/sharepoint/_index.md
+++ b/en/sharepoint/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for SharePoint
-second_title: Aspose.Slides Documentation
+second_title: Aspose.Slides for SharePoint
 description: Aspose.Slides for SharePoint is a flexible solution that makes it possible to convert PowerPoint® documents within Microsoft SharePoint Sites.
 type: docs
 weight: 60

--- a/es/androidjava/_index.md
+++ b/es/androidjava/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides para Android a través de Java
-second_title: Documentación de Aspose.Slides
+second_title: Aspose.Slides for Android
 description: Aspose.Slides para Android ofrece muchas características clave que te permiten agregar, modificar y manipular texto, formas, tablas y animaciones, audios y videos en las diapositivas.
 type: docs
 weight: 40

--- a/es/cpp/_index.md
+++ b/es/cpp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides para C++
-second_title: Documentación de Aspose.Slides
+second_title: Aspose.Slides for C++
 description: Aspose.Slides para C++ es el primer y único componente que proporciona la funcionalidad para gestionar documentos de PowerPoint®.
 type: docs
 weight: 30

--- a/es/jasperreports/_index.md
+++ b/es/jasperreports/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides para JasperReports
-second_title: Documentación de Aspose.Slides
+second_title: Aspose.Slides for JasperReports
 description: Aspose.Slides para JasperReports es una biblioteca especialmente diseñada y desarrollada para desarrolladores que necesitan exportar fácilmente informes de JasperReports a formatos de Microsoft PowerPoint Presentation (PPT) y Microsoft PowerPoint Show (PPS) en sus aplicaciones Java.
 type: docs
 weight: 70

--- a/es/java/_index.md
+++ b/es/java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides para Java
-second_title: Documentación de Aspose.Slides
+second_title: Aspose.Slides for Java
 description: Aspose.Slides para Java es el primer y único componente que proporciona la funcionalidad para gestionar documentos de PowerPoint®. Aspose.Slides para Java ofrece muchas características clave, como la gestión de texto, formas, exportación de diapositivas a SVG, PDF y otros formatos.
 type: docs
 weight: 20

--- a/es/net/_index.md
+++ b/es/net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Aspose.Slides para .NET"
-second_title: "Documentación de Aspose.Slides"
+second_title: Aspose.Slides for .NET
 type: docs
 weight: 10
 url: /es/net/

--- a/es/nodejs-java/_index.md
+++ b/es/nodejs-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides para Node.js a través de Java
-second_title: "Aspose.Slides para Node.js a través de .NET Documentación"
+second_title: Aspose.Slides for Node.js
 description: Aspose.Slides para Node.js a través de Java proporciona muchas características clave como la gestión de texto, formas, tablas y animaciones, la adición de audio y vídeo a las diapositivas, la vista previa de diapositivas, la exportación de diapositivas a SVG, formato PDF y más.
 type: docs
 weight: 47

--- a/es/nodejs-net/_index.md
+++ b/es/nodejs-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides para Node.js a través de .NET
-second_title: "Documentación de Aspose.Slides para Node.js a través de .NET"
+second_title: Aspose.Slides for Node.js
 description: Aspose.Slides para Node.js a través de .NET proporciona muchas características clave, como la gestión de texto, formas, tablas y animaciones, la adición de audio y video a las diapositivas, la vista previa de diapositivas, la exportación de diapositivas a formato SVG, PDF y más.
 type: docs
 weight: 47

--- a/es/php-java/_index.md
+++ b/es/php-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides para PHP a través de Java
-second_title: "Documentación de Aspose.Slides para PHP"
+second_title: Aspose.Slides for PHP
 description: Aspose.Slides para PHP a través de Java proporciona muchas características clave, como gestionar texto, formas, tablas y animaciones, añadir audio y vídeo a las diapositivas, previsualizar diapositivas, exportar diapositivas a SVG, PDF y más.
 type: docs
 weight: 45

--- a/es/python-java/_index.md
+++ b/es/python-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides para Python a través de Java
-second_title: "Documentación de Aspose.Slides para Python"
+second_title: Aspose.Slides for Python
 description: Aspose.Slides para Python a través de Java proporciona muchas características clave, como la gestión de texto, formas, tablas y animaciones, la adición de audio y video a las diapositivas, la vista previa de diapositivas, la exportación de diapositivas a SVG, formato PDF y más.
 type: docs
 weight: 47

--- a/es/python-net/_index.md
+++ b/es/python-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Python via .NET
-second_title: "Documentación de Aspose.Slides para Python"
+second_title: Aspose.Slides for Python
 type: docs
 weight: 35
 url: /es/python-net/

--- a/es/reportingservices/_index.md
+++ b/es/reportingservices/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides para Reporting Services
-second_title: Documentación de Aspose.Slides
+second_title: Aspose.Slides for Reporting Services
 description: Aspose.Slides para Reporting Services es la única solución en el mercado que hace posible generar verdaderos informes PPT y PPS en Microsoft SQL Server 2005, 2008, 2012, 2016 y 2017 Reporting Services (32 bits y 64 bits).
 type: docs
 weight: 50

--- a/es/sharepoint/_index.md
+++ b/es/sharepoint/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides para SharePoint
-second_title: Documentación de Aspose.Slides
+second_title: Aspose.Slides for SharePoint
 description: Aspose.Slides para SharePoint es una solución flexible que hace posible convertir documentos de PowerPoint® dentro de sitios de Microsoft SharePoint.
 type: docs
 weight: 60

--- a/fr/androidjava/_index.md
+++ b/fr/androidjava/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides pour Android via Java
-second_title: Documentation Aspose.Slides
+second_title: Aspose.Slides for Android
 description: Aspose.Slides pour Android offre de nombreuses fonctionnalités clés qui vous permettent d'ajouter, de modifier et de manipuler du texte, des formes, des tableaux et des animations, des fichiers audio et des vidéos dans des diapositives.
 type: docs
 weight: 40

--- a/fr/cpp/_index.md
+++ b/fr/cpp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides pour C++
-second_title: Documentation Aspose.Slides
+second_title: Aspose.Slides for C++
 description: Aspose.Slides pour C++ est le premier et le seul composant qui fournit la fonctionnalité de gestion des documents PowerPoint®.
 type: docs
 weight: 30

--- a/fr/jasperreports/_index.md
+++ b/fr/jasperreports/_index.md
@@ -1,6 +1,6 @@
 ---  
 title: Aspose.Slides pour JasperReports  
-second_title: Documentation Aspose.Slides  
+second_title: Aspose.Slides for JasperReports
 description: Aspose.Slides pour JasperReports est une bibliothèque spécialement conçue et développée pour les développeurs qui ont besoin d'exporter facilement des rapports de JasperReports vers les formats de présentation Microsoft PowerPoint (PPT) et Microsoft PowerPoint Show (PPS) dans leurs applications Java.  
 type: docs  
 weight: 70  

--- a/fr/java/_index.md
+++ b/fr/java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides pour Java
-second_title: Documentation Aspose.Slides
+second_title: Aspose.Slides for Java
 description: Aspose.Slides pour Java est le premier et le seul composant qui fournit la fonctionnalité pour gérer les documents PowerPoint®. Aspose.Slides pour Java offre de nombreuses fonctionnalités clés telles que la gestion du texte, des formes, l'exportation de diapositives vers SVG, PDF et d'autres formats.
 type: docs
 weight: 20

--- a/fr/net/_index.md
+++ b/fr/net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides pour .NET
-second_title: "Documentation Aspose.Slides"
+second_title: Aspose.Slides for .NET
 type: docs
 weight: 10
 url: /fr/net/

--- a/fr/nodejs-java/_index.md
+++ b/fr/nodejs-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides pour Node.js via Java
-second_title: "Documentation d'Aspose.Slides pour Node.js via .NET"
+second_title: Aspose.Slides for Node.js
 description: Aspose.Slides pour Node.js via Java fournit de nombreuses fonctionnalités clés telles que la gestion de texte, de formes, de tableaux et d'animations, l'ajout d'audio et de vidéo aux diapositives, l'aperçu des diapositives, l'exportation des diapositives en SVG, en PDF et plus encore.
 type: docs
 weight: 47

--- a/fr/nodejs-net/_index.md
+++ b/fr/nodejs-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides pour Node.js via .NET
-second_title: "Documentation d'Aspose.Slides pour Node.js via .NET"
+second_title: Aspose.Slides for Node.js
 description: Aspose.Slides pour Node.js via .NET fournit de nombreuses fonctionnalités clés telles que la gestion du texte, des formes, des tableaux et des animations, l'ajout de contenu audio et vidéo aux diapositives, l'aperçu des diapositives, l'exportation des diapositives au format SVG, PDF et plus encore.
 type: docs
 weight: 47

--- a/fr/php-java/_index.md
+++ b/fr/php-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides pour PHP via Java
-second_title: "Documentation d'Aspose.Slides pour PHP"
+second_title: Aspose.Slides for PHP
 description: Aspose.Slides pour PHP via Java offre de nombreuses fonctionnalités clés telles que la gestion du texte, des formes, des tables et des animations, l'ajout d'audio et de vidéo aux diapositives, l'aperçu des diapositives, l'exportation des diapositives au format SVG, PDF et plus encore.
 type: docs
 weight: 45

--- a/fr/python-java/_index.md
+++ b/fr/python-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides pour Python via Java
-second_title: "Documentation d'Aspose.Slides pour Python"
+second_title: Aspose.Slides for Python
 description: Aspose.Slides pour Python via Java propose de nombreuses fonctionnalités clés telles que la gestion du texte, des formes, des tableaux et des animations, l'ajout de fichiers audio et vidéo aux diapositives, l'aperçu des diapositives, l'exportation des diapositives au format SVG, PDF et plus encore.
 type: docs
 weight: 47

--- a/fr/python-net/_index.md
+++ b/fr/python-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides pour Python via .NET
-second_title: "Aspose.Slides pour Python Documentation"
+second_title: Aspose.Slides for Python
 type: docs
 weight: 35
 url: /fr/python-net/

--- a/fr/reportingservices/_index.md
+++ b/fr/reportingservices/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides pour Reporting Services
-second_title: Documentation d'Aspose.Slides
+second_title: Aspose.Slides for Reporting Services
 description: Aspose.Slides pour Reporting Services est la seule solution sur le marché qui permet de générer de véritables rapports PPT et PPS dans Microsoft SQL Server 2005, 2008, 2012, 2016 et 2017 Reporting Services (32 bits et 64 bits).
 type: docs
 weight: 50

--- a/fr/sharepoint/_index.md
+++ b/fr/sharepoint/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides pour SharePoint
-second_title: Documentation Aspose.Slides
+second_title: Aspose.Slides for SharePoint
 description: Aspose.Slides pour SharePoint est une solution flexible qui permet de convertir des documents PowerPoint® au sein des sites Microsoft SharePoint.
 type: docs
 weight: 60

--- a/ja/androidjava/_index.md
+++ b/ja/androidjava/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Android via Java
-second_title: Aspose.Slides ドキュメント
+second_title: Aspose.Slides for Android
 description: Aspose.Slides for Android は、スライド内のテキスト、図形、テーブル、アニメーション、音声、およびビデオを追加、変更、操作するための多くの主要な機能を提供します。
 type: docs
 weight: 40

--- a/ja/cpp/_index.md
+++ b/ja/cpp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for C++
-second_title: Aspose.Slides ドキュメント
+second_title: Aspose.Slides for C++
 description: Aspose.Slides for C++ は、PowerPoint® ドキュメントを管理する機能を提供する最初で唯一のコンポーネントです。
 type: docs
 weight: 30

--- a/ja/jasperreports/_index.md
+++ b/ja/jasperreports/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for JasperReports
-second_title: Aspose.Slides ドキュメント
+second_title: Aspose.Slides for JasperReports
 description: Aspose.Slides for JasperReportsは、JasperReportsからMicrosoft PowerPoint プレゼンテーション（PPT）およびMicrosoft PowerPoint ショー（PPS）形式にレポートを簡単にエクスポートする必要がある開発者のために特別に設計され、開発されたライブラリです。
 type: docs
 weight: 70

--- a/ja/java/_index.md
+++ b/ja/java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Java
-second_title: Aspose.Slides ドキュメント
+second_title: Aspose.Slides for Java
 description: Aspose.Slides for Java は、PowerPoint® ドキュメントを管理する機能を提供する初めてかつ唯一のコンポーネントです。Aspose.Slides for Java には、テキスト、図形の管理、スライドを SVG、PDF およびその他の形式にエクスポートするなど、多くの重要な機能があります。
 type: docs
 weight: 20

--- a/ja/net/_index.md
+++ b/ja/net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for .NET
-second_title: "Aspose.Slides ドキュメント"
+second_title: Aspose.Slides for .NET
 type: docs
 weight: 10
 url: /ja/net/

--- a/ja/nodejs-java/_index.md
+++ b/ja/nodejs-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Node.js via Java
-second_title: "Aspose.Slides for Node.js via .NET ドキュメント"
+second_title: Aspose.Slides for Node.js
 description: Aspose.Slides for Node.js via Java は、テキスト、図形、テーブル、アニメーションの管理、スライドへの音声と映像の追加、スライドのプレビュー、SVG、PDF形式へのスライドのエクスポートなど、多くの主要機能を提供します。
 type: docs
 weight: 47

--- a/ja/nodejs-net/_index.md
+++ b/ja/nodejs-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Node.js via .NET
-second_title: "Aspose.Slides for Node.js via .NET ドキュメント"
+second_title: Aspose.Slides for Node.js
 description: Aspose.Slides for Node.js via .NET は、テキスト、シェイプ、テーブル、アニメーションの管理、スライドへのオーディオおよびビデオの追加、スライドのプレビュー、SVG、PDF形式へのスライドのエクスポートなど、多くの重要な機能を提供します。
 type: docs
 weight: 47

--- a/ja/php-java/_index.md
+++ b/ja/php-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for PHP via Java
-second_title: "Aspose.Slides for PHP ドキュメント"
+second_title: Aspose.Slides for PHP
 description: Aspose.Slides for PHP via Java は、テキスト、図形、テーブル、アニメーションの管理、スライドへのオーディオおよびビデオの追加、スライドのプレビュー、SVG、PDF形式へのスライドのエクスポートなど、数多くの主要な機能を提供します。
 type: docs
 weight: 45

--- a/ja/python-java/_index.md
+++ b/ja/python-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Python via Java
-second_title: "Aspose.Slides for Python ドキュメント"
+second_title: Aspose.Slides for Python
 description: Aspose.Slides for Python via Javaは、テキスト、図形、表、アニメーションの管理、スライドへの音声およびビデオの追加、スライドのプレビュー、SVGおよびPDF形式へのスライドのエクスポートなど、多くの主要な機能を提供します。
 type: docs
 weight: 47

--- a/ja/python-net/_index.md
+++ b/ja/python-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Aspose.Slides for Python via .NET"
-second_title: "Aspose.Slides for Python ドキュメント"
+second_title: Aspose.Slides for Python
 type: docs
 weight: 35
 url: /ja/python-net/

--- a/ja/reportingservices/_index.md
+++ b/ja/reportingservices/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Reporting Services
-second_title: Aspose.Slides ドキュメント
+second_title: Aspose.Slides for Reporting Services
 description: Aspose.Slides for Reporting Services は、Microsoft SQL Server 2005、2008、2012、2016、2017 の Reporting Services（32ビットおよび64ビット）で真の PPT および PPS レポートを生成する唯一のソリューションです。
 type: docs
 weight: 50

--- a/ja/sharepoint/_index.md
+++ b/ja/sharepoint/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for SharePoint
-second_title: Aspose.Slides ドキュメント
+second_title: Aspose.Slides for SharePoint
 description: Aspose.Slides for SharePoint は、Microsoft SharePoint サイト内で PowerPoint® ドキュメントを変換することを可能にする柔軟なソリューションです。
 type: docs
 weight: 60

--- a/ru/androidjava/_index.md
+++ b/ru/androidjava/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides для Android через Java
-second_title: Документация Aspose.Slides
+second_title: Aspose.Slides for Android
 description: Aspose.Slides для Android предлагает множество ключевых функций, которые позволяют добавлять, изменять и управлять текстом, фигурами, таблицами и анимациями, аудио и видео в слайдах.
 type: docs
 weight: 40

--- a/ru/cpp/_index.md
+++ b/ru/cpp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides для C++
-second_title: Документация Aspose.Slides
+second_title: Aspose.Slides for C++
 description: Aspose.Slides для C++ — это первый и единственный компонент, который предоставляет функциональность для управления документами PowerPoint®.
 type: docs
 weight: 30

--- a/ru/jasperreports/_index.md
+++ b/ru/jasperreports/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides для JasperReports
-second_title: Документация Aspose.Slides
+second_title: Aspose.Slides for JasperReports
 description: Aspose.Slides для JasperReports — это библиотека, специально разработанная для разработчиков, которым необходимо легко экспортировать отчеты из JasperReports в форматы Microsoft PowerPoint Presentation (PPT) и Microsoft PowerPoint Show (PPS) в своих Java-приложениях.
 type: docs
 weight: 70

--- a/ru/java/_index.md
+++ b/ru/java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides для Java
-second_title: Документация Aspose.Slides
+second_title: Aspose.Slides for Java
 description: Aspose.Slides для Java — это первый и единственный компонент, который предоставляет возможность управлять документами PowerPoint®. Aspose.Slides для Java предлагает множество ключевых функций, таких как управление текстом, формами, экспорт слайдов в SVG, PDF и другие форматы.
 type: docs
 weight: 20

--- a/ru/net/_index.md
+++ b/ru/net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides для .NET
-second_title: "Документация Aspose.Slides"
+second_title: Aspose.Slides for .NET
 type: docs
 weight: 10
 url: /ru/net/

--- a/ru/nodejs-java/_index.md
+++ b/ru/nodejs-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides для Node.js через Java
-second_title: "Aspose.Slides для Node.js через .NET Документация"
+second_title: Aspose.Slides for Node.js
 description: Aspose.Slides для Node.js через Java предоставляет множество ключевых функций, таких как управление текстом, формами, таблицами и анимацией, добавление аудио и видео на слайды, предварительный просмотр слайдов, экспорт слайдов в SVG, PDF формат и многое другое.
 type: docs
 weight: 47

--- a/ru/nodejs-net/_index.md
+++ b/ru/nodejs-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides для Node.js через .NET
-second_title: "Документация Aspose.Slides для Node.js через .NET"
+second_title: Aspose.Slides for Node.js
 description: Aspose.Slides для Node.js через .NET предоставляет множество ключевых функций, таких как управление текстом, формами, таблицами и анимациями, добавление аудио и видео в слайды, предварительный просмотр слайдов, экспорт слайдов в форматы SVG, PDF и многое другое.
 type: docs
 weight: 47

--- a/ru/php-java/_index.md
+++ b/ru/php-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides для PHP через Java
-second_title: "Документация Aspose.Slides для PHP"
+second_title: Aspose.Slides for PHP
 description: Aspose.Slides для PHP через Java предоставляет множество ключевых функций, таких как управление текстом, формами, таблицами и анимациями, добавление аудио и видео на слайды, предварительный просмотр слайдов, экспорт слайдов в формат SVG, PDF и многое другое.
 type: docs
 weight: 45

--- a/ru/python-java/_index.md
+++ b/ru/python-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides для Python через Java
-second_title: "Документация Aspose.Slides для Python"
+second_title: Aspose.Slides for Python
 description: Aspose.Slides для Python через Java предоставляет множество ключевых функций, таких как управление текстом, фигурами, таблицами и анимациями, добавление аудио и видео на слайды, предварительный просмотр слайдов, экспорт слайдов в формат SVG, PDF и многое другое.
 type: docs
 weight: 47

--- a/ru/python-net/_index.md
+++ b/ru/python-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Python через .NET
-second_title: "Документация Aspose.Slides for Python"
+second_title: Aspose.Slides for Python
 type: docs
 weight: 35
 url: /ru/python-net/

--- a/ru/reportingservices/_index.md
+++ b/ru/reportingservices/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides для Reporting Services
-second_title: Документация Aspose.Slides
+second_title: Aspose.Slides for Reporting Services
 description: Aspose.Slides для Reporting Services — единственное решение на рынке, которое позволяет генерировать настоящие отчеты в формате PPT и PPS в Microsoft SQL Server 2005, 2008, 2012, 2016 и 2017 Reporting Services (32-битные и 64-битные).
 type: docs
 weight: 50

--- a/ru/sharepoint/_index.md
+++ b/ru/sharepoint/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides для SharePoint
-second_title: Документация по Aspose.Slides
+second_title: Aspose.Slides for SharePoint
 description: Aspose.Slides для SharePoint - это гибкое решение, которое позволяет конвертировать документы PowerPoint® в рамках сайтов Microsoft SharePoint.
 type: docs
 weight: 60

--- a/zh/androidjava/_index.md
+++ b/zh/androidjava/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Android via Java
-second_title: Aspose.Slides 文档
+second_title: Aspose.Slides for Android
 description: Aspose.Slides for Android 提供许多关键功能，使您能够在幻灯片中添加、修改和操作文本、形状、表格和动画、音频和视频。
 type: docs
 weight: 40

--- a/zh/cpp/_index.md
+++ b/zh/cpp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for C++
-second_title: Aspose.Slides 文档
+second_title: Aspose.Slides for C++
 description: Aspose.Slides for C++ 是第一个也是唯一一个提供管理 PowerPoint® 文档功能的组件。
 type: docs
 weight: 30

--- a/zh/jasperreports/_index.md
+++ b/zh/jasperreports/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for JasperReports
-second_title: Aspose.Slides 文档
+second_title: Aspose.Slides for JasperReports
 description: Aspose.Slides for JasperReports 是一个专门为开发者设计和开发的库，旨在帮助开发者轻松地将 JasperReports 报告导出为 Microsoft PowerPoint 演示文稿 (PPT) 和 Microsoft PowerPoint 幻灯片 (PPS) 格式，供其在 Java 应用程序中使用。
 type: docs
 weight: 70

--- a/zh/java/_index.md
+++ b/zh/java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Java
-second_title: Aspose.Slides 文档
+second_title: Aspose.Slides for Java
 description: Aspose.Slides for Java 是第一个也是唯一一个提供管理 PowerPoint® 文档功能的组件。Aspose.Slides for Java 提供了许多关键功能，如管理文本、形状、将幻灯片导出为 SVG、PDF 和其他格式。
 type: docs
 weight: 20

--- a/zh/net/_index.md
+++ b/zh/net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for .NET
-second_title: "Aspose.Slides 文档"
+second_title: Aspose.Slides for .NET
 type: docs
 weight: 10
 url: /zh/net/

--- a/zh/nodejs-java/_index.md
+++ b/zh/nodejs-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Node.js via Java
-second_title: "Aspose.Slides for Node.js via .NET 文档"
+second_title: Aspose.Slides for Node.js
 description: Aspose.Slides for Node.js via Java 提供了许多关键功能，例如管理文本、形状、表格和动画，向幻灯片添加音频和视频，预览幻灯片，以及将幻灯片导出为 SVG、PDF 格式等。
 type: docs
 weight: 47

--- a/zh/nodejs-net/_index.md
+++ b/zh/nodejs-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Node.js via .NET
-second_title: "Aspose.Slides for Node.js via .NET 文档"
+second_title: Aspose.Slides for Node.js
 description: Aspose.Slides for Node.js via .NET 提供了许多关键功能，如管理文本、形状、表格和动画，向幻灯片添加音频和视频，预览幻灯片，将幻灯片导出为 SVG、PDF 格式等。
 type: docs
 weight: 47

--- a/zh/php-java/_index.md
+++ b/zh/php-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for PHP via Java
-second_title: "Aspose.Slides for PHP 文档"
+second_title: Aspose.Slides for PHP
 description: Aspose.Slides for PHP via Java 提供了许多关键特性，如管理文本、形状、表格和动画，向幻灯片添加音频和视频、预览幻灯片、将幻灯片导出为 SVG、PDF 格式等。
 type: docs
 weight: 45

--- a/zh/python-java/_index.md
+++ b/zh/python-java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Python via Java
-second_title: "Aspose.Slides for Python 文档"
+second_title: Aspose.Slides for Python
 description: Aspose.Slides for Python via Java 提供了许多关键功能，例如管理文本、形状、表格和动画，将音频和视频添加到幻灯片、预览幻灯片、将幻灯片导出为 SVG、PDF 格式等。
 type: docs
 weight: 47

--- a/zh/python-net/_index.md
+++ b/zh/python-net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Python via .NET
-second_title: "Aspose.Slides for Python 文档"
+second_title: Aspose.Slides for Python
 type: docs
 weight: 35
 url: /zh/python-net/

--- a/zh/reportingservices/_index.md
+++ b/zh/reportingservices/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for Reporting Services
-second_title: Aspose.Slides 文档
+second_title: Aspose.Slides for Reporting Services
 description: Aspose.Slides for Reporting Services 是市场上唯一能够在 Microsoft SQL Server 2005、2008、2012、2016 和 2017 Reporting Services (32 位和 64 位) 中生成真实 PPT 和 PPS 报告的解决方案。
 type: docs
 weight: 50

--- a/zh/sharepoint/_index.md
+++ b/zh/sharepoint/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Aspose.Slides for SharePoint
-second_title: Aspose.Slides 文档
+second_title: Aspose.Slides for SharePoint
 description: Aspose.Slides for SharePoint 是一个灵活的解决方案，使得在 Microsoft SharePoint 网站中转换 PowerPoint® 文档成为可能。
 type: docs
 weight: 60


### PR DESCRIPTION
Changes `second_title` on the 12 family roots across the 8 published locales, so the
rendered <title> names the platform family instead of repeating the word
"Documentation":

  before   Licensing|Aspose.Slides Documentation
  after    Licensing|Aspose.Slides for .NET

Seven of the twelve families currently emit the identical suffix "Aspose.Slides
Documentation", so a search result cannot distinguish .NET from Java from C++ from
Android. The rendered title is "<page title>|<second_title>" -- head.html plus the
find-root-page and get-second-title templates, whose trim markers remove the spaces
around the pipe.

Verified by a full English build on the vendored Hugo 0.80.0 (3,574 pages, no errors),
measuring visible title length with HTML entities unescaped: mean rendered title length
for the .NET and Java families drops by 5 characters, and 31 more pages fall under 50.

Three small families get slightly longer -- Reporting Services, JasperReports and
SharePoint -- because their product names are longer than the word "Documentation".
They gain the same disambiguation, so the rule is applied uniformly rather than
special-cased.

96 files, one `second_title` line each.