### PR TITLE
SLIDESDOC-818 Add documentation for getting the visual bounds of shapes

### DIFF
--- a/en/androidjava/developer-guide/presentation-content/powerpoint-shapes/create-shape-thumbnails/_index.md
+++ b/en/androidjava/developer-guide/presentation-content/powerpoint-shapes/create-shape-thumbnails/_index.md
@@ -9,6 +9,8 @@ keywords:
 - shape image
 - render shape
 - shape rendering
+- visual bounds
+- shape bounds
 - PowerPoint
 - presentation
 - Android
@@ -112,24 +114,59 @@ try {
 }
 ```
 
+## **Get the Actual Visual Bounds of a Shape**
+
+The frame properties of [IShape](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ishape/)—its `getX()`, `getY()`, `getWidth()`, and `getHeight()` methods—describe the rectangle stored in the presentation model. The content that is actually rendered can extend beyond that frame or occupy a different axis-aligned rectangle. Rotation, outlines, arrowheads, text layout and overflow, generated SmartArt geometry, and other rendering effects can all change the occupied area.
+
+Use [Shape.getVisualBounds](https://reference.aspose.com/slides/androidjava/com.aspose.slides/shape/#getVisualBounds--) to calculate that occupied area without creating an image. The method returns a [RectF](https://developer.android.com/reference/android/graphics/RectF) in slide coordinates. The returned rectangle is not clipped to the slide, so its coordinates can be negative when content extends beyond the slide origin.
+
+[Shape.getVisualBounds](https://reference.aspose.com/slides/androidjava/com.aspose.slides/shape/#getVisualBounds--) is not currently declared by the [IShape](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ishape/) interface. Therefore, keep the shape obtained from the slide's shape collection as an interface value and cast it only when calling the method.
+
+The following example gets and compares the frame and visual bounds:
+
+```java
+Presentation presentation = new Presentation("example.pptx");
+try {
+    ISlide slide = presentation.getSlides().get_Item(0);
+    IShape shape = slide.getShapes().get_Item(0);
+
+    RectF visualBounds = ((Shape) shape).getVisualBounds();
+
+    float frameLeft = shape.getX();
+    float frameTop = shape.getY();
+    float frameRight = frameLeft + shape.getWidth();
+    float frameBottom = frameTop + shape.getHeight();
+    RectF frameBounds = new RectF(frameLeft, frameTop, frameRight, frameBottom);
+
+    System.out.println("Frame bounds: " + frameBounds);
+    System.out.println("Visual bounds: " + visualBounds);
+} finally {
+    presentation.dispose();
+}
+```
+
+The same [RectF](https://developer.android.com/reference/android/graphics/RectF) can be used to align nearby shapes to its left, right, top, or bottom edge; reserve enough space in a generated layout; or detect content outside a permitted region. Visual bounds are especially useful for SmartArt, text boxes, arrows, pictures, rotated shapes, and group shapes, where the stored frame may not represent the full rendered result.
+
+Use [Shape.getVisualBounds](https://reference.aspose.com/slides/androidjava/com.aspose.slides/shape/#getVisualBounds--) when you need coordinates for layout or validation and do not need a bitmap. Use [IShape.getImage](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ishape/#getImage--) when you need to render the shape. With [ShapeThumbnailBounds](https://reference.aspose.com/slides/androidjava/com.aspose.slides/shapethumbnailbounds/), `ShapeThumbnailBounds.Shape` sizes the image from the shape bounds, including outline settings, while `ShapeThumbnailBounds.Appearance` sizes it from the shape's appearance and restricts the result to the slide bounds. In contrast, [Shape.getVisualBounds](https://reference.aspose.com/slides/androidjava/com.aspose.slides/shape/#getVisualBounds--) returns only the calculated rectangle and does not clip it to the slide.
+
 ## **FAQ**
 
-### What image formats can be used when saving shape thumbnails?
+**What image formats can be used when saving shape thumbnails?**
 
 [PNG, JPEG, BMP, GIF, TIFF](https://reference.aspose.com/slides/androidjava/com.aspose.slides/imageformat/), and others. Shapes can also be [exported as vector SVG](https://reference.aspose.com/slides/androidjava/com.aspose.slides/shape/#writeAsSvg-java.io.OutputStream-com.aspose.slides.ISVGOptions-) by saving the shape’s content as SVG.
 
-### What is the difference between Shape and Appearance bounds when rendering a thumbnail?
+**What is the difference between Shape and Appearance bounds when rendering a thumbnail?**
 
 `Shape` uses the shape’s geometry; `Appearance` takes [visual effects](/slides/androidjava/shape-effect/) (shadows, glows, etc.) into account.
 
-### What happens if a shape is marked as hidden? Will it still render as a thumbnail?
+**What happens if a shape is marked as hidden? Will it still render as a thumbnail?**
 
 A hidden shape remains part of the model and can be rendered; the hidden flag affects slideshow display but does not prevent generating the shape’s image.
 
-### Are group shapes, charts, SmartArt, and other complex objects supported?
+**Are group shapes, charts, SmartArt, and other complex objects supported?**
 
 Yes. Any object represented as [Shape](https://reference.aspose.com/slides/androidjava/com.aspose.slides/shape/) (including [GroupShape](https://reference.aspose.com/slides/androidjava/com.aspose.slides/groupshape/), [Chart](https://reference.aspose.com/slides/androidjava/com.aspose.slides/chart/), and [SmartArt](https://reference.aspose.com/slides/androidjava/com.aspose.slides/smartart/)) can be saved as a thumbnail or as SVG.
 
-### Do system-installed fonts affect the quality of thumbnails for text shapes?
+**Do system-installed fonts affect the quality of thumbnails for text shapes?**
 
 Yes. You should [provide the required fonts](/slides/androidjava/custom-font/) (or [configure font substitutions](/slides/androidjava/font-substitution/)) to avoid unwanted fallbacks and text reflow.

--- a/en/cpp/developer-guide/presentation-content/powerpoint-shapes/shape-thumbnails/_index.md
+++ b/en/cpp/developer-guide/presentation-content/powerpoint-shapes/shape-thumbnails/_index.md
@@ -9,6 +9,8 @@ keywords:
 - shape image
 - render shape
 - shape rendering
+- visual bounds
+- shape bounds
 - PowerPoint
 - presentation
 - C++
@@ -95,24 +97,55 @@ image->Dispose();
 presentation->Dispose();
 ```
 
+## **Get the Actual Visual Bounds of a Shape**
+
+The frame properties of [IShape](https://reference.aspose.com/slides/cpp/aspose.slides/ishape/)—`IShape::get_X()`, `IShape::get_Y()`, `IShape::get_Width()`, and `IShape::get_Height()`—describe the rectangle stored in the presentation model. The content that is actually rendered can extend beyond that frame or occupy a different axis-aligned rectangle. Rotation, outlines, arrowheads, text layout and overflow, generated SmartArt geometry, and other rendering effects can all change the occupied area.
+
+Use [Shape::GetVisualBounds](https://reference.aspose.com/slides/cpp/aspose.slides/shape/getvisualbounds/) to calculate that occupied area without creating an image. The method returns a [RectangleF](https://reference.aspose.com/slides/cpp/system.drawing/rectanglef/) in slide coordinates. The returned rectangle is not clipped to the slide, so its coordinates can be negative when content extends beyond the slide origin.
+
+[Shape::GetVisualBounds](https://reference.aspose.com/slides/cpp/aspose.slides/shape/getvisualbounds/) is not currently declared by the [IShape](https://reference.aspose.com/slides/cpp/aspose.slides/ishape/) interface. Therefore, keep the shape obtained from the slide's shape collection as an interface value and cast it only when calling the method.
+
+The following example gets and compares the frame and visual bounds:
+
+```cpp
+auto presentation = MakeObject<Presentation>(u"example.pptx");
+
+auto slide = presentation->get_Slide(0);
+auto shape = slide->get_Shape(0);
+
+auto visualBounds = System::AsCast<Shape>(shape)->GetVisualBounds();
+
+System::Drawing::RectangleF frameBounds(
+    shape->get_X(), shape->get_Y(), shape->get_Width(), shape->get_Height());
+
+Console::WriteLine(u"Frame bounds: {0}", frameBounds);
+Console::WriteLine(u"Visual bounds: {0}", visualBounds);
+
+presentation->Dispose();
+```
+
+The same [RectangleF](https://reference.aspose.com/slides/cpp/system.drawing/rectanglef/) can be used to align nearby shapes to its `RectangleF::get_Left()`, `RectangleF::get_Right()`, `RectangleF::get_Top()`, or `RectangleF::get_Bottom()` edge; reserve enough space in a generated layout; or detect content outside a permitted region. Visual bounds are especially useful for SmartArt, text boxes, arrows, pictures, rotated shapes, and group shapes, where the stored frame may not represent the full rendered result.
+
+Use [Shape::GetVisualBounds](https://reference.aspose.com/slides/cpp/aspose.slides/shape/getvisualbounds/) when you need coordinates for layout or validation and do not need a bitmap. Use [IShape::GetImage](https://reference.aspose.com/slides/cpp/aspose.slides/ishape/getimage/) when you need to render the shape. With [ShapeThumbnailBounds](https://reference.aspose.com/slides/cpp/aspose.slides/shapethumbnailbounds/), `ShapeThumbnailBounds::Shape` sizes the image from the shape bounds, including outline settings, while `ShapeThumbnailBounds::Appearance` sizes it from the shape's appearance and restricts the result to the slide bounds. In contrast, [Shape::GetVisualBounds](https://reference.aspose.com/slides/cpp/aspose.slides/shape/getvisualbounds/) returns only the calculated rectangle and does not clip it to the slide.
+
 ## **FAQ**
 
-### What image formats can be used when saving shape thumbnails?
+**What image formats can be used when saving shape thumbnails?**
 
 [PNG, JPEG, BMP, GIF, TIFF](https://reference.aspose.com/slides/cpp/aspose.slides/imageformat/), and others. Shapes can also be [exported as vector SVG](https://reference.aspose.com/slides/cpp/aspose.slides/shape/writeassvg/) by saving the shape’s content as SVG.
 
-### What is the difference between Shape and Appearance bounds when rendering a thumbnail?
+**What is the difference between Shape and Appearance bounds when rendering a thumbnail?**
 
 `Shape` uses the shape’s geometry; `Appearance` takes [visual effects](/slides/cpp/shape-effect/) (shadows, glows, etc.) into account.
 
-### What happens if a shape is marked as hidden? Will it still render as a thumbnail?
+**What happens if a shape is marked as hidden? Will it still render as a thumbnail?**
 
 A hidden shape remains part of the model and can be rendered; the hidden flag affects slideshow display but does not prevent generating the shape’s image.
 
-### Are group shapes, charts, SmartArt, and other complex objects supported?
+**Are group shapes, charts, SmartArt, and other complex objects supported?**
 
 Yes. Any object represented as [Shape](https://reference.aspose.com/slides/cpp/aspose.slides/shape/) (including [GroupShape](https://reference.aspose.com/slides/cpp/aspose.slides/groupshape/), [Chart](https://reference.aspose.com/slides/cpp/aspose.slides.charts/chart/), and [SmartArt](https://reference.aspose.com/slides/cpp/aspose.slides.smartart/smartart/)) can be saved as a thumbnail or as SVG.
 
-### Do system-installed fonts affect the quality of thumbnails for text shapes?
+**Do system-installed fonts affect the quality of thumbnails for text shapes?**
 
 Yes. You should [provide the required fonts](/slides/cpp/custom-font/) (or [configure font substitutions](/slides/cpp/font-substitution/)) to avoid unwanted fallbacks and text reflow.

--- a/en/java/developer-guide/presentation-content/powerpoint-shapes/create-shape-thumbnails/_index.md
+++ b/en/java/developer-guide/presentation-content/powerpoint-shapes/create-shape-thumbnails/_index.md
@@ -9,6 +9,8 @@ keywords:
 - shape image
 - render shape
 - shape rendering
+- visual bounds
+- shape bounds
 - PowerPoint
 - presentation
 - Java
@@ -29,9 +31,9 @@ This article explains how to generate slide thumbnails in different ways:
 ## **Generate a Shape Thumbnail from a Slide**
 To generate a shape thumbnail from any slide using Aspose.Slides for Java, do this:
 
-1. Create an instance of the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) class.
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation/) class.
 1. Obtain the reference of any slide using its ID or index.
-1. [Get the shape thumbnail image](https://reference.aspose.com/slides/java/com.aspose.slides/IShape#getImage--) of the referenced slide on default scale.
+1. [Get the shape thumbnail image](https://reference.aspose.com/slides/java/com.aspose.slides/ishape/#getImage--) of the referenced slide on default scale.
 1. Save the thumbnail image in your preferred image format.
 
 This sample code shows you how to generate a shape thumbnail from a slide:
@@ -57,9 +59,9 @@ try {
 ## **Generate a User-Defined Scaling Factor Thumbnail**
 To generate the shape thumbnail of a slide using Aspose.Slides for Java, do this:
 
-1. Create an instance of the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) class.
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation/) class.
 1. Obtain the reference of any slide using its ID or index.
-1. [Get the shape thumbnail image](https://reference.aspose.com/slides/java/com.aspose.slides/IShape#getImage-int-float-float-) of the referenced slide with user-defined dimensions.
+1. [Get the shape thumbnail image](https://reference.aspose.com/slides/java/com.aspose.slides/ishape/#getImage-int-float-float-) of the referenced slide with user-defined dimensions.
 1. Save the thumbnail image in your preferred image format.
 
 This sample code shows you how to generate a shape thumbnail based on a defined scaling factor:
@@ -85,7 +87,7 @@ try {
 ## **Create a Bounds-Based Shape Appearance Thumbnail**
 This method of creating thumbnails of shapes allows developers to generate a thumbnail in the bounds of the shape's appearance. It takes into account all the shape effects. The generated shape thumbnail is restricted by the slide bounds. To generate a thumbnail of a slide shape in the bound of its appearance, do this:
 
-1. Create an instance of the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation) class.
+1. Create an instance of the [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/presentation/) class.
 1. Obtain the reference of any slide using its ID or index.
 1. Get the thumbnail image of the referenced slide with shape bounds as appearance.
 1. Save the thumbnail image in your preferred image format.
@@ -110,24 +112,56 @@ try {
 }
 ```
 
+## **Get the Actual Visual Bounds of a Shape**
+
+The frame properties of [IShape](https://reference.aspose.com/slides/java/com.aspose.slides/ishape/)—its `getX()`, `getY()`, `getWidth()`, and `getHeight()` methods—describe the rectangle stored in the presentation model. The content that is actually rendered can extend beyond that frame or occupy a different axis-aligned rectangle. Rotation, outlines, arrowheads, text layout and overflow, generated SmartArt geometry, and other rendering effects can all change the occupied area.
+
+Use [Shape.getVisualBounds](https://reference.aspose.com/slides/java/com.aspose.slides/shape/#getVisualBounds--) to calculate that occupied area without creating an image. The method returns a [Rectangle2D.Float](https://docs.oracle.com/javase/8/docs/api/java/awt/geom/Rectangle2D.Float.html) in slide coordinates. The returned rectangle is not clipped to the slide, so its coordinates can be negative when content extends beyond the slide origin.
+
+[Shape.getVisualBounds](https://reference.aspose.com/slides/java/com.aspose.slides/shape/#getVisualBounds--) is not currently declared by the [IShape](https://reference.aspose.com/slides/java/com.aspose.slides/ishape/) interface. Therefore, keep the shape obtained from the slide's shape collection as an interface value and cast it only when calling the method.
+
+The following example gets and compares the frame and visual bounds:
+
+```java
+Presentation presentation = new Presentation("example.pptx");
+try {
+    ISlide slide = presentation.getSlides().get_Item(0);
+    IShape shape = slide.getShapes().get_Item(0);
+
+    Rectangle2D.Float visualBounds = ((Shape) shape).getVisualBounds();
+
+    Rectangle2D.Float frameBounds = new Rectangle2D.Float(
+        shape.getX(), shape.getY(), shape.getWidth(), shape.getHeight());
+
+    System.out.println("Frame bounds: " + frameBounds);
+    System.out.println("Visual bounds: " + visualBounds);
+} finally {
+    presentation.dispose();
+}
+```
+
+The same [Rectangle2D.Float](https://docs.oracle.com/javase/8/docs/api/java/awt/geom/Rectangle2D.Float.html) can be used to align nearby shapes to its left, right, top, or bottom edge; reserve enough space in a generated layout; or detect content outside a permitted region. Visual bounds are especially useful for SmartArt, text boxes, arrows, pictures, rotated shapes, and group shapes, where the stored frame may not represent the full rendered result.
+
+Use [Shape.getVisualBounds](https://reference.aspose.com/slides/java/com.aspose.slides/shape/#getVisualBounds--) when you need coordinates for layout or validation and do not need a bitmap. Use [IShape.getImage](https://reference.aspose.com/slides/java/com.aspose.slides/ishape/#getImage--) when you need to render the shape. With [ShapeThumbnailBounds](https://reference.aspose.com/slides/java/com.aspose.slides/shapethumbnailbounds/), `ShapeThumbnailBounds.Shape` sizes the image from the shape bounds, including outline settings, while `ShapeThumbnailBounds.Appearance` sizes it from the shape's appearance and restricts the result to the slide bounds. In contrast, [Shape.getVisualBounds](https://reference.aspose.com/slides/java/com.aspose.slides/shape/#getVisualBounds--) returns only the calculated rectangle and does not clip it to the slide.
+
 ## **FAQ**
 
-### What image formats can be used when saving shape thumbnails?
+**What image formats can be used when saving shape thumbnails?**
 
 [PNG, JPEG, BMP, GIF, TIFF](https://reference.aspose.com/slides/java/com.aspose.slides/imageformat/), and others. Shapes can also be [exported as vector SVG](https://reference.aspose.com/slides/java/com.aspose.slides/shape/#writeAsSvg-java.io.OutputStream-com.aspose.slides.ISVGOptions-) by saving the shape’s content as SVG.
 
-### What is the difference between Shape and Appearance bounds when rendering a thumbnail?
+**What is the difference between Shape and Appearance bounds when rendering a thumbnail?**
 
 `Shape` uses the shape’s geometry; `Appearance` takes [visual effects](/slides/java/shape-effect/) (shadows, glows, etc.) into account.
 
-### What happens if a shape is marked as hidden? Will it still render as a thumbnail?
+**What happens if a shape is marked as hidden? Will it still render as a thumbnail?**
 
 A hidden shape remains part of the model and can be rendered; the hidden flag affects slideshow display but does not prevent generating the shape’s image.
 
-### Are group shapes, charts, SmartArt, and other complex objects supported?
+**Are group shapes, charts, SmartArt, and other complex objects supported?**
 
 Yes. Any object represented as [Shape](https://reference.aspose.com/slides/java/com.aspose.slides/shape/) (including [GroupShape](https://reference.aspose.com/slides/java/com.aspose.slides/groupshape/), [Chart](https://reference.aspose.com/slides/java/com.aspose.slides/chart/), and [SmartArt](https://reference.aspose.com/slides/java/com.aspose.slides/smartart/)) can be saved as a thumbnail or as SVG.
 
-### Do system-installed fonts affect the quality of thumbnails for text shapes?
+**Do system-installed fonts affect the quality of thumbnails for text shapes?**
 
 Yes. You should [provide the required fonts](/slides/java/custom-font/) (or [configure font substitutions](/slides/java/font-substitution/)) to avoid unwanted fallbacks and text reflow.

--- a/en/net/developer-guide/presentation-content/powerpoint-shapes/create-shape-thumbnails/_index.md
+++ b/en/net/developer-guide/presentation-content/powerpoint-shapes/create-shape-thumbnails/_index.md
@@ -9,6 +9,8 @@ keywords:
 - shape image
 - render shape
 - shape rendering
+- visual bounds
+- shape bounds
 - PowerPoint
 - presentation
 - .NET
@@ -97,24 +99,51 @@ using (Presentation presentation = new Presentation("HelloWorld.pptx"))
 }
 ```
 
+## **Get the Actual Visual Bounds of a Shape**
+
+The frame properties of [IShape](https://reference.aspose.com/slides/net/aspose.slides/ishape/)—its `X`, `Y`, `Width`, and `Height` properties—describe the rectangle stored in the presentation model. The content that is actually rendered can extend beyond that frame or occupy a different axis-aligned rectangle. Rotation, outlines, arrowheads, text layout and overflow, generated SmartArt geometry, and other rendering effects can all change the occupied area.
+
+Use [GetVisualBounds](https://reference.aspose.com/slides/net/aspose.slides/shape/getvisualbounds/) to calculate that occupied area without creating an image. The method returns a [RectangleF](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.rectanglef) in slide coordinates. The returned rectangle is not clipped to the slide, so its coordinates can be negative when content extends beyond the slide origin.
+
+[GetVisualBounds](https://reference.aspose.com/slides/net/aspose.slides/shape/getvisualbounds/) is not currently declared by the [IShape](https://reference.aspose.com/slides/net/aspose.slides/ishape/) interface. Therefore, keep the shape obtained from the slide's shape collection as an interface value and cast it only when calling the method.
+
+The following example gets and compares the frame and visual bounds:
+
+```csharp
+using var presentation = new Presentation("example.pptx");
+
+var slide = presentation.Slides[0];
+IShape shape = slide.Shapes[0];
+
+var visualBounds = ((Shape)shape).GetVisualBounds();
+var frameBounds = new RectangleF(shape.X, shape.Y, shape.Width, shape.Height);
+
+Console.WriteLine($"Frame bounds: {frameBounds}");
+Console.WriteLine($"Visual bounds: {visualBounds}");
+```
+
+The same [RectangleF](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.rectanglef) can be used to align nearby shapes to its `Left`, `Right`, `Top`, or `Bottom` edge; reserve enough space in a generated layout; or detect content outside a permitted region. Visual bounds are especially useful for SmartArt, text boxes, arrows, pictures, rotated shapes, and group shapes, where the stored frame may not represent the full rendered result.
+
+Use [GetVisualBounds](https://reference.aspose.com/slides/net/aspose.slides/shape/getvisualbounds/) when you need coordinates for layout or validation and do not need a bitmap. Use [IShape.GetImage](https://reference.aspose.com/slides/net/aspose.slides/ishape/getimage/) when you need to render the shape. With [ShapeThumbnailBounds](https://reference.aspose.com/slides/net/aspose.slides/shapethumbnailbounds/), `ShapeThumbnailBounds.Shape` sizes the image from the shape bounds, including outline settings, while `ShapeThumbnailBounds.Appearance` sizes it from the shape's appearance and restricts the result to the slide bounds. In contrast, [GetVisualBounds](https://reference.aspose.com/slides/net/aspose.slides/shape/getvisualbounds/) returns only the calculated rectangle and does not clip it to the slide.
+
 ## **FAQ**
 
-### What image formats can be used when saving shape thumbnails?
+**What image formats can be used when saving shape thumbnails?**
 
 [PNG, JPEG, BMP, GIF, TIFF](https://reference.aspose.com/slides/net/aspose.slides/imageformat/), and others. Shapes can also be [exported as vector SVG](https://reference.aspose.com/slides/net/aspose.slides/shape/writeassvg/) by saving the shape’s content as SVG.
 
-### What is the difference between Shape and Appearance bounds when rendering a thumbnail?
+**What is the difference between Shape and Appearance bounds when rendering a thumbnail?**
 
 `Shape` uses the shape’s geometry; `Appearance` takes [visual effects](/slides/net/shape-effect/) (shadows, glows, etc.) into account.
 
-### What happens if a shape is marked as hidden? Will it still render as a thumbnail?
+**What happens if a shape is marked as hidden? Will it still render as a thumbnail?**
 
 A hidden shape remains part of the model and can be rendered; the hidden flag affects slideshow display but does not prevent generating the shape’s image.
 
-### Are group shapes, charts, SmartArt, and other complex objects supported?
+**Are group shapes, charts, SmartArt, and other complex objects supported?**
 
 Yes. Any object represented as [Shape](https://reference.aspose.com/slides/net/aspose.slides/shape/) (including [GroupShape](https://reference.aspose.com/slides/net/aspose.slides/groupshape/), [Chart](https://reference.aspose.com/slides/net/aspose.slides.charts/chart/), and [SmartArt](https://reference.aspose.com/slides/net/aspose.slides.smartart/smartart/)) can be saved as a thumbnail or as SVG.
 
-### Do system-installed fonts affect the quality of thumbnails for text shapes?
+**Do system-installed fonts affect the quality of thumbnails for text shapes?**
 
 Yes. You should [provide the required fonts](/slides/net/custom-font/) (or [configure font substitutions](/slides/net/font-substitution/)) to avoid unwanted fallbacks and text reflow.

--- a/en/nodejs-java/developer-guide/presentation-content/powerpoint-shapes/create-shape-thumbnails/_index.md
+++ b/en/nodejs-java/developer-guide/presentation-content/powerpoint-shapes/create-shape-thumbnails/_index.md
@@ -9,6 +9,8 @@ keywords:
 - shape image
 - render shape
 - shape rendering
+- visual bounds
+- shape bounds
 - PowerPoint
 - presentation
 - Node.js
@@ -119,24 +121,68 @@ try {
 }
 ```
 
+## **Get the Actual Visual Bounds of a Shape**
+
+The frame properties of a [Shape](https://reference.aspose.com/slides/nodejs-java/aspose.slides/shape/)—its `getX()`, `getY()`, `getWidth()`, and `getHeight()` methods—describe the rectangle stored in the presentation model. The content that is actually rendered can extend beyond that frame or occupy a different axis-aligned rectangle. Rotation, outlines, arrowheads, text layout and overflow, generated SmartArt geometry, and other rendering effects can all change the occupied area.
+
+Use [Shape.getVisualBounds](https://reference.aspose.com/slides/nodejs-java/aspose.slides/shape/#getVisualBounds--) to calculate that occupied area without creating an image. The method returns a [Rectangle2D.Float](https://docs.oracle.com/javase/8/docs/api/java/awt/geom/Rectangle2D.Float.html) object in slide coordinates. The returned rectangle is not clipped to the slide, so its coordinates can be negative when content extends beyond the slide origin.
+
+The following example gets and compares the frame and visual bounds:
+
+```javascript
+const presentation = new aspose.slides.Presentation("example.pptx");
+try {
+    const slide = presentation.getSlides().get_Item(0);
+    const shape = slide.getShapes().get_Item(0);
+
+    const visualBounds = shape.getVisualBounds();
+
+    const frameBounds = {
+        x: shape.getX(),
+        y: shape.getY(),
+        width: shape.getWidth(),
+        height: shape.getHeight()
+    };
+    const visualBoundsValues = {
+        x: visualBounds.getX(),
+        y: visualBounds.getY(),
+        width: visualBounds.getWidth(),
+        height: visualBounds.getHeight()
+    };
+
+    console.log(
+        `Frame bounds (x, y, width, height): ${frameBounds.x}, ${frameBounds.y}, ${frameBounds.width}, ${frameBounds.height}`
+    );
+    console.log(
+        `Visual bounds (x, y, width, height): ${visualBoundsValues.x}, ${visualBoundsValues.y}, ${visualBoundsValues.width}, ${visualBoundsValues.height}`
+    );
+} finally {
+    presentation.dispose();
+}
+```
+
+The same rectangle can be used to align nearby shapes to its left, right, top, or bottom edge; reserve enough space in a generated layout; or detect content outside a permitted region. Visual bounds are especially useful for SmartArt, text boxes, arrows, pictures, rotated shapes, and group shapes, where the stored frame may not represent the full rendered result.
+
+Use [Shape.getVisualBounds](https://reference.aspose.com/slides/nodejs-java/aspose.slides/shape/#getVisualBounds--) when you need coordinates for layout or validation and do not need a bitmap. Use [Shape.getImage](https://reference.aspose.com/slides/nodejs-java/aspose.slides/shape/#getImage--) when you need to render the shape. With [ShapeThumbnailBounds](https://reference.aspose.com/slides/nodejs-java/aspose.slides/shapethumbnailbounds/), `ShapeThumbnailBounds.Shape` sizes the image from the shape bounds, including outline settings, while `ShapeThumbnailBounds.Appearance` sizes it from the shape's appearance and restricts the result to the slide bounds. In contrast, [Shape.getVisualBounds](https://reference.aspose.com/slides/nodejs-java/aspose.slides/shape/#getVisualBounds--) returns only the calculated rectangle and does not clip it to the slide.
+
 ## **FAQ**
 
-### What image formats can be used when saving shape thumbnails?
+**What image formats can be used when saving shape thumbnails?**
 
 [PNG, JPEG, BMP, GIF, TIFF](https://reference.aspose.com/slides/nodejs-java/aspose.slides/imageformat/), and others. Shapes can also be [exported as vector SVG](https://reference.aspose.com/slides/nodejs-java/aspose.slides/shape/writeassvg/) by saving the shape’s content as SVG.
 
-### What is the difference between Shape and Appearance bounds when rendering a thumbnail?
+**What is the difference between Shape and Appearance bounds when rendering a thumbnail?**
 
 `Shape` uses the shape’s geometry; `Appearance` takes [visual effects](/slides/nodejs-java/shape-effect/) (shadows, glows, etc.) into account.
 
-### What happens if a shape is marked as hidden? Will it still render as a thumbnail?
+**What happens if a shape is marked as hidden? Will it still render as a thumbnail?**
 
 A hidden shape remains part of the model and can be rendered; the hidden flag affects slideshow display but does not prevent generating the shape’s image.
 
-### Are group shapes, charts, SmartArt, and other complex objects supported?
+**Are group shapes, charts, SmartArt, and other complex objects supported?**
 
 Yes. Any object represented as [Shape](https://reference.aspose.com/slides/nodejs-java/aspose.slides/shape/) (including [GroupShape](https://reference.aspose.com/slides/nodejs-java/aspose.slides/groupshape/), [Chart](https://reference.aspose.com/slides/nodejs-java/aspose.slides/chart/), and [SmartArt](https://reference.aspose.com/slides/nodejs-java/aspose.slides/smartart/)) can be saved as a thumbnail or as SVG.
 
-### Do system-installed fonts affect the quality of thumbnails for text shapes?
+**Do system-installed fonts affect the quality of thumbnails for text shapes?**
 
 Yes. You should [provide the required fonts](/slides/nodejs-java/custom-font/) (or [configure font substitutions](/slides/nodejs-java/font-substitution/)) to avoid unwanted fallbacks and text reflow.

--- a/en/php-java/developer-guide/presentation-content/powerpoint-shapes/create-shape-thumbnails/_index.md
+++ b/en/php-java/developer-guide/presentation-content/powerpoint-shapes/create-shape-thumbnails/_index.md
@@ -9,6 +9,8 @@ keywords:
 - shape image
 - render shape
 - shape rendering
+- visual bounds
+- shape bounds
 - PowerPoint
 - presentation
 - PHP
@@ -118,24 +120,61 @@ This sample code is based on the steps above:
   }
 ```
 
+## **Get the Actual Visual Bounds of a Shape**
+
+The frame properties of [Shape](https://reference.aspose.com/slides/php-java/aspose.slides/shape/)—`Shape::getX()`, `Shape::getY()`, `Shape::getWidth()`, and `Shape::getHeight()`—describe the rectangle stored in the presentation model. The content that is actually rendered can extend beyond that frame or occupy a different axis-aligned rectangle. Rotation, outlines, arrowheads, text layout and overflow, generated SmartArt geometry, and other rendering effects can all change the occupied area.
+
+Use [Shape::getVisualBounds](https://reference.aspose.com/slides/php-java/aspose.slides/shape/#getVisualBounds) to calculate that occupied area without creating an image. The method returns a [Rectangle2D.Float](https://docs.oracle.com/javase/8/docs/api/java/awt/geom/Rectangle2D.Float.html) in slide coordinates. The returned rectangle is not clipped to the slide, so its coordinates can be negative when content extends beyond the slide origin.
+
+The following example gets and compares the frame and visual bounds:
+
+```php
+  $presentation = new Presentation("example.pptx");
+  try {
+      $slide = $presentation->getSlides()->get_Item(0);
+      $shape = $slide->getShapes()->get_Item(0);
+
+      $visualBounds = $shape->getVisualBounds();
+
+      $frameX = $shape->getX();
+      $frameY = $shape->getY();
+      $frameWidth = $shape->getWidth();
+      $frameHeight = $shape->getHeight();
+
+      $visualX = $visualBounds->getX();
+      $visualY = $visualBounds->getY();
+      $visualWidth = $visualBounds->getWidth();
+      $visualHeight = $visualBounds->getHeight();
+
+      echo "Frame bounds (x, y, width, height): $frameX, $frameY, $frameWidth, $frameHeight\n";
+      echo "Visual bounds (x, y, width, height): $visualX, $visualY, $visualWidth, $visualHeight\n";
+  } finally {
+      $presentation->dispose();
+  }
+```
+
+The same [Rectangle2D.Float](https://docs.oracle.com/javase/8/docs/api/java/awt/geom/Rectangle2D.Float.html) can be used to align nearby shapes to its left, right, top, or bottom edge; reserve enough space in a generated layout; or detect content outside a permitted region. Visual bounds are especially useful for SmartArt, text boxes, arrows, pictures, rotated shapes, and group shapes, where the stored frame may not represent the full rendered result.
+
+Use [Shape::getVisualBounds](https://reference.aspose.com/slides/php-java/aspose.slides/shape/#getVisualBounds) when you need coordinates for layout or validation and do not need a bitmap. Use [Shape::getImage](https://reference.aspose.com/slides/php-java/aspose.slides/shape/#getImage) when you need to render the shape. With [ShapeThumbnailBounds](https://reference.aspose.com/slides/php-java/aspose.slides/shapethumbnailbounds/), `ShapeThumbnailBounds::Shape` sizes the image from the shape bounds, including outline settings, while `ShapeThumbnailBounds::Appearance` sizes it from the shape's appearance and restricts the result to the slide bounds. In contrast, `Shape::getVisualBounds` returns only the calculated rectangle and does not clip it to the slide.
+
 ## **FAQ**
 
-### What image formats can be used when saving shape thumbnails?
+**What image formats can be used when saving shape thumbnails?**
 
 [PNG, JPEG, BMP, GIF, TIFF](https://reference.aspose.com/slides/php-java/aspose.slides/imageformat/), and others. Shapes can also be [exported as vector SVG](https://reference.aspose.com/slides/php-java/aspose.slides/shape/writeassvg/) by saving the shape’s content as SVG.
 
-### What is the difference between Shape and Appearance bounds when rendering a thumbnail?
+**What is the difference between Shape and Appearance bounds when rendering a thumbnail?**
 
 `Shape` uses the shape’s geometry; `Appearance` takes [visual effects](/slides/php-java/shape-effect/) (shadows, glows, etc.) into account.
 
-### What happens if a shape is marked as hidden? Will it still render as a thumbnail?
+**What happens if a shape is marked as hidden? Will it still render as a thumbnail?**
 
 A hidden shape remains part of the model and can be rendered; the hidden flag affects slideshow display but does not prevent generating the shape’s image.
 
-### Are group shapes, charts, SmartArt, and other complex objects supported?
+**Are group shapes, charts, SmartArt, and other complex objects supported?**
 
 Yes. Any object represented as [Shape](https://reference.aspose.com/slides/php-java/aspose.slides/shape/) (including [GroupShape](https://reference.aspose.com/slides/php-java/aspose.slides/groupshape/), [Chart](https://reference.aspose.com/slides/php-java/aspose.slides/chart/), and [SmartArt](https://reference.aspose.com/slides/php-java/aspose.slides/smartart/)) can be saved as a thumbnail or as SVG.
 
-### Do system-installed fonts affect the quality of thumbnails for text shapes?
+**Do system-installed fonts affect the quality of thumbnails for text shapes?**
 
 Yes. You should [provide the required fonts](/slides/php-java/custom-font/) (or [configure font substitutions](/slides/php-java/font-substitution/)) to avoid unwanted fallbacks and text reflow.

--- a/en/python-net/developer-guide/presentation-content/powerpoint-shapes/create-shape-thumbnails/_index.md
+++ b/en/python-net/developer-guide/presentation-content/powerpoint-shapes/create-shape-thumbnails/_index.md
@@ -9,6 +9,8 @@ keywords:
 - shape image
 - render shape
 - shape rendering
+- visual bounds
+- shape bounds
 - PowerPoint
 - presentation
 - Python
@@ -109,24 +111,53 @@ with slides.Presentation("hello_world.pptx") as presentation:
         thumbnail.save("apperance_bounds.png", slides.ImageFormat.PNG)
 ```
 
+## **Get the Actual Visual Bounds of a Shape**
+
+The frame properties of a [Shape](https://reference.aspose.com/slides/python-net/aspose.slides/shape/)—`Shape.x`, `Shape.y`, `Shape.width`, and `Shape.height`—describe the rectangle stored in the presentation model. The content that is actually rendered can extend beyond that frame or occupy a different axis-aligned rectangle. Rotation, outlines, arrowheads, text layout and overflow, generated SmartArt geometry, and other rendering effects can all change the occupied area.
+
+Use [Shape.get_visual_bounds](https://reference.aspose.com/slides/python-net/aspose.slides/shape/get_visual_bounds/) to calculate that occupied area without creating an image. The method returns a floating-point rectangle in slide coordinates. The returned rectangle is not clipped to the slide, so its coordinates can be negative when content extends beyond the slide origin.
+
+The following example gets and compares the frame and visual bounds:
+
+```py
+import aspose.pydrawing as drawing
+import aspose.slides as slides
+
+with slides.Presentation("example.pptx") as presentation:
+    slide = presentation.slides[0]
+    shape = slide.shapes[0]
+
+    visual_bounds = shape.get_visual_bounds()
+
+    frame_values = (shape.x, shape.y, shape.width, shape.height)
+    visual_values = (visual_bounds.x, visual_bounds.y, visual_bounds.width, visual_bounds.height)
+
+    print(f"Frame bounds (x, y, width, height): {frame_values}")
+    print(f"Visual bounds (x, y, width, height): {visual_values}")
+```
+
+The same rectangle can be used to align nearby shapes to its `left`, `right`, `top`, or `bottom` edge; reserve enough space in a generated layout; or detect content outside a permitted region. Visual bounds are especially useful for SmartArt, text boxes, arrows, pictures, rotated shapes, and group shapes, where the stored frame may not represent the full rendered result.
+
+Use [Shape.get_visual_bounds](https://reference.aspose.com/slides/python-net/aspose.slides/shape/get_visual_bounds/) when you need coordinates for layout or validation and do not need a bitmap. Use [Shape.get_image](https://reference.aspose.com/slides/python-net/aspose.slides/shape/get_image/) when you need to render the shape. With [ShapeThumbnailBounds](https://reference.aspose.com/slides/python-net/aspose.slides/shapethumbnailbounds/), `ShapeThumbnailBounds.SHAPE` sizes the image from the shape bounds, including outline settings, while `ShapeThumbnailBounds.APPEARANCE` sizes it from the shape's appearance and restricts the result to the slide bounds. In contrast, `Shape.get_visual_bounds` returns only the calculated rectangle and does not clip it to the slide.
+
 ## **FAQ**
 
-### What image formats can be used when saving shape thumbnails?
+**What image formats can be used when saving shape thumbnails?**
 
 [PNG, JPEG, BMP, GIF, TIFF](https://reference.aspose.com/slides/python-net/aspose.slides/imageformat/), and others. Shapes can also be [exported as vector SVG](https://reference.aspose.com/slides/python-net/aspose.slides/shape/write_as_svg/) by saving the shape’s content as SVG.
 
-### What is the difference between SHAPE and APPEARANCE bounds when rendering a thumbnail?
+**What is the difference between SHAPE and APPEARANCE bounds when rendering a thumbnail?**
 
 `SHAPE` uses the shape’s geometry; `APPEARANCE` takes [visual effects](/slides/python-net/shape-effect/) (shadows, glows, etc.) into account.
 
-### What happens if a shape is marked as hidden? Will it still render as a thumbnail?
+**What happens if a shape is marked as hidden? Will it still render as a thumbnail?**
 
 A hidden shape remains part of the model and can be rendered; the hidden flag affects slideshow display but does not prevent generating the shape’s image.
 
-### Are group shapes, charts, SmartArt, and other complex objects supported?
+**Are group shapes, charts, SmartArt, and other complex objects supported?**
 
 Yes. Any object represented as [Shape](https://reference.aspose.com/slides/python-net/aspose.slides/shape/) (including [GroupShape](https://reference.aspose.com/slides/python-net/aspose.slides/groupshape/), [Chart](https://reference.aspose.com/slides/python-net/aspose.slides.charts/chart/), and [SmartArt](https://reference.aspose.com/slides/python-net/aspose.slides.smartart/smartart/)) can be saved as a thumbnail or as SVG.
 
-### Do system-installed fonts affect the quality of thumbnails for text shapes?
+**Do system-installed fonts affect the quality of thumbnails for text shapes?**
 
 Yes. You should [provide the required fonts](/slides/python-net/custom-font/) (or [configure font substitutions](/slides/python-net/font-substitution/)) to avoid unwanted fallbacks and text reflow.


### PR DESCRIPTION
Added keywords and the section "Get the Actual Visual Bounds of a Shape" (.NET, Android via Java, C++, Java, Node.js via Java, PHP via Java, and Python via .NET). 
Formatted the FAQ sections.