### PR TITLE
SLIDESDOC-819 Add documentation for trimming video frames

### DIFF
--- a/en/androidjava/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
+++ b/en/androidjava/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
@@ -79,7 +79,7 @@ try {
 
 ## **Create a Video Frame with Video from a Web Source**
 
-Microsoft [PowerPoint 2013 and newer](https://support.microsoft.com/en-us/office/versions-of-powerpoint-that-support-online-videos-2a0e184d-af50-4da9-b530-e4355ac436a9?ui=en-us&rs=en-us&ad=us) support YouTube videos in presentations. If the video you want to use is available online (e.g. on YouTube), you can add it to your presentation through its web link. 
+Newer versions of Microsoft [PowerPoint](https://support.microsoft.com/en-us/powerpoint/training/insert-a-video-from-youtube-or-another-site) support online videos in presentations. If the video you want to use is available online (e.g. on YouTube), you can add it to your presentation through its web link.
 
 1. Create an instance of [Presentation ](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation)class
 1. Get a slide's reference through its index. 
@@ -120,6 +120,70 @@ private static void addVideoFromYouTube(Presentation pres, String videoID)
     } catch (IOException e) {
         e.printStackTrace();
     }
+}
+```
+
+## **Trim a Video Frame**
+
+Aspose.Slides allows you to control which part of a video is played by setting the trim-from-start and trim-from-end values through [IVideoFrame.setTrimFromStart](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ivideoframe/#setTrimFromStart-float-) and [IVideoFrame.setTrimFromEnd](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ivideoframe/#setTrimFromEnd-float-). Both values are specified in milliseconds and define how much time is skipped from the beginning and end of the video, respectively. These settings change the video playback settings in the presentation; they do not cut or otherwise modify the embedded video binary data.
+
+**Set Trim Settings**
+
+To create a video frame and set its trim settings:
+
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/presentation/) class.
+1. Add an [IVideo](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ivideo/) object to the presentation.
+1. Add an [IVideoFrame](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ivideoframe/) object to a slide.
+1. Set the trim-from-start and trim-from-end values through [IVideoFrame.setTrimFromStart](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ivideoframe/#setTrimFromStart-float-) and [IVideoFrame.setTrimFromEnd](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ivideoframe/#setTrimFromEnd-float-).
+1. Save the modified presentation.
+
+The following code example skips the first 2.5 seconds and the last second of an embedded video during playback:
+
+```java
+Presentation presentation = new Presentation();
+try {
+    FileInputStream videoStream = new FileInputStream("video.mp4");
+    try {
+        IVideo video = presentation.getVideos().addVideo(
+                videoStream, LoadingStreamBehavior.ReadStreamAndRelease);
+        ISlide slide = presentation.getSlides().get_Item(0);
+        IVideoFrame videoFrame = slide.getShapes().addVideoFrame(50, 50, 640, 360, video);
+
+        videoFrame.setTrimFromStart(2500f);
+        videoFrame.setTrimFromEnd(1000f);
+
+        presentation.save("video_with_trim.pptx", SaveFormat.Pptx);
+    } finally {
+        videoStream.close();
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
+**Read Trim Settings**
+
+To inspect existing trim settings, load a presentation, find an [IVideoFrame](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ivideoframe/) object among the shapes on the first slide, and read the values through [IVideoFrame.getTrimFromStart](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ivideoframe/#getTrimFromStart--) and [IVideoFrame.getTrimFromEnd](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ivideoframe/#getTrimFromEnd--).
+
+The following code example finds the first video frame on the first slide and reports its trim settings in milliseconds:
+
+```java
+Presentation presentation = new Presentation("video_with_trim.pptx");
+try {
+    ISlide slide = presentation.getSlides().get_Item(0);
+    for (IShape shape : slide.getShapes()) {
+        if (shape instanceof IVideoFrame) {
+            IVideoFrame videoFrame = (IVideoFrame) shape;
+            float trimFromStart = videoFrame.getTrimFromStart();
+            float trimFromEnd = videoFrame.getTrimFromEnd();
+
+            System.out.println("Trim from start: " + trimFromStart + " ms");
+            System.out.println("Trim from end: " + trimFromEnd + " ms");
+            break;
+        }
+    }
+} finally {
+    presentation.dispose();
 }
 ```
 
@@ -265,18 +329,18 @@ try {
 
 ## **FAQ**
 
-### Which video playback parameters can be changed for a VideoFrame?
+**Which video playback parameters can be changed for a VideoFrame?**
 
 You can control the [playback mode](https://reference.aspose.com/slides/androidjava/com.aspose.slides/videoframe/#setPlayMode-int-) (auto or on click) and [looping](https://reference.aspose.com/slides/androidjava/com.aspose.slides/videoframe/#setPlayLoopMode-boolean-). These options are available via the [VideoFrame](https://reference.aspose.com/slides/androidjava/com.aspose.slides/videoframe/) object's properties.
 
-### Does adding a video affect the PPTX file size?
+**Does adding a video affect the PPTX file size?**
 
 Yes. When you embed a local video, the binary data is included in the document, so the presentation size grows in proportion to the file size. When you add an online video, a link and a thumbnail are embedded, so the size increase is smaller.
 
-### Can I replace the video in an existing VideoFrame without changing its position and size?
+**Can I replace the video in an existing VideoFrame without changing its position and size?**
 
 Yes. You can swap the [video content](https://reference.aspose.com/slides/androidjava/com.aspose.slides/videoframe/#setEmbeddedVideo-com.aspose.slides.IVideo-) within the frame while preserving the shape's geometry; this is a common scenario for updating media in an existing layout.
 
-### Can the content type (MIME) of an embedded video be determined?
+**Can the content type (MIME) of an embedded video be determined?**
 
 Yes. An embedded video has a [content type](https://reference.aspose.com/slides/androidjava/com.aspose.slides/video/#getContentType--) that you can read and use, for example when saving it to disk.

--- a/en/cpp/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
+++ b/en/cpp/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
@@ -69,7 +69,7 @@ System::SharedPtr<IVideoFrame> vf = sld->get_Shapes()->AddVideoFrame(50.0f, 150.
 
 ## **Create a Video Frame with Video from a Web Source**
 
-Microsoft [PowerPoint 2013 and newer](https://support.microsoft.com/en-us/office/versions-of-powerpoint-that-support-online-videos-2a0e184d-af50-4da9-b530-e4355ac436a9?ui=en-us&rs=en-us&ad=us) support YouTube videos in presentations. If the video you want to use is available online (e.g. on YouTube), you can add it to your presentation through its web link. 
+Newer versions of Microsoft [PowerPoint](https://support.microsoft.com/en-us/powerpoint/training/insert-a-video-from-youtube-or-another-site) support online videos in presentations. If the video you want to use is available online (e.g. on YouTube), you can add it to your presentation through its web link.
 
 1. Create an instance of [Presentation ](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/)class
 1. Get a slide's reference through its index. 
@@ -98,6 +98,66 @@ vf->set_PlayMode(VideoPlayModePreset::Auto);
 
 //Saves the presentation to disk
 pres->Save(outPath, Aspose::Slides::Export::SaveFormat::Pptx);
+```
+
+## **Trim a Video Frame**
+
+Aspose.Slides allows you to control which part of a video is played by setting the trim-from-start and trim-from-end values through [IVideoFrame::set_TrimFromStart](https://reference.aspose.com/slides/cpp/aspose.slides/ivideoframe/set_trimfromstart/) and [IVideoFrame::set_TrimFromEnd](https://reference.aspose.com/slides/cpp/aspose.slides/ivideoframe/set_trimfromend/). Both values are specified in milliseconds and define how much time is skipped from the beginning and end of the video, respectively. These settings change the video playback settings in the presentation; they do not cut or otherwise modify the embedded video binary data.
+
+**Set Trim Settings**
+
+To create a video frame and set its trim settings:
+
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/) class.
+1. Add an [IVideo](https://reference.aspose.com/slides/cpp/aspose.slides/ivideo/) object to the presentation.
+1. Add an [IVideoFrame](https://reference.aspose.com/slides/cpp/aspose.slides/ivideoframe/) object to a slide.
+1. Set the trim-from-start and trim-from-end values through [IVideoFrame::set_TrimFromStart](https://reference.aspose.com/slides/cpp/aspose.slides/ivideoframe/set_trimfromstart/) and [IVideoFrame::set_TrimFromEnd](https://reference.aspose.com/slides/cpp/aspose.slides/ivideoframe/set_trimfromend/).
+1. Save the modified presentation.
+
+The following code example skips the first 2.5 seconds and the last second of an embedded video during playback:
+
+```cpp
+auto presentation = MakeObject<Presentation>();
+
+auto videoData = File::ReadAllBytes(u"video.mp4");
+auto video = presentation->get_Videos()->AddVideo(videoData);
+
+auto slide = presentation->get_Slide(0);
+auto videoFrame = slide->get_Shapes()->AddVideoFrame(50, 50, 640, 360, video);
+
+videoFrame->set_TrimFromStart(2500.0f);
+videoFrame->set_TrimFromEnd(1000.0f);
+
+presentation->Save(u"video_with_trim.pptx", SaveFormat::Pptx);
+presentation->Dispose();
+```
+
+**Read Trim Settings**
+
+To inspect existing trim settings, load a presentation, find an [IVideoFrame](https://reference.aspose.com/slides/cpp/aspose.slides/ivideoframe/) object among the shapes on the first slide, and read the values through [IVideoFrame::get_TrimFromStart](https://reference.aspose.com/slides/cpp/aspose.slides/ivideoframe/get_trimfromstart/) and [IVideoFrame::get_TrimFromEnd](https://reference.aspose.com/slides/cpp/aspose.slides/ivideoframe/get_trimfromend/).
+
+The following code example finds the first video frame on the first slide and reports its trim settings in milliseconds:
+
+```cpp
+auto presentation = MakeObject<Presentation>(u"video_with_trim.pptx");
+
+auto slide = presentation->get_Slide(0);
+for (auto&& shape : slide->get_Shapes())
+{
+    if (ObjectExt::Is<IVideoFrame>(shape))
+    {
+        auto videoFrame = ExplicitCast<IVideoFrame>(shape);
+        auto trimFromStart = videoFrame->get_TrimFromStart();
+        auto trimFromEnd = videoFrame->get_TrimFromEnd();
+
+        Console::WriteLine(u"Trim from start: {0} ms", trimFromStart);
+        Console::WriteLine(u"Trim from end: {0} ms", trimFromEnd);
+
+        break;
+    }
+}
+
+presentation->Dispose();
 ```
 
 ## **Manage Video Captions**
@@ -232,18 +292,18 @@ for (auto&& slide : presentation->get_Slides())
 
 ## **FAQ**
 
-### Which video playback parameters can be changed for a VideoFrame?
+**Which video playback parameters can be changed for a VideoFrame?**
 
 You can control the [playback mode](https://reference.aspose.com/slides/cpp/aspose.slides/videoframe/set_playmode/) (auto or on click) and [looping](https://reference.aspose.com/slides/cpp/aspose.slides/videoframe/set_playloopmode/). These options are available via the [VideoFrame](https://reference.aspose.com/slides/cpp/aspose.slides/videoframe/) object's properties.
 
-### Does adding a video affect the PPTX file size?
+**Does adding a video affect the PPTX file size?**
 
 Yes. When you embed a local video, the binary data is included in the document, so the presentation size grows in proportion to the file size. When you add an online video, a link and a thumbnail are embedded, so the size increase is smaller.
 
-### Can I replace the video in an existing VideoFrame without changing its position and size?
+**Can I replace the video in an existing VideoFrame without changing its position and size?**
 
 Yes. You can swap the [video content](https://reference.aspose.com/slides/cpp/aspose.slides/videoframe/set_embeddedvideo/) within the frame while preserving the shape's geometry; this is a common scenario for updating media in an existing layout.
 
-### Can the content type (MIME) of an embedded video be determined?
+**Can the content type (MIME) of an embedded video be determined?**
 
 Yes. An embedded video has a [content type](https://reference.aspose.com/slides/cpp/aspose.slides/video/get_contenttype/) that you can read and use, for example when saving it to disk.

--- a/en/java/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
+++ b/en/java/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
@@ -122,6 +122,70 @@ private static void addVideoFromYouTube(Presentation pres, String videoID)
 }
 ```
 
+## **Trim a Video Frame**
+
+Aspose.Slides allows you to control which part of a video is played by setting the trim-from-start and trim-from-end values through [IVideoFrame.setTrimFromStart](https://reference.aspose.com/slides/java/com.aspose.slides/ivideoframe/#setTrimFromStart-float-) and [IVideoFrame.setTrimFromEnd](https://reference.aspose.com/slides/java/com.aspose.slides/ivideoframe/#setTrimFromEnd-float-). Both values are specified in milliseconds and define how much time is skipped from the beginning and end of the video, respectively. These settings change the video playback settings in the presentation; they do not cut or otherwise modify the embedded video binary data.
+
+**Set Trim Settings**
+
+To create a video frame and set its trim settings:
+
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation/) class.
+1. Add an [IVideo](https://reference.aspose.com/slides/java/com.aspose.slides/ivideo/) object to the presentation.
+1. Add an [IVideoFrame](https://reference.aspose.com/slides/java/com.aspose.slides/ivideoframe/) object to a slide.
+1. Set the trim-from-start and trim-from-end values through [IVideoFrame.setTrimFromStart](https://reference.aspose.com/slides/java/com.aspose.slides/ivideoframe/#setTrimFromStart-float-) and [IVideoFrame.setTrimFromEnd](https://reference.aspose.com/slides/java/com.aspose.slides/ivideoframe/#setTrimFromEnd-float-).
+1. Save the modified presentation.
+
+The following code example skips the first 2.5 seconds and the last second of an embedded video during playback:
+
+```java
+Presentation presentation = new Presentation();
+try {
+    FileInputStream videoStream = new FileInputStream("video.mp4");
+    try {
+        IVideo video = presentation.getVideos().addVideo(
+                videoStream, LoadingStreamBehavior.ReadStreamAndRelease);
+        ISlide slide = presentation.getSlides().get_Item(0);
+        IVideoFrame videoFrame = slide.getShapes().addVideoFrame(50, 50, 640, 360, video);
+
+        videoFrame.setTrimFromStart(2500f);
+        videoFrame.setTrimFromEnd(1000f);
+
+        presentation.save("video_with_trim.pptx", SaveFormat.Pptx);
+    } finally {
+        videoStream.close();
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
+**Read Trim Settings**
+
+To inspect existing trim settings, load a presentation, find an [IVideoFrame](https://reference.aspose.com/slides/java/com.aspose.slides/ivideoframe/) object among the shapes on the first slide, and read the values through [IVideoFrame.getTrimFromStart](https://reference.aspose.com/slides/java/com.aspose.slides/ivideoframe/#getTrimFromStart--) and [IVideoFrame.getTrimFromEnd](https://reference.aspose.com/slides/java/com.aspose.slides/ivideoframe/#getTrimFromEnd--).
+
+The following code example finds the first video frame on the first slide and reports its trim settings in milliseconds:
+
+```java
+Presentation presentation = new Presentation("video_with_trim.pptx");
+try {
+    ISlide slide = presentation.getSlides().get_Item(0);
+    for (IShape shape : slide.getShapes()) {
+        if (shape instanceof IVideoFrame) {
+            IVideoFrame videoFrame = (IVideoFrame) shape;
+            float trimFromStart = videoFrame.getTrimFromStart();
+            float trimFromEnd = videoFrame.getTrimFromEnd();
+
+            System.out.println("Trim from start: " + trimFromStart + " ms");
+            System.out.println("Trim from end: " + trimFromEnd + " ms");
+            break;
+        }
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
 ## **Manage Video Captions**
 
 Aspose.Slides allows you to manage closed captions for video frames in PowerPoint presentations. Captions are stored in WebVTT format and are exposed through the [IVideoFrame.getCaptionTracks](https://reference.aspose.com/slides/java/com.aspose.slides/ivideoframe/#getCaptionTracks--) method.
@@ -263,18 +327,18 @@ try {
 
 ## **FAQ**
 
-### Which video playback parameters can be changed for a VideoFrame?
+**Which video playback parameters can be changed for a VideoFrame?**
 
 You can control the [playback mode](https://reference.aspose.com/slides/java/com.aspose.slides/videoframe/#setPlayMode-int-) (auto or on click) and [looping](https://reference.aspose.com/slides/java/com.aspose.slides/videoframe/#setPlayLoopMode-boolean-). These options are available via the [VideoFrame](https://reference.aspose.com/slides/java/com.aspose.slides/videoframe/) object's properties.
 
-### Does adding a video affect the PPTX file size?
+**Does adding a video affect the PPTX file size?**
 
 Yes. When you embed a local video, the binary data is included in the document, so the presentation size grows in proportion to the file size. When you add an online video, a link and a thumbnail are embedded, so the size increase is smaller.
 
-### Can I replace the video in an existing VideoFrame without changing its position and size?
+**Can I replace the video in an existing VideoFrame without changing its position and size?**
 
 Yes. You can swap the [video content](https://reference.aspose.com/slides/java/com.aspose.slides/videoframe/#setEmbeddedVideo-com.aspose.slides.IVideo-) within the frame while preserving the shape's geometry; this is a common scenario for updating media in an existing layout.
 
-### Can the content type (MIME) of an embedded video be determined?
+**Can the content type (MIME) of an embedded video be determined?**
 
 Yes. An embedded video has a [content type](https://reference.aspose.com/slides/java/com.aspose.slides/video/#getContentType--) that you can read and use, for example when saving it to disk.

--- a/en/net/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
+++ b/en/net/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
@@ -73,7 +73,7 @@ using (Presentation pres = new Presentation())
 
 
 ## **Create a Video Frame with Video from a Web Source**
-Microsoft [PowerPoint 2013 and newer](https://support.microsoft.com/en-us/office/versions-of-powerpoint-that-support-online-videos-2a0e184d-af50-4da9-b530-e4355ac436a9?ui=en-us&rs=en-us&ad=us) support YouTube videos in presentations. If the video you want to use is available online (e.g. on YouTube), you can add it to your presentation through its web link. 
+Newer versions of Microsoft [PowerPoint](https://support.microsoft.com/en-us/powerpoint/training/insert-a-video-from-youtube-or-another-site) support online videos in presentations. If the video you want to use is available online (e.g. on YouTube), you can add it to your presentation through its web link.
 
 1. Create an instance of [Presentation ](https://reference.aspose.com/slides/net/aspose.slides/presentation)class
 1. Get a slide's reference through its index. 
@@ -105,6 +105,62 @@ private static void AddVideoFromYouTube(Presentation pres, string videoId)
     {
         string thumbnailUri = "http://img.youtube.com/vi/" + videoId + "/hqdefault.jpg";
         videoFrame.PictureFormat.Picture.Image = pres.Images.AddImage(client.DownloadData(thumbnailUri));
+    }
+}
+```
+
+## **Trim a Video Frame**
+
+Aspose.Slides allows you to control which part of a video is played by setting the trim-from-start and trim-from-end values through [IVideoFrame.TrimFromStart](https://reference.aspose.com/slides/net/aspose.slides/ivideoframe/trimfromstart/) and [IVideoFrame.TrimFromEnd](https://reference.aspose.com/slides/net/aspose.slides/ivideoframe/trimfromend/). Both values are specified in milliseconds and define how much time is skipped from the beginning and end of the video, respectively. These settings change the video playback settings in the presentation; they do not cut or otherwise modify the embedded video binary data.
+
+**Set Trim Settings**
+
+To create a video frame and set its trim settings:
+
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation/) class.
+1. Add an [IVideo](https://reference.aspose.com/slides/net/aspose.slides/ivideo/) object to the presentation.
+1. Add an [IVideoFrame](https://reference.aspose.com/slides/net/aspose.slides/ivideoframe/) object to a slide.
+1. Set the trim-from-start and trim-from-end values through [IVideoFrame.TrimFromStart](https://reference.aspose.com/slides/net/aspose.slides/ivideoframe/trimfromstart/) and [IVideoFrame.TrimFromEnd](https://reference.aspose.com/slides/net/aspose.slides/ivideoframe/trimfromend/).
+1. Save the modified presentation.
+
+The following code example skips the first 2.5 seconds and the last second of an embedded video during playback:
+
+```cs
+using var presentation = new Presentation();
+
+var videoData = File.ReadAllBytes("video.mp4");
+var video = presentation.Videos.AddVideo(videoData);
+
+var slide = presentation.Slides[0];
+var videoFrame = slide.Shapes.AddVideoFrame(50, 50, 640, 360, video);
+
+videoFrame.TrimFromStart = 2500f;
+videoFrame.TrimFromEnd = 1000f;
+
+presentation.Save("video_with_trim.pptx", SaveFormat.Pptx);
+```
+
+**Read Trim Settings**
+
+To inspect existing trim settings, load a presentation, find an [IVideoFrame](https://reference.aspose.com/slides/net/aspose.slides/ivideoframe/) object among the shapes on the first slide, and read the values through [IVideoFrame.TrimFromStart](https://reference.aspose.com/slides/net/aspose.slides/ivideoframe/trimfromstart/) and [IVideoFrame.TrimFromEnd](https://reference.aspose.com/slides/net/aspose.slides/ivideoframe/trimfromend/).
+
+The following code example finds the first video frame on the first slide and reports its trim settings in milliseconds:
+
+```cs
+using var presentation = new Presentation("video_with_trim.pptx");
+
+var slide = presentation.Slides[0];
+foreach (var shape in slide.Shapes)
+{
+    if (shape is IVideoFrame videoFrame)
+    {
+        var trimFromStart = videoFrame.TrimFromStart;
+        var trimFromEnd = videoFrame.TrimFromEnd;
+
+        Console.WriteLine($"Trim from start: {trimFromStart} ms");
+        Console.WriteLine($"Trim from end: {trimFromEnd} ms");
+
+        break;
     }
 }
 ```
@@ -240,18 +296,18 @@ foreach (ISlide slide in presentation.Slides)
 
 ## **FAQ**
 
-### Which video playback parameters can be changed for a VideoFrame?
+**Which video playback parameters can be changed for a VideoFrame?**
 
 You can control the [playback mode](https://reference.aspose.com/slides/net/aspose.slides/videoframe/playmode/) (auto or on click) and [looping](https://reference.aspose.com/slides/net/aspose.slides/videoframe/playloopmode/). These options are available via the [VideoFrame](https://reference.aspose.com/slides/net/aspose.slides/videoframe/) object's properties.
 
-### Does adding a video affect the PPTX file size?
+**Does adding a video affect the PPTX file size?**
 
 Yes. When you embed a local video, the binary data is included in the document, so the presentation size grows in proportion to the file size. When you add an online video, a link and a thumbnail are embedded, so the size increase is smaller.
 
-### Can I replace the video in an existing VideoFrame without changing its position and size?
+**Can I replace the video in an existing VideoFrame without changing its position and size?**
 
 Yes. You can swap the [video content](https://reference.aspose.com/slides/net/aspose.slides/videoframe/embeddedvideo/) within the frame while preserving the shape's geometry; this is a common scenario for updating media in an existing layout.
 
-### Can the content type (MIME) of an embedded video be determined?
+**Can the content type (MIME) of an embedded video be determined?**
 
 Yes. An embedded video has a [content type](https://reference.aspose.com/slides/net/aspose.slides/video/contenttype/) that you can read and use, for example when saving it to disk.

--- a/en/nodejs-java/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
+++ b/en/nodejs-java/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
@@ -137,6 +137,72 @@ async function getImageStream(url) {
 }
 ```
 
+## **Trim a Video Frame**
+
+Aspose.Slides allows you to control which part of a video is played by setting the trim-from-start and trim-from-end values through [VideoFrame.setTrimFromStart](https://reference.aspose.com/slides/nodejs-java/aspose.slides/videoframe/settrimfromstart/) and [VideoFrame.setTrimFromEnd](https://reference.aspose.com/slides/nodejs-java/aspose.slides/videoframe/settrimfromend/). Both values are specified in milliseconds and define how much time is skipped from the beginning and end of the video, respectively. These settings change the video playback settings in the presentation; they do not cut or otherwise modify the embedded video binary data.
+
+**Set Trim Settings**
+
+To create a video frame and set its trim settings:
+
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/) class.
+1. Add a [Video](https://reference.aspose.com/slides/nodejs-java/aspose.slides/video/) object to the presentation.
+1. Add a [VideoFrame](https://reference.aspose.com/slides/nodejs-java/aspose.slides/videoframe/) object to a slide.
+1. Set the trim-from-start and trim-from-end values through [VideoFrame.setTrimFromStart](https://reference.aspose.com/slides/nodejs-java/aspose.slides/videoframe/settrimfromstart/) and [VideoFrame.setTrimFromEnd](https://reference.aspose.com/slides/nodejs-java/aspose.slides/videoframe/settrimfromend/).
+1. Save the modified presentation.
+
+The following code example skips the first 2.5 seconds and the last second of an embedded video during playback:
+
+```javascript
+const presentation = new aspose.slides.Presentation();
+try {
+    const videoStream = java.newInstanceSync("java.io.FileInputStream", "video.mp4");
+    try {
+        const video = presentation.getVideos().addVideo(
+            videoStream, aspose.slides.LoadingStreamBehavior.ReadStreamAndRelease);
+        const slide = presentation.getSlides().get_Item(0);
+        const videoFrame = slide.getShapes().addVideoFrame(50, 50, 640, 360, video);
+
+        videoFrame.setTrimFromStart(2500);
+        videoFrame.setTrimFromEnd(1000);
+
+        presentation.save("video_with_trim.pptx", aspose.slides.SaveFormat.Pptx);
+    } finally {
+        videoStream.close();
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
+**Read Trim Settings**
+
+To inspect existing trim settings, load a presentation, find a [VideoFrame](https://reference.aspose.com/slides/nodejs-java/aspose.slides/videoframe/) object among the shapes on the first slide, and read the values through [VideoFrame.getTrimFromStart](https://reference.aspose.com/slides/nodejs-java/aspose.slides/videoframe/gettrimfromstart/) and [VideoFrame.getTrimFromEnd](https://reference.aspose.com/slides/nodejs-java/aspose.slides/videoframe/gettrimfromend/).
+
+The following code example finds the first video frame on the first slide and reports its trim settings in milliseconds:
+
+```javascript
+const presentation = new aspose.slides.Presentation("video_with_trim.pptx");
+try {
+    const slide = presentation.getSlides().get_Item(0);
+    const shapeCount = slide.getShapes().size();
+    for (let shapeIndex = 0; shapeIndex < shapeCount; shapeIndex++) {
+        const shape = slide.getShapes().get_Item(shapeIndex);
+        if (java.instanceOf(shape, "com.aspose.slides.VideoFrame")) {
+            const videoFrame = shape;
+            const trimFromStart = videoFrame.getTrimFromStart();
+            const trimFromEnd = videoFrame.getTrimFromEnd();
+
+            console.log("Trim from start: " + trimFromStart + " ms");
+            console.log("Trim from end: " + trimFromEnd + " ms");
+            break;
+        }
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
 ## **Manage Video Captions**
 
 Aspose.Slides allows you to manage closed captions for video frames in PowerPoint presentations. Captions are stored in WebVTT format and are exposed through the [VideoFrame.getCaptionTracks](https://reference.aspose.com/slides/nodejs-java/aspose.slides/videoframe/#getCaptionTracks) method.
@@ -282,18 +348,18 @@ try {
 
 ## **FAQ**
 
-### Which video playback parameters can be changed for a VideoFrame?
+**Which video playback parameters can be changed for a VideoFrame?**
 
 You can control the [playback mode](https://reference.aspose.com/slides/nodejs-java/aspose.slides/videoframe/setplaymode/) (auto or on click) and [looping](https://reference.aspose.com/slides/nodejs-java/aspose.slides/videoframe/setplayloopmode/). These options are available via the [VideoFrame](https://reference.aspose.com/slides/nodejs-java/aspose.slides/videoframe/) object's properties.
 
-### Does adding a video affect the PPTX file size?
+**Does adding a video affect the PPTX file size?**
 
 Yes. When you embed a local video, the binary data is included in the document, so the presentation size grows in proportion to the file size. When you add an online video, a link and a thumbnail are embedded, so the size increase is smaller.
 
-### Can I replace the video in an existing VideoFrame without changing its position and size?
+**Can I replace the video in an existing VideoFrame without changing its position and size?**
 
 Yes. You can swap the [video content](https://reference.aspose.com/slides/nodejs-java/aspose.slides/videoframe/setembeddedvideo/) within the frame while preserving the shape's geometry; this is a common scenario for updating media in an existing layout.
 
-### Can the content type (MIME) of an embedded video be determined?
+**Can the content type (MIME) of an embedded video be determined?**
 
 Yes. An embedded video has a [content type](https://reference.aspose.com/slides/nodejs-java/aspose.slides/video/getcontenttype/) that you can read and use, for example when saving it to disk.

--- a/en/php-java/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
+++ b/en/php-java/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
@@ -106,6 +106,72 @@ This PHP code shows you how to add a video from the web to a slide in a PowerPoi
 
 ```
 
+## **Trim a Video Frame**
+
+Aspose.Slides allows you to control which part of a video is played by setting the trim-from-start and trim-from-end values through [VideoFrame::setTrimFromStart](https://reference.aspose.com/slides/php-java/aspose.slides/videoframe/#setTrimFromStart) and [VideoFrame::setTrimFromEnd](https://reference.aspose.com/slides/php-java/aspose.slides/videoframe/#setTrimFromEnd). Both values are specified in milliseconds and define how much time is skipped from the beginning and end of the video, respectively. These settings change the video playback settings in the presentation; they do not cut or otherwise modify the embedded video binary data.
+
+**Set Trim Settings**
+
+To create a video frame and set its trim settings:
+
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/) class.
+1. Add a [Video](https://reference.aspose.com/slides/php-java/aspose.slides/video/) object to the presentation.
+1. Add a [VideoFrame](https://reference.aspose.com/slides/php-java/aspose.slides/videoframe/) object to a slide.
+1. Set the trim-from-start and trim-from-end values through [VideoFrame::setTrimFromStart](https://reference.aspose.com/slides/php-java/aspose.slides/videoframe/#setTrimFromStart) and [VideoFrame::setTrimFromEnd](https://reference.aspose.com/slides/php-java/aspose.slides/videoframe/#setTrimFromEnd).
+1. Save the modified presentation.
+
+The following code example skips the first 2.5 seconds and the last second of an embedded video during playback:
+
+```php
+$presentation = new Presentation();
+$videoStream = null;
+try {
+    $videoStream = new Java("java.io.FileInputStream", "video.mp4");
+    $video = $presentation->getVideos()->addVideo(
+        $videoStream, LoadingStreamBehavior::ReadStreamAndRelease);
+    $slide = $presentation->getSlides()->get_Item(0);
+    $videoFrame = $slide->getShapes()->addVideoFrame(50, 50, 640, 360, $video);
+
+    $videoFrame->setTrimFromStart(2500);
+    $videoFrame->setTrimFromEnd(1000);
+
+    $presentation->save("video_with_trim.pptx", SaveFormat::Pptx);
+} finally {
+    if ($videoStream !== null) {
+        $videoStream->close();
+    }
+    $presentation->dispose();
+}
+```
+
+**Read Trim Settings**
+
+To inspect existing trim settings, load a presentation, find a [VideoFrame](https://reference.aspose.com/slides/php-java/aspose.slides/videoframe/) object among the shapes on the first slide, and read the values through [VideoFrame::getTrimFromStart](https://reference.aspose.com/slides/php-java/aspose.slides/videoframe/#getTrimFromStart) and [VideoFrame::getTrimFromEnd](https://reference.aspose.com/slides/php-java/aspose.slides/videoframe/#getTrimFromEnd).
+
+The following code example finds the first video frame on the first slide and reports its trim settings in milliseconds:
+
+```php
+$presentation = new Presentation("video_with_trim.pptx");
+try {
+    $slide = $presentation->getSlides()->get_Item(0);
+    $shapeCount = java_values($slide->getShapes()->size());
+    for ($shapeIndex = 0; $shapeIndex < $shapeCount; $shapeIndex++) {
+        $shape = $slide->getShapes()->get_Item($shapeIndex);
+        if (java_instanceof($shape, new JavaClass("com.aspose.slides.VideoFrame"))) {
+            $videoFrame = $shape;
+            $trimFromStart = java_values($videoFrame->getTrimFromStart());
+            $trimFromEnd = java_values($videoFrame->getTrimFromEnd());
+
+            echo "Trim from start: " . $trimFromStart . " ms\n";
+            echo "Trim from end: " . $trimFromEnd . " ms\n";
+            break;
+        }
+    }
+} finally {
+    $presentation->dispose();
+}
+```
+
 ## **Manage Video Captions**
 
 Aspose.Slides allows you to manage closed captions for video frames in PowerPoint presentations. Captions are stored in WebVTT format and are exposed through the [VideoFrame::getCaptionTracks](https://reference.aspose.com/slides/php-java/aspose.slides/videoframe/#getCaptionTracks) method.
@@ -248,18 +314,18 @@ This PHP code shows you how to extract the video on a presentation slide:
 
 ## **FAQ**
 
-### Which video playback parameters can be changed for a VideoFrame?
+**Which video playback parameters can be changed for a VideoFrame?**
 
 You can control the [playback mode](https://reference.aspose.com/slides/php-java/aspose.slides/videoframe/setplaymode/) (auto or on click) and [looping](https://reference.aspose.com/slides/php-java/aspose.slides/videoframe/setplayloopmode/). These options are available via the [VideoFrame](https://reference.aspose.com/slides/php-java/aspose.slides/videoframe/) object's properties.
 
-### Does adding a video affect the PPTX file size?
+**Does adding a video affect the PPTX file size?**
 
 Yes. When you embed a local video, the binary data is included in the document, so the presentation size grows in proportion to the file size. When you add an online video, a link and a thumbnail are embedded, so the size increase is smaller.
 
-### Can I replace the video in an existing VideoFrame without changing its position and size?
+**Can I replace the video in an existing VideoFrame without changing its position and size?**
 
 Yes. You can swap the [video content](https://reference.aspose.com/slides/php-java/aspose.slides/videoframe/setembeddedvideo/) within the frame while preserving the shape's geometry; this is a common scenario for updating media in an existing layout.
 
-### Can the content type (MIME) of an embedded video be determined?
+**Can the content type (MIME) of an embedded video be determined?**
 
 Yes. An embedded video has a [content type](https://reference.aspose.com/slides/php-java/aspose.slides/video/getcontenttype/) that you can read and use, for example when saving it to disk.

--- a/en/python-net/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
+++ b/en/python-net/developer-guide/presentation-content/manage-media-files/video-frame/_index.md
@@ -70,7 +70,7 @@ with slides.Presentation() as pres:
 
 ## **Create Video Frame with Video from Web Source**
 
-Microsoft [PowerPoint 2013 and newer](https://support.microsoft.com/en-us/office/versions-of-powerpoint-that-support-online-videos-2a0e184d-af50-4da9-b530-e4355ac436a9?ui=en-us&rs=en-us&ad=us) support YouTube videos in presentations. If the video you want to use is available online (e.g. on YouTube), you can add it to your presentation through its web link. 
+Newer versions of Microsoft [PowerPoint](https://support.microsoft.com/en-us/office/insert-a-video-from-youtube-or-another-site-8340ec69-4cee-4fe1-ab96-4849154bc6db) support online videos in presentations. If the video you want to use is available online (e.g. on YouTube), you can add it to your presentation through its web link.
 
 1. Create an instance of [Presentation](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/) class
 1. Get a slide's reference through its index. 
@@ -98,6 +98,62 @@ def add_video_from_youyube(pres, videoId):
 with slides.Presentation() as pres:
     add_video_from_youyube(pres, "s5JbfQZ5Cc0")
     pres.save("AddVideoFrameFromWebSource_out.pptx", slides.export.SaveFormat.PPTX)
+```
+
+## **Trim a Video Frame**
+
+Aspose.Slides allows you to control which part of a video is played by setting the trim-from-start and trim-from-end values through [VideoFrame.trim_from_start](https://reference.aspose.com/slides/python-net/aspose.slides/videoframe/trim_from_start/) and [VideoFrame.trim_from_end](https://reference.aspose.com/slides/python-net/aspose.slides/videoframe/trim_from_end/). Both values are specified in milliseconds and define how much time is skipped from the beginning and end of the video, respectively. These settings change the video playback settings in the presentation; they do not cut or otherwise modify the embedded video binary data.
+
+**Set Trim Settings**
+
+To create a video frame and set its trim settings:
+
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/) class.
+1. Add a [Video](https://reference.aspose.com/slides/python-net/aspose.slides/video/) object to the presentation.
+1. Add a [VideoFrame](https://reference.aspose.com/slides/python-net/aspose.slides/videoframe/) object to a slide.
+1. Set the trim-from-start and trim-from-end values through [VideoFrame.trim_from_start](https://reference.aspose.com/slides/python-net/aspose.slides/videoframe/trim_from_start/) and [VideoFrame.trim_from_end](https://reference.aspose.com/slides/python-net/aspose.slides/videoframe/trim_from_end/).
+1. Save the modified presentation.
+
+The following code example skips the first 2.5 seconds and the last second of an embedded video during playback:
+
+```python
+import aspose.slides as slides
+
+with slides.Presentation() as presentation:
+    with open("video.mp4", "rb") as video_stream:
+        video_data = video_stream.read()
+
+    video = presentation.videos.add_video(video_data)
+
+    slide = presentation.slides[0]
+    video_frame = slide.shapes.add_video_frame(50, 50, 640, 360, video)
+
+    video_frame.trim_from_start = 2500.0
+    video_frame.trim_from_end = 1000.0
+
+    presentation.save("video_with_trim.pptx", slides.export.SaveFormat.PPTX)
+```
+
+**Read Trim Settings**
+
+To inspect existing trim settings, load a presentation, find a [VideoFrame](https://reference.aspose.com/slides/python-net/aspose.slides/videoframe/) object among the shapes on the first slide, and read the values through [VideoFrame.trim_from_start](https://reference.aspose.com/slides/python-net/aspose.slides/videoframe/trim_from_start/) and [VideoFrame.trim_from_end](https://reference.aspose.com/slides/python-net/aspose.slides/videoframe/trim_from_end/).
+
+The following code example finds the first video frame on the first slide and reports its trim settings in milliseconds:
+
+```python
+import aspose.slides as slides
+
+with slides.Presentation("video_with_trim.pptx") as presentation:
+    slide = presentation.slides[0]
+    for shape in slide.shapes:
+        if isinstance(shape, slides.VideoFrame):
+            video_frame = shape
+            trim_from_start = video_frame.trim_from_start
+            trim_from_end = video_frame.trim_from_end
+
+            print(f"Trim from start: {trim_from_start} ms")
+            print(f"Trim from end: {trim_from_end} ms")
+            break
 ```
 
 ## **Manage Video Captions**
@@ -215,18 +271,18 @@ with slides.Presentation(path + "Video.pptx") as presentation:
 
 ## **FAQ**
 
-### Which video playback parameters can be changed for a VideoFrame?
+**Which video playback parameters can be changed for a VideoFrame?**
 
 You can control the [playback mode](https://reference.aspose.com/slides/python-net/aspose.slides/videoframe/play_mode/) (auto or on click) and [looping](https://reference.aspose.com/slides/python-net/aspose.slides/videoframe/play_loop_mode/). These options are available via the [VideoFrame](https://reference.aspose.com/slides/python-net/aspose.slides/videoframe/) object's properties.
 
-### Does adding a video affect the PPTX file size?
+**Does adding a video affect the PPTX file size?**
 
 Yes. When you embed a local video, the binary data is included in the document, so the presentation size grows in proportion to the file size. When you add an online video, a link and a thumbnail are embedded, so the size increase is smaller.
 
-### Can I replace the video in an existing VideoFrame without changing its position and size?
+**Can I replace the video in an existing VideoFrame without changing its position and size?**
 
 Yes. You can swap the [video content](https://reference.aspose.com/slides/python-net/aspose.slides/videoframe/embedded_video/) within the frame while preserving the shape's geometry; this is a common scenario for updating media in an existing layout.
 
-### Can the content type (MIME) of an embedded video be determined?
+**Can the content type (MIME) of an embedded video be determined?**
 
 Yes. An embedded video has a [content type](https://reference.aspose.com/slides/python-net/aspose.slides/video/content_type/) that you can read and use, for example when saving it to disk.


### PR DESCRIPTION
Added the section "Trim a Video Frame" (.NET, Android via Java, C++, Java, Node.js via Java, PHP via Java, and Python via .NET). 
Formatted the FAQ aections.