### PR TITLE
SLIDESDOC-816 Add documentation for loading only document properties from encrypted presentations

### DIFF
--- a/en/androidjava/developer-guide/presentation-security/password-protected-presentation/_index.md
+++ b/en/androidjava/developer-guide/presentation-security/password-protected-presentation/_index.md
@@ -133,7 +133,6 @@ try {
 } finally {
     if (presentation != null) presentation.dispose();
 }
-}
 ```
 
 ## **Remove Encryption from a Presentation**
@@ -170,23 +169,58 @@ try {
 }
 ```
 
-## **Get the Properties of an Encrypted Presentation**
+## **Get Properties of an Encrypted Presentation**
 
-Typically, users struggle to get the document properties of an encrypted or password-protected presentation. Aspose.Slides, however, offers a mechanism that allows you to password protect a presentation while retaining the means for users to access the properties of that presentation.
+Typically, users struggle to retrieve the document properties of an encrypted or password-protected presentation. However, Aspose.Slides offers a mechanism that allows you to password protect a presentation while still retaining the ability for users to access its properties.
 
-**Note** that when Aspose.Slides encrypts a presentation, the presentation’s document properties get password protected too by default. But if you need to make the presentation’s properties accessible (even after the presentation gets encrypted), Aspose.Slides allows you to do precisely that. 
+**Note:** By default, when Aspose.Slides encrypts a presentation, the presentation’s document properties are also password protected. If you need to make the document properties accessible even after encryption, Aspose.Slides allows you to do precisely that.
 
-If you want users to retain the ability to access the properties of a presentation you encrypted, you can set the [encryptDocumentProperties](https://reference.aspose.com/slides/androidjava/com.aspose.slides/IProtectionManager#getEncryptDocumentProperties--) property to `true`. This sample code shows you how to encrypt a presentation while providing the means for users to access its document properties:
+If you want users to retain the ability to access the properties of an encrypted presentation, pass `false` to [IProtectionManager.setEncryptDocumentProperties](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iprotectionmanager/#setEncryptDocumentProperties-boolean-). This sample code shows you how to encrypt a presentation while still providing users access to its document properties:
 
 ```java
 Presentation presentation = new Presentation("pres.pptx");
 try {
-    presentation.getProtectionManager().setEncryptDocumentProperties(true);
+    presentation.getProtectionManager().setEncryptDocumentProperties(false);
     presentation.getProtectionManager().encrypt("123123");
+    presentation.save("encrypted-pres.pptx", SaveFormat.Pptx);
 } finally {
     if (presentation != null) presentation.dispose();
 }
 ```
+
+## **Load Only Document Properties from an Encrypted Presentation**
+
+To inspect the metadata of an encrypted presentation without loading its slides or other content, create a [LoadOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/loadoptions/) object and pass `true` to [setOnlyLoadDocumentProperties](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iloadoptions/#setOnlyLoadDocumentProperties-boolean-). In this mode, Aspose.Slides ignores the password and loads only the document properties that are publicly accessible.
+
+The following code example reads built-in and custom document properties through [IPresentation.getDocumentProperties](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ipresentation/#getDocumentProperties--):
+
+```java
+LoadOptions loadOptions = new LoadOptions();
+loadOptions.setOnlyLoadDocumentProperties(true);
+
+Presentation presentation = new Presentation("encrypted-pres.pptx", loadOptions);
+try {
+    IDocumentProperties documentProperties = presentation.getDocumentProperties();
+
+    // Read built-in document properties.
+    System.out.println("Title: " + documentProperties.getTitle());
+    System.out.println("Author: " + documentProperties.getAuthor());
+
+    // Read custom document properties.
+    int customPropertyCount = documentProperties.getCountOfCustomProperties();
+
+    for (int propertyIndex = 0; propertyIndex < customPropertyCount; propertyIndex++) {
+        String propertyName = documentProperties.getCustomPropertyName(propertyIndex);
+        Object propertyValue = documentProperties.get_Item(propertyName);
+
+        System.out.println(propertyName + ": " + propertyValue);
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
+This workflow works only when the document properties were left unencrypted (public) when the presentation was encrypted. If the document properties are encrypted, passing `true` to `loadOptions.setOnlyLoadDocumentProperties` causes an exception because the password is ignored in this mode. To access encrypted document properties or load the complete presentation, including its slides and other content, provide the correct password through [ILoadOptions.setPassword](https://reference.aspose.com/slides/androidjava/com.aspose.slides/iloadoptions/#setPassword-java.lang.String-).
 
 ## **Check Whether a Presentation Is Password Protected**
 
@@ -253,14 +287,14 @@ It returns `true` if the presentation has been encrypted with the specified pass
 
 ## **FAQ**
 
-### What encryption methods are supported by Aspose.Slides?
+**What encryption methods are supported by Aspose.Slides?**
 
 Aspose.Slides supports modern encryption methods, including AES-based algorithms, ensuring a high level of data security for your presentations.
 
-### What happens if an incorrect password is entered when attempting to open a presentation?
+**What happens if an incorrect password is entered when attempting to open a presentation?**
 
 An exception is thrown if an incorrect password is used, alerting you that access to the presentation is denied. This helps prevent unauthorized access and protects the presentation content.
 
-### Are there any performance implications when working with password-protected presentations?
+**Are there any performance implications when working with password-protected presentations?**
 
 The encryption and decryption process may introduce a slight overhead during opening and saving operations. In most cases, this performance impact is minimal and does not significantly affect the overall processing time of your presentation tasks.

--- a/en/cpp/developer-guide/presentation-security/password-protected-presentation/_index.md
+++ b/en/cpp/developer-guide/presentation-security/password-protected-presentation/_index.md
@@ -173,20 +173,58 @@ presentation->get_ProtectionManager()->RemoveWriteProtection();
 presentation->Save(u"write-protection-removed.pptx", SaveFormat::Pptx);
 ```
 
-## **Get the Properties of an Encrypted Presentation**
+## **Get Properties of an Encrypted Presentation**
 
-Typically, users struggle to get the document properties of an encrypted or password-protected presentation. Aspose.Slides, however, offers a mechanism that allows you to password protect a presentation while retaining the means for users to access the properties of that presentation.
+Typically, users struggle to retrieve the document properties of an encrypted or password-protected presentation. However, Aspose.Slides provides a mechanism that allows you to password protect a presentation while still enabling access to its document properties.
 
-**Note** that when Aspose.Slides encrypts a presentation, the presentation’s document properties get password protected too by default. But if you need to make the presentation’s properties accessible (even after the presentation gets encrypted), Aspose.Slides allows you to do precisely that. 
+**Note:** By default, when Aspose.Slides encrypts a presentation, the presentation’s document properties are also password protected. If you need to make the document properties accessible even after encryption, Aspose.Slides allows you to do precisely that.
 
-If you want users to retain the ability to access the properties of a presentation you encrypted, you can pass `true` to the [set_EncryptDocumentProperties()](https://reference.aspose.com/slides/cpp/class/aspose.slides.protection_manager#a67e041b432552969d106f72fa7fe5a1d) method. This sample code shows you how to encrypt a presentation while providing the means for users to access its document properties:
+If you want users to retain the ability to access the properties of an encrypted presentation, pass `false` to the `set_EncryptDocumentProperties` method of [IProtectionManager](https://reference.aspose.com/slides/cpp/aspose.slides/iprotectionmanager/). This sample code shows you how to encrypt a presentation while still providing users access to its document properties:
 
 ``` cpp
 auto presentation = System::MakeObject<Presentation>(u"pres.pptx");
 
-presentation->get_ProtectionManager()->set_EncryptDocumentProperties(true);
+presentation->get_ProtectionManager()->set_EncryptDocumentProperties(false);
 presentation->get_ProtectionManager()->Encrypt(u"123123");
+presentation->Save(u"encrypted-pres.pptx", SaveFormat::Pptx);
+presentation->Dispose();
 ```
+
+## **Load Only Document Properties from an Encrypted Presentation**
+
+To inspect the metadata of an encrypted presentation without loading its slides or other content, create a [LoadOptions](https://reference.aspose.com/slides/cpp/aspose.slides/loadoptions/) object and set [set_OnlyLoadDocumentProperties](https://reference.aspose.com/slides/cpp/aspose.slides/loadoptions/set_onlyloaddocumentproperties/) to `true`. In this mode, Aspose.Slides ignores the password and loads only the document properties that are publicly accessible.
+
+The following code example reads built-in and custom document properties through [IPresentation::get_DocumentProperties](https://reference.aspose.com/slides/cpp/aspose.slides/ipresentation/get_documentproperties/):
+
+``` cpp
+auto loadOptions = MakeObject<LoadOptions>();
+loadOptions->set_OnlyLoadDocumentProperties(true);
+
+auto presentation = MakeObject<Presentation>(u"encrypted-pres.pptx", loadOptions);
+auto documentProperties = presentation->get_DocumentProperties();
+
+// Read built-in document properties.
+auto title = documentProperties->get_Title();
+auto author = documentProperties->get_Author();
+Console::WriteLine(String(u"Title: ") + title);
+Console::WriteLine(String(u"Author: ") + author);
+
+// Read custom document properties.
+int customPropertyCount = documentProperties->get_CountOfCustomProperties();
+
+for (int propertyIndex = 0; propertyIndex < customPropertyCount; propertyIndex++)
+{
+    auto propertyName = documentProperties->GetCustomPropertyName(propertyIndex);
+    auto propertyValue = documentProperties->idx_get(propertyName);
+    auto propertyValueText = ObjectExt::ToString(propertyValue);
+
+    Console::WriteLine(propertyName + u": " + propertyValueText);
+}
+
+presentation->Dispose();
+```
+
+This workflow works only when the document properties were left unencrypted (public) when the presentation was encrypted. If the document properties are encrypted, setting `LoadOptions::set_OnlyLoadDocumentProperties` to `true` causes an exception because the password is ignored in this mode. To access encrypted document properties or load the complete presentation, including its slides and other content, provide the correct password with `LoadOptions::set_Password` in [LoadOptions](https://reference.aspose.com/slides/cpp/aspose.slides/loadoptions/).
 
 ## **Check Whether a Presentation Is Password Protected**
 
@@ -245,14 +283,14 @@ It returns `true` if the presentation has been encrypted with the specified pass
 
 ## **FAQ**
 
-### What encryption methods are supported by Aspose.Slides?
+**What encryption methods are supported by Aspose.Slides?**
 
 Aspose.Slides supports modern encryption methods, including AES-based algorithms, ensuring a high level of data security for your presentations.
 
-### What happens if an incorrect password is entered when attempting to open a presentation?
+**What happens if an incorrect password is entered when attempting to open a presentation?**
 
 An exception is thrown if an incorrect password is used, alerting you that access to the presentation is denied. This helps prevent unauthorized access and protects the presentation content.
 
-### Are there any performance implications when working with password-protected presentations?
+**Are there any performance implications when working with password-protected presentations?**
 
 The encryption and decryption process may introduce a slight overhead during opening and saving operations. In most cases, this performance impact is minimal and does not significantly affect the overall processing time of your presentation tasks.

--- a/en/java/developer-guide/presentation-security/password-protected-presentation/_index.md
+++ b/en/java/developer-guide/presentation-security/password-protected-presentation/_index.md
@@ -132,7 +132,6 @@ try {
 } finally {
     if (presentation != null) presentation.dispose();
 }
-}
 ```
 
 ## **Remove Encryption from a Presentation**
@@ -169,23 +168,58 @@ try {
 }
 ```
 
-## **Get the Properties of an Encrypted Presentation**
+## **Get Properties of an Encrypted Presentation**
 
-Typically, users struggle to get the document properties of an encrypted or password-protected presentation. Aspose.Slides, however, offers a mechanism that allows you to password protect a presentation while retaining the means for users to access the properties of that presentation.
+Typically, users struggle to retrieve the document properties of an encrypted or password-protected presentation. However, Aspose.Slides offers a mechanism that allows you to password protect a presentation while still retaining the ability for users to access its properties.
 
-**Note** that when Aspose.Slides encrypts a presentation, the presentation’s document properties get password protected too by default. But if you need to make the presentation’s properties accessible (even after the presentation gets encrypted), Aspose.Slides allows you to do precisely that. 
+**Note:** By default, when Aspose.Slides encrypts a presentation, the presentation’s document properties are also password protected. If you need to make the document properties accessible even after encryption, Aspose.Slides allows you to do precisely that.
 
-If you want users to retain the ability to access the properties of a presentation you encrypted, you can set the [encryptDocumentProperties](https://reference.aspose.com/slides/java/com.aspose.slides/IProtectionManager#getEncryptDocumentProperties--) property to `true`. This sample code shows you how to encrypt a presentation while providing the means for users to access its document properties:
+If you want users to retain the ability to access the properties of an encrypted presentation, pass `false` to [IProtectionManager.setEncryptDocumentProperties](https://reference.aspose.com/slides/java/com.aspose.slides/iprotectionmanager/#setEncryptDocumentProperties-boolean-). This sample code shows you how to encrypt a presentation while still providing users access to its document properties:
 
 ```java
 Presentation presentation = new Presentation("pres.pptx");
 try {
-    presentation.getProtectionManager().setEncryptDocumentProperties(true);
+    presentation.getProtectionManager().setEncryptDocumentProperties(false);
     presentation.getProtectionManager().encrypt("123123");
+    presentation.save("encrypted-pres.pptx", SaveFormat.Pptx);
 } finally {
     if (presentation != null) presentation.dispose();
 }
 ```
+
+## **Load Only Document Properties from an Encrypted Presentation**
+
+To inspect the metadata of an encrypted presentation without loading its slides or other content, create a [LoadOptions](https://reference.aspose.com/slides/java/com.aspose.slides/loadoptions/) object and pass `true` to [setOnlyLoadDocumentProperties](https://reference.aspose.com/slides/java/com.aspose.slides/iloadoptions/#setOnlyLoadDocumentProperties-boolean-). In this mode, Aspose.Slides ignores the password and loads only the document properties that are publicly accessible.
+
+The following code example reads built-in and custom document properties through [IPresentation.getDocumentProperties](https://reference.aspose.com/slides/java/com.aspose.slides/ipresentation/#getDocumentProperties--):
+
+```java
+LoadOptions loadOptions = new LoadOptions();
+loadOptions.setOnlyLoadDocumentProperties(true);
+
+Presentation presentation = new Presentation("encrypted-pres.pptx", loadOptions);
+try {
+    IDocumentProperties documentProperties = presentation.getDocumentProperties();
+
+    // Read built-in document properties.
+    System.out.println("Title: " + documentProperties.getTitle());
+    System.out.println("Author: " + documentProperties.getAuthor());
+
+    // Read custom document properties.
+    int customPropertyCount = documentProperties.getCountOfCustomProperties();
+
+    for (int propertyIndex = 0; propertyIndex < customPropertyCount; propertyIndex++) {
+        String propertyName = documentProperties.getCustomPropertyName(propertyIndex);
+        Object propertyValue = documentProperties.get_Item(propertyName);
+
+        System.out.println(propertyName + ": " + propertyValue);
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
+This workflow works only when the document properties were left unencrypted (public) when the presentation was encrypted. If the document properties are encrypted, passing `true` to `loadOptions.setOnlyLoadDocumentProperties` causes an exception because the password is ignored in this mode. To access encrypted document properties or load the complete presentation, including its slides and other content, provide the correct password through [ILoadOptions.setPassword](https://reference.aspose.com/slides/java/com.aspose.slides/iloadoptions/#setPassword-java.lang.String-).
 
 ## **Check Whether a Presentation Is Password Protected**
 
@@ -252,14 +286,14 @@ It returns `true` if the presentation has been encrypted with the specified pass
 
 ## **FAQ**
 
-### What encryption methods are supported by Aspose.Slides?
+**What encryption methods are supported by Aspose.Slides?**
 
 Aspose.Slides supports modern encryption methods, including AES-based algorithms, ensuring a high level of data security for your presentations.
 
-### What happens if an incorrect password is entered when attempting to open a presentation?
+**What happens if an incorrect password is entered when attempting to open a presentation?**
 
 An exception is thrown if an incorrect password is used, alerting you that access to the presentation is denied. This helps prevent unauthorized access and protects the presentation content.
 
-### Are there any performance implications when working with password-protected presentations?
+**Are there any performance implications when working with password-protected presentations?**
 
 The encryption and decryption process may introduce a slight overhead during opening and saving operations. In most cases, this performance impact is minimal and does not significantly affect the overall processing time of your presentation tasks.

--- a/en/net/developer-guide/presentation-security/password-protected-presentation/_index.md
+++ b/en/net/developer-guide/presentation-security/password-protected-presentation/_index.md
@@ -163,15 +163,48 @@ Typically, users struggle to retrieve the document properties of an encrypted or
 
 **Note:** By default, when Aspose.Slides encrypts a presentation, the presentation’s document properties are also password protected. If you need to make the document properties accessible even after encryption, Aspose.Slides allows you to do precisely that.
 
-If you want users to retain the ability to access the properties of an encrypted presentation, you can set the [EncryptDocumentProperties](https://reference.aspose.com/slides/net/aspose.slides/protectionmanager/properties/encryptdocumentproperties) property to `true`. This sample code shows you how to encrypt a presentation while still providing users access to its document properties:
+If you want users to retain the ability to access the properties of an encrypted presentation, set the `EncryptDocumentProperties` property of [IProtectionManager](https://reference.aspose.com/slides/net/aspose.slides/iprotectionmanager/) to `false`. This sample code shows you how to encrypt a presentation while still providing users access to its document properties:
 
 ```c#
-using (Presentation presentation = new Presentation("pres.pptx"))
+using var presentation = new Presentation("pres.pptx");
+
+presentation.ProtectionManager.EncryptDocumentProperties = false;
+presentation.ProtectionManager.Encrypt("123123");
+presentation.Save("encrypted-pres.pptx", SaveFormat.Pptx);
+```
+
+## **Load Only Document Properties from an Encrypted Presentation**
+
+To inspect the metadata of an encrypted presentation without loading its slides or other content, create a [LoadOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/) object and set [OnlyLoadDocumentProperties](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/onlyloaddocumentproperties/) to `true`. In this mode, Aspose.Slides ignores the password and loads only the document properties that are publicly accessible.
+
+The following code example reads built-in and custom document properties through [IPresentation.DocumentProperties](https://reference.aspose.com/slides/net/aspose.slides/ipresentation/documentproperties/):
+
+```c#
+var loadOptions = new LoadOptions
 {
-    presentation.ProtectionManager.EncryptDocumentProperties = true;
-    presentation.ProtectionManager.Encrypt("123123");
+    OnlyLoadDocumentProperties = true
+};
+
+using var presentation = new Presentation("encrypted-pres.pptx", loadOptions);
+var documentProperties = presentation.DocumentProperties;
+
+// Read built-in document properties.
+Console.WriteLine("Title: " + documentProperties.Title);
+Console.WriteLine("Author: " + documentProperties.Author);
+
+// Read custom document properties.
+var customPropertyCount = documentProperties.CountOfCustomProperties;
+
+for (var propertyIndex = 0; propertyIndex < customPropertyCount; propertyIndex++)
+{
+    var propertyName = documentProperties.GetCustomPropertyName(propertyIndex);
+    var propertyValue = documentProperties[propertyName];
+
+    Console.WriteLine(propertyName + ": " + propertyValue);
 }
 ```
+
+This workflow works only when the document properties were left unencrypted (public) when the presentation was encrypted. If the document properties are encrypted, setting `OnlyLoadDocumentProperties` to `true` causes an exception because the password is ignored in this mode. To access encrypted document properties or load the complete presentation, including its slides and other content, provide the correct `Password` value in [LoadOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/).
 
 ## **Check Whether a Presentation Is Password Protected**
 
@@ -244,14 +277,14 @@ It returns `true` if the presentation has been encrypted with the specified pass
 
 ## **FAQ**
 
-### What encryption methods are supported by Aspose.Slides?
+**What encryption methods are supported by Aspose.Slides?**
 
 Aspose.Slides supports modern encryption methods, including AES-based algorithms, ensuring a high level of data security for your presentations.
 
-### What happens if an incorrect password is entered when attempting to open a presentation?
+**What happens if an incorrect password is entered when attempting to open a presentation?**
 
 An exception is thrown if an incorrect password is used, alerting you that access to the presentation is denied. This helps prevent unauthorized access and protects the presentation content.
 
-### Are there any performance implications when working with password-protected presentations?
+**Are there any performance implications when working with password-protected presentations?**
 
 The encryption and decryption process may introduce a slight overhead during opening and saving operations. In most cases, this performance impact is minimal and does not significantly affect the overall processing time of your presentation tasks.

--- a/en/nodejs-java/developer-guide/presentation-security/password-protected-presentation/_index.md
+++ b/en/nodejs-java/developer-guide/presentation-security/password-protected-presentation/_index.md
@@ -197,25 +197,60 @@ try {
 }
 ```
 
-## **Getting the Properties of an Encrypted Presentation**
+## **Get Properties of an Encrypted Presentation**
 
-Typically, users struggle to get the document properties of an encrypted or password-protected presentation. Aspose.Slides, however, offers a mechanism that allows you to password protect a presentation while retaining the means for users to access the properties of that presentation.
+Typically, users struggle to retrieve the document properties of an encrypted or password-protected presentation. However, Aspose.Slides offers a mechanism that allows you to password protect a presentation while still retaining the ability for users to access its properties.
 
-**Note** that when Aspose.Slides encrypts a presentation, the presentation’s document properties get password protected too by default. But if you need to make the presentation’s properties accessible (even after the presentation gets encrypted), Aspose.Slides allows you to do precisely that. 
+**Note:** By default, when Aspose.Slides encrypts a presentation, the presentation’s document properties are also password protected. If you need to make the document properties accessible even after encryption, Aspose.Slides allows you to do precisely that.
 
-If you want users to retain the ability to access the properties of a presentation you encrypted, you can set the [encryptDocumentProperties](https://reference.aspose.com/slides/nodejs-java/aspose.slides/ProtectionManager#getEncryptDocumentProperties--) property to `true`. This sample code shows you how to encrypt a presentation while providing the means for users to access its document properties:
+If you want users to retain the ability to access the properties of an encrypted presentation, pass `false` to `setEncryptDocumentProperties` on [ProtectionManager](https://reference.aspose.com/slides/nodejs-java/aspose.slides/protectionmanager/). This sample code shows you how to encrypt a presentation while still providing users access to its document properties:
 
 ```javascript
-var presentation = new aspose.slides.Presentation("pres.pptx");
+const presentation = new aspose.slides.Presentation("pres.pptx");
 try {
-    presentation.getProtectionManager().setEncryptDocumentProperties(true);
+    presentation.getProtectionManager().setEncryptDocumentProperties(false);
     presentation.getProtectionManager().encrypt("123123");
+    presentation.save("encrypted-pres.pptx", aspose.slides.SaveFormat.Pptx);
 } finally {
     if (presentation != null) {
         presentation.dispose();
     }
 }
 ```
+
+## **Load Only Document Properties from an Encrypted Presentation**
+
+To inspect the metadata of an encrypted presentation without loading its slides or other content, create a [LoadOptions](https://reference.aspose.com/slides/nodejs-java/aspose.slides/loadoptions/) object and pass `true` to `setOnlyLoadDocumentProperties`. In this mode, Aspose.Slides ignores the password and loads only the document properties that are publicly accessible.
+
+The following code example reads built-in and custom document properties through `getDocumentProperties` on [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/):
+
+```javascript
+const loadOptions = new aspose.slides.LoadOptions();
+loadOptions.setOnlyLoadDocumentProperties(true);
+
+const presentation = new aspose.slides.Presentation("encrypted-pres.pptx", loadOptions);
+try {
+    const documentProperties = presentation.getDocumentProperties();
+
+    // Read built-in document properties.
+    console.log("Title: " + documentProperties.getTitle());
+    console.log("Author: " + documentProperties.getAuthor());
+
+    // Read custom document properties.
+    const customPropertyCount = documentProperties.getCountOfCustomProperties();
+
+    for (let propertyIndex = 0; propertyIndex < customPropertyCount; propertyIndex++) {
+        const propertyName = documentProperties.getCustomPropertyName(propertyIndex);
+        const propertyValue = documentProperties.get_Item(propertyName);
+
+        console.log(propertyName + ": " + propertyValue);
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
+This workflow works only when the document properties were left unencrypted (public) when the presentation was encrypted. If the document properties are encrypted, passing `true` to `LoadOptions.setOnlyLoadDocumentProperties` causes an exception because the password is ignored in this mode. To access encrypted document properties or load the complete presentation, including its slides and other content, provide the correct password through `LoadOptions.setPassword` on [LoadOptions](https://reference.aspose.com/slides/nodejs-java/aspose.slides/loadoptions/).
 
 ## **Checking whether a Presentation is Password Protected Before Loading it**
 
@@ -288,14 +323,14 @@ It returns `true` if the presentation has been encrypted with the specified pass
 
 ## **FAQ**
 
-### What encryption methods are supported by Aspose.Slides?
+**What encryption methods are supported by Aspose.Slides?**
 
 Aspose.Slides supports modern encryption methods, including AES-based algorithms, ensuring a high level of data security for your presentations.
 
-### What happens if an incorrect password is entered when attempting to open a presentation?
+**What happens if an incorrect password is entered when attempting to open a presentation?**
 
 An exception is thrown if an incorrect password is used, alerting you that access to the presentation is denied. This helps prevent unauthorized access and protects the presentation content.
 
-### Are there any performance implications when working with password-protected presentations?
+**Are there any performance implications when working with password-protected presentations?**
 
 The encryption and decryption process may introduce a slight overhead during opening and saving operations. In most cases, this performance impact is minimal and does not significantly affect the overall processing time of your presentation tasks.

--- a/en/php-java/developer-guide/presentation-security/password-protected-presentation/_index.md
+++ b/en/php-java/developer-guide/presentation-security/password-protected-presentation/_index.md
@@ -196,25 +196,60 @@ You can remove the write protection from a presentation by using the [removeWrit
   }
 ```
 
-## **Get the Properties of an Encrypted Presentation**
+## **Get Properties of an Encrypted Presentation**
 
-Typically, users struggle to get the document properties of an encrypted or password-protected presentation. Aspose.Slides, however, offers a mechanism that allows you to password protect a presentation while retaining the means for users to access the properties of that presentation.
+Typically, users struggle to retrieve the document properties of an encrypted or password-protected presentation. However, Aspose.Slides offers a mechanism that allows you to password protect a presentation while still retaining the ability for users to access its properties.
 
-**Note** that when Aspose.Slides encrypts a presentation, the presentation’s document properties get password protected too by default. But if you need to make the presentation’s properties accessible (even after the presentation gets encrypted), Aspose.Slides allows you to do precisely that. 
+**Note:** By default, when Aspose.Slides encrypts a presentation, the presentation’s document properties are also password protected. If you need to make the document properties accessible even after encryption, Aspose.Slides allows you to do precisely that.
 
-If you want users to retain the ability to access the properties of a presentation you encrypted, you can use the [encryptDocumentProperties](https://reference.aspose.com/slides/php-java/aspose.slides/protectionmanager/#getEncryptDocumentProperties) method with `true` value. This sample code shows you how to encrypt a presentation while providing the means for users to access its document properties:
+If you want users to retain the ability to access the properties of an encrypted presentation, pass `false` to [ProtectionManager::setEncryptDocumentProperties](https://reference.aspose.com/slides/php-java/aspose.slides/protectionmanager/#setEncryptDocumentProperties). This sample code shows you how to encrypt a presentation while still providing users access to its document properties:
 
 ```php
   $presentation = new Presentation("pres.pptx");
   try {
-    $presentation->getProtectionManager()->setEncryptDocumentProperties(true);
+    $presentation->getProtectionManager()->setEncryptDocumentProperties(false);
     $presentation->getProtectionManager()->encrypt("123123");
+    $presentation->save("encrypted-pres.pptx", SaveFormat::Pptx);
   } finally {
     if (!java_is_null($presentation)) {
       $presentation->dispose();
     }
   }
 ```
+
+## **Load Only Document Properties from an Encrypted Presentation**
+
+To inspect the metadata of an encrypted presentation without loading its slides or other content, create a [LoadOptions](https://reference.aspose.com/slides/php-java/aspose.slides/loadoptions/) object and pass `true` to [setOnlyLoadDocumentProperties](https://reference.aspose.com/slides/php-java/aspose.slides/loadoptions/#setOnlyLoadDocumentProperties). In this mode, Aspose.Slides ignores the password and loads only the document properties that are publicly accessible.
+
+The following code example reads built-in and custom document properties through [Presentation::getDocumentProperties](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/#getDocumentProperties):
+
+```php
+$loadOptions = new LoadOptions();
+$loadOptions->setOnlyLoadDocumentProperties(true);
+
+$presentation = new Presentation("encrypted-pres.pptx", $loadOptions);
+try {
+    $documentProperties = $presentation->getDocumentProperties();
+
+    # Read built-in document properties.
+    echo("Title: " . $documentProperties->getTitle() . "\n");
+    echo("Author: " . $documentProperties->getAuthor() . "\n");
+
+    # Read custom document properties.
+    $customPropertyCount = java_values($documentProperties->getCountOfCustomProperties());
+
+    for ($propertyIndex = 0; $propertyIndex < $customPropertyCount; $propertyIndex++) {
+        $propertyName = $documentProperties->getCustomPropertyName($propertyIndex);
+        $propertyValue = java_values($documentProperties->get_Item($propertyName));
+
+        echo($propertyName . ": " . $propertyValue . "\n");
+    }
+} finally {
+    $presentation->dispose();
+}
+```
+
+This workflow works only when the document properties were left unencrypted (public) when the presentation was encrypted. If the document properties are encrypted, passing `true` to [LoadOptions::setOnlyLoadDocumentProperties](https://reference.aspose.com/slides/php-java/aspose.slides/loadoptions/#setOnlyLoadDocumentProperties) causes an exception because the password is ignored in this mode. To access encrypted document properties or load the complete presentation, including its slides and other content, provide the correct password through [LoadOptions::setPassword](https://reference.aspose.com/slides/php-java/aspose.slides/loadoptions/#setPassword).
 
 ## **Check Whether a Presentation Is Password Protected**
 
@@ -288,14 +323,14 @@ It returns `true` if the presentation has been encrypted with the specified pass
 
 ## **FAQ**
 
-### What encryption methods are supported by Aspose.Slides?
+**What encryption methods are supported by Aspose.Slides?**
 
 Aspose.Slides supports modern encryption methods, including AES-based algorithms, ensuring a high level of data security for your presentations.
 
-### What happens if an incorrect password is entered when attempting to open a presentation?
+**What happens if an incorrect password is entered when attempting to open a presentation?**
 
 An exception is thrown if an incorrect password is used, alerting you that access to the presentation is denied. This helps prevent unauthorized access and protects the presentation content.
 
-### Are there any performance implications when working with password-protected presentations?
+**Are there any performance implications when working with password-protected presentations?**
 
 The encryption and decryption process may introduce a slight overhead during opening and saving operations. In most cases, this performance impact is minimal and does not significantly affect the overall processing time of your presentation tasks.

--- a/en/python-net/developer-guide/presentation-security/password-protected-presentation/_index.md
+++ b/en/python-net/developer-guide/presentation-security/password-protected-presentation/_index.md
@@ -174,21 +174,51 @@ with slides.Presentation("write-protected-pres.pptx") as pres:
     pres.save("write-protection-removed.pptx", slides.export.SaveFormat.PPTX)
 ```
 
-## **Getting the Properties of an Encrypted Presentation**
+## **Get Properties of an Encrypted Presentation**
 
-Typically, users struggle to get the document properties of an encrypted or password-protected presentation. Aspose.Slides, however, offers a mechanism that allows you to password protect a presentation while retaining the means for users to access the properties of that presentation.
+Typically, users struggle to retrieve the document properties of an encrypted or password-protected presentation. However, Aspose.Slides offers a mechanism that allows you to password protect a presentation while still retaining the ability for users to access its properties.
 
-**Note** that when Aspose.Slides encrypts a presentation, the presentation’s document properties get password protected too by default. But if you need to make the presentation’s properties accessible (even after the presentation gets encrypted), Aspose.Slides allows you to do precisely that. 
+**Note:** By default, when Aspose.Slides encrypts a presentation, the presentation’s document properties are also password protected. If you need to make the document properties accessible even after encryption, Aspose.Slides allows you to do precisely that.
 
-If you want users to retain the ability to access the properties of a presentation you encrypted, you can set the [EncryptDocumentProperties](https://reference.aspose.com/slides/python-net/aspose.slides/protectionmanager/) property to `True`. This sample code shows you how to encrypt a presentation while providing the means for users to access its document properties:
+If you want users to retain the ability to access the properties of an encrypted presentation, set the `encrypt_document_properties` property of [ProtectionManager](https://reference.aspose.com/slides/python-net/aspose.slides/protectionmanager/) to `False`. This sample code shows you how to encrypt a presentation while still providing users access to its document properties:
 
 ```py
 import aspose.slides as slides
 
-with slides.Presentation() as pres:
-    pres.protection_manager.encrypt_document_properties = True
-    pres.protection_manager.encrypt("123123")
+with slides.Presentation("pres.pptx") as presentation:
+    presentation.protection_manager.encrypt_document_properties = False
+    presentation.protection_manager.encrypt("123123")
+    presentation.save("encrypted-pres.pptx", slides.export.SaveFormat.PPTX)
 ```
+
+## **Load Only Document Properties from an Encrypted Presentation**
+
+To inspect the metadata of an encrypted presentation without loading its slides or other content, create a [LoadOptions](https://reference.aspose.com/slides/python-net/aspose.slides/loadoptions/) object and set [only_load_document_properties](https://reference.aspose.com/slides/python-net/aspose.slides/loadoptions/only_load_document_properties/) to `True`. In this mode, Aspose.Slides ignores the password and loads only the document properties that are publicly accessible.
+
+The following code example reads built-in document properties and lists custom document properties through [Presentation.document_properties](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/document_properties/):
+
+```py
+import aspose.slides as slides
+
+load_options = slides.LoadOptions()
+load_options.only_load_document_properties = True
+
+with slides.Presentation("encrypted-pres.pptx", load_options) as presentation:
+    document_properties = presentation.document_properties
+
+    # Read built-in document properties.
+    print("Title: " + document_properties.title)
+    print("Author: " + document_properties.author)
+
+    # List custom document properties.
+    custom_property_count = document_properties.count_of_custom_properties
+
+    for property_index in range(custom_property_count):
+        property_name = document_properties.get_custom_property_name(property_index)
+        print(property_name)
+```
+
+This workflow works only when the document properties were left unencrypted (public) when the presentation was encrypted. If the document properties are encrypted, setting `only_load_document_properties` to `True` causes an exception because the password is ignored in this mode. To access encrypted document properties or load the complete presentation, including its slides and other content, provide the correct `password` value in [LoadOptions](https://reference.aspose.com/slides/python-net/aspose.slides/loadoptions/).
 
 ## **Checking whether a Presentation is Password Protected Before Loading it**
 
@@ -252,14 +282,14 @@ It returns `True` if the presentation has been encrypted with the specified pass
 
 ## **FAQ**
 
-### What encryption methods are supported by Aspose.Slides?
+**What encryption methods are supported by Aspose.Slides?**
 
 Aspose.Slides supports modern encryption methods, including AES-based algorithms, ensuring a high level of data security for your presentations.
 
-### What happens if an incorrect password is entered when attempting to open a presentation?
+**What happens if an incorrect password is entered when attempting to open a presentation?**
 
 An exception is thrown if an incorrect password is used, alerting you that access to the presentation is denied. This helps prevent unauthorized access and protects the presentation content.
 
-### Are there any performance implications when working with password-protected presentations?
+**Are there any performance implications when working with password-protected presentations?**
 
 The encryption and decryption process may introduce a slight overhead during opening and saving operations. In most cases, this performance impact is minimal and does not significantly affect the overall processing time of your presentation tasks.


### PR DESCRIPTION
Added the section "Load Only Document Properties from an Encrypted Presentation" (.NET, Android via Java, C++, Java, Node.js via Java, PHP via Java, and Python via .NET). 
Formatted the FAQ sections.
Made minor fixes.