### PR TITLE
SLIDESDOC-815 Add documentation for recovering chart workbooks from chart cache

### DIFF
--- a/en/androidjava/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
+++ b/en/androidjava/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
@@ -13,6 +13,8 @@ keywords:
 - data source
 - external workbook
 - external data
+- chart cache
+- workbook recovery
 - PowerPoint
 - presentation
 - Android
@@ -289,28 +291,54 @@ try {
 }
 ```
 
+### **Recover a Workbook from the Chart Cache**
+
+If a chart uses an external workbook that is missing or unavailable, Aspose.Slides can reconstruct the chart workbook from the data cached in the presentation. Create [LoadOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/loadoptions/), configure it with [SpreadsheetOptions](https://reference.aspose.com/slides/androidjava/com.aspose.slides/spreadsheetoptions/), and call [ISpreadsheetOptions.setRecoverWorkbookFromChartCache](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ispreadsheetoptions/#setRecoverWorkbookFromChartCache-boolean-) with `true` before opening the presentation.
+
+The following Java example opens a presentation whose chart references an unavailable external workbook and accesses the recovered data through [IChart.getChartData](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ichart/#getChartData--) and [IChartData.getChartDataWorkbook](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ichartdata/#getChartDataWorkbook--):
+
+```java
+SpreadsheetOptions spreadsheetOptions = new SpreadsheetOptions();
+spreadsheetOptions.setRecoverWorkbookFromChartCache(true);
+
+LoadOptions loadOptions = new LoadOptions();
+loadOptions.setSpreadsheetOptions(spreadsheetOptions);
+
+Presentation presentation = new Presentation("presentation.pptx", loadOptions);
+try {
+    IChart chart = (IChart)presentation.getSlides().get_Item(0).getShapes().get_Item(0);
+    IChartDataWorkbook recoveredWorkbook = chart.getChartData().getChartDataWorkbook();
+
+    // Read or modify the recovered workbook data here.
+} finally {
+    presentation.dispose();
+}
+```
+
+If the external workbook is unavailable and recovery is disabled, Aspose.Slides throws an exception. Enable recovery only when using the cached chart data is an acceptable fallback, because the cache may not contain changes made to the external workbook after the presentation was last updated.
+
 ## **FAQ**
 
-### Can I determine whether a specific chart is linked to an external or an embedded workbook?
+**Can I determine whether a specific chart is linked to an external or an embedded workbook?**
 
 Yes. A chart has a [data source type](https://reference.aspose.com/slides/androidjava/com.aspose.slides/chartdata/#getDataSourceType--) and a [path to an external workbook](https://reference.aspose.com/slides/androidjava/com.aspose.slides/chartdata/#getExternalWorkbookPath--); if the source is an external workbook, you can read the full path to make sure an external file is being used.
 
-### Are relative paths to external workbooks supported, and how are they stored?
+**Are relative paths to external workbooks supported, and how are they stored?**
 
 Yes. If you specify a relative path, it is automatically converted to an absolute path. This is convenient for project portability; however, be aware that the presentation will store the absolute path in the PPTX file.
 
-### Can I use workbooks located on network resources/shares?
+**Can I use workbooks located on network resources/shares?**
 
 Yes, such workbooks can be used as an external data source. However, editing remote workbooks directly from Aspose.Slides is not supported—they can only be used as a source.
 
-### Does Aspose.Slides overwrite the external XLSX when saving the presentation?
+**Does Aspose.Slides overwrite the external XLSX when saving the presentation?**
 
 No. The presentation stores a [link to the external file](https://reference.aspose.com/slides/androidjava/com.aspose.slides/chartdata/#getExternalWorkbookPath--) and uses it for reading data. The external file itself is not modified when the presentation is saved.
 
-### What should I do if the external file is password-protected?
+**What should I do if the external file is password-protected?**
 
 Aspose.Slides does not accept a password when linking. A common approach is to remove protection in advance or prepare a decrypted copy (for example, using [Aspose.Cells](/cells/androidjava/)) and link to that copy.
 
-### Can multiple charts reference the same external workbook?
+**Can multiple charts reference the same external workbook?**
 
 Yes. Each chart stores its own link. If they all point to the same file, updating that file will be reflected in each chart the next time the data is loaded.

--- a/en/cpp/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
+++ b/en/cpp/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
@@ -13,6 +13,8 @@ keywords:
 - data source
 - external workbook
 - external data
+- chart cache
+- workbook recovery
 - PowerPoint
 - presentation
 - C++
@@ -299,28 +301,55 @@ const String templatePath = u"../templates/presentation.pptx";
 	pres->Save(outPath, Aspose::Slides::Export::SaveFormat::Pptx);
 ```
 
+### **Recover a Workbook from the Chart Cache**
+
+If a chart uses an external workbook that is missing or unavailable, Aspose.Slides can reconstruct the chart workbook from the data cached in the presentation. Create [LoadOptions](https://reference.aspose.com/slides/cpp/aspose.slides/loadoptions/), configure it with [set_SpreadsheetOptions](https://reference.aspose.com/slides/cpp/aspose.slides/loadoptions/set_spreadsheetoptions/), and call [ISpreadsheetOptions::set_RecoverWorkbookFromChartCache](https://reference.aspose.com/slides/cpp/aspose.slides/ispreadsheetoptions/set_recoverworkbookfromchartcache/) with `true` before opening the presentation.
+
+The following C++ example opens a presentation whose chart references an unavailable external workbook and accesses the recovered data through [IChart::get_ChartData](https://reference.aspose.com/slides/cpp/aspose.slides.charts/ichart/get_chartdata/) and [IChartData::get_ChartDataWorkbook](https://reference.aspose.com/slides/cpp/aspose.slides.charts/ichartdata/get_chartdataworkbook/):
+
+```cpp
+auto spreadsheetOptions = MakeObject<SpreadsheetOptions>();
+spreadsheetOptions->set_RecoverWorkbookFromChartCache(true);
+
+auto loadOptions = MakeObject<LoadOptions>();
+loadOptions->set_SpreadsheetOptions(spreadsheetOptions);
+
+auto presentation = MakeObject<Presentation>(u"presentation.pptx", loadOptions);
+
+auto shape = presentation->get_Slide(0)->get_Shape(0);
+auto chart = System::ExplicitCast<IChart>(shape);
+
+auto recoveredWorkbook = chart->get_ChartData()->get_ChartDataWorkbook();
+
+// Read or modify the recovered workbook data here.
+
+presentation->Dispose();
+```
+
+If the external workbook is unavailable and recovery is disabled, Aspose.Slides throws a `System::InvalidOperationException`. Enable recovery only when using the cached chart data is an acceptable fallback, because the cache may not contain changes made to the external workbook after the presentation was last updated.
+
 ## **FAQ**
 
-### Can I determine whether a specific chart is linked to an external or an embedded workbook?
+**Can I determine whether a specific chart is linked to an external or an embedded workbook?**
 
 Yes. A chart has a [data source type](https://reference.aspose.com/slides/cpp/aspose.slides.charts/chartdata/get_datasourcetype/) and a [path to an external workbook](https://reference.aspose.com/slides/cpp/aspose.slides.charts/chartdata/get_externalworkbookpath/); if the source is an external workbook, you can read the full path to make sure an external file is being used.
 
-### Are relative paths to external workbooks supported, and how are they stored?
+**Are relative paths to external workbooks supported, and how are they stored?**
 
 Yes. If you specify a relative path, it is automatically converted to an absolute path. This is convenient for project portability; however, be aware that the presentation will store the absolute path in the PPTX file.
 
-### Can I use workbooks located on network resources/shares?
+**Can I use workbooks located on network resources/shares?**
 
 Yes, such workbooks can be used as an external data source. However, editing remote workbooks directly from Aspose.Slides is not supported—they can only be used as a source.
 
-### Does Aspose.Slides overwrite the external XLSX when saving the presentation?
+**Does Aspose.Slides overwrite the external XLSX when saving the presentation?**
 
 No. The presentation stores a [link to the external file](https://reference.aspose.com/slides/cpp/aspose.slides.charts/chartdata/get_externalworkbookpath/) and uses it for reading data. The external file itself is not modified when the presentation is saved.
 
-### What should I do if the external file is password-protected?
+**What should I do if the external file is password-protected?**
 
 Aspose.Slides does not accept a password when linking. A common approach is to remove protection in advance or prepare a decrypted copy (for example, using [Aspose.Cells](/cells/cpp/)) and link to that copy.
 
-### Can multiple charts reference the same external workbook?
+**Can multiple charts reference the same external workbook?**
 
 Yes. Each chart stores its own link. If they all point to the same file, updating that file will be reflected in each chart the next time the data is loaded.

--- a/en/java/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
+++ b/en/java/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
@@ -13,6 +13,8 @@ keywords:
 - data source
 - external workbook
 - external data
+- chart cache
+- workbook recovery
 - PowerPoint
 - presentation
 - Java
@@ -290,28 +292,54 @@ try {
 }
 ```
 
+### **Recover a Workbook from the Chart Cache**
+
+If a chart uses an external workbook that is missing or unavailable, Aspose.Slides can reconstruct the chart workbook from the data cached in the presentation. Create [LoadOptions](https://reference.aspose.com/slides/java/com.aspose.slides/loadoptions/), configure it with [SpreadsheetOptions](https://reference.aspose.com/slides/java/com.aspose.slides/spreadsheetoptions/), and call [ISpreadsheetOptions.setRecoverWorkbookFromChartCache](https://reference.aspose.com/slides/java/com.aspose.slides/ispreadsheetoptions/#setRecoverWorkbookFromChartCache-boolean-) with `true` before opening the presentation.
+
+The following Java example opens a presentation whose chart references an unavailable external workbook and accesses the recovered data through [IChart.getChartData](https://reference.aspose.com/slides/java/com.aspose.slides/ichart/#getChartData--) and [IChartData.getChartDataWorkbook](https://reference.aspose.com/slides/java/com.aspose.slides/ichartdata/#getChartDataWorkbook--):
+
+```java
+SpreadsheetOptions spreadsheetOptions = new SpreadsheetOptions();
+spreadsheetOptions.setRecoverWorkbookFromChartCache(true);
+
+LoadOptions loadOptions = new LoadOptions();
+loadOptions.setSpreadsheetOptions(spreadsheetOptions);
+
+Presentation presentation = new Presentation("presentation.pptx", loadOptions);
+try {
+    IChart chart = (IChart)presentation.getSlides().get_Item(0).getShapes().get_Item(0);
+    IChartDataWorkbook recoveredWorkbook = chart.getChartData().getChartDataWorkbook();
+
+    // Read or modify the recovered workbook data here.
+} finally {
+    presentation.dispose();
+}
+```
+
+If the external workbook is unavailable and recovery is disabled, Aspose.Slides throws an exception. Enable recovery only when using the cached chart data is an acceptable fallback, because the cache may not contain changes made to the external workbook after the presentation was last updated.
+
 ## **FAQ**
 
-### Can I determine whether a specific chart is linked to an external or an embedded workbook?
+**Can I determine whether a specific chart is linked to an external or an embedded workbook?**
 
 Yes. A chart has a [data source type](https://reference.aspose.com/slides/java/com.aspose.slides/chartdata/#getDataSourceType--) and a [path to an external workbook](https://reference.aspose.com/slides/java/com.aspose.slides/chartdata/#getExternalWorkbookPath--); if the source is an external workbook, you can read the full path to make sure an external file is being used.
 
-### Are relative paths to external workbooks supported, and how are they stored?
+**Are relative paths to external workbooks supported, and how are they stored?**
 
 Yes. If you specify a relative path, it is automatically converted to an absolute path. This is convenient for project portability; however, be aware that the presentation will store the absolute path in the PPTX file.
 
-### Can I use workbooks located on network resources/shares?
+**Can I use workbooks located on network resources/shares?**
 
 Yes, such workbooks can be used as an external data source. However, editing remote workbooks directly from Aspose.Slides is not supported—they can only be used as a source.
 
-### Does Aspose.Slides overwrite the external XLSX when saving the presentation?
+**Does Aspose.Slides overwrite the external XLSX when saving the presentation?**
 
 No. The presentation stores a [link to the external file](https://reference.aspose.com/slides/java/com.aspose.slides/chartdata/#getExternalWorkbookPath--) and uses it for reading data. The external file itself is not modified when the presentation is saved.
 
-### What should I do if the external file is password-protected?
+**What should I do if the external file is password-protected?**
 
 Aspose.Slides does not accept a password when linking. A common approach is to remove protection in advance or prepare a decrypted copy (for example, using [Aspose.Cells](/cells/java/)) and link to that copy.
 
-### Can multiple charts reference the same external workbook?
+**Can multiple charts reference the same external workbook?**
 
 Yes. Each chart stores its own link. If they all point to the same file, updating that file will be reflected in each chart the next time the data is loaded.

--- a/en/net/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
+++ b/en/net/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
@@ -13,6 +13,8 @@ keywords:
 - data source
 - external workbook
 - external data
+- chart cache
+- workbook recovery
 - PowerPoint
 - presentation
 - .NET
@@ -268,28 +270,53 @@ using (Presentation pres = new Presentation("presentation.pptx"))
 }
 ```
 
+### **Recover a Workbook from the Chart Cache**
+
+If a chart uses an external workbook that is missing or unavailable, Aspose.Slides can reconstruct the chart workbook from the data cached in the presentation. Create [LoadOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/), configure its [SpreadsheetOptions](https://reference.aspose.com/slides/net/aspose.slides/loadoptions/spreadsheetoptions/), and set [ISpreadsheetOptions.RecoverWorkbookFromChartCache](https://reference.aspose.com/slides/net/aspose.slides/ispreadsheetoptions/recoverworkbookfromchartcache/) to `true` before opening the presentation.
+
+The following C# example opens a presentation whose chart references an unavailable external workbook and accesses the recovered data through [IChart.ChartData](https://reference.aspose.com/slides/net/aspose.slides.charts/ichart/chartdata/) and [IChartData.ChartDataWorkbook](https://reference.aspose.com/slides/net/aspose.slides.charts/ichartdata/chartdataworkbook/):
+
+```csharp
+var loadOptions = new LoadOptions
+{
+    SpreadsheetOptions = new SpreadsheetOptions
+    {
+        RecoverWorkbookFromChartCache = true
+    }
+};
+
+using var presentation = new Presentation("presentation.pptx", loadOptions);
+
+var chart = (IChart)presentation.Slides[0].Shapes[0];
+var recoveredWorkbook = chart.ChartData.ChartDataWorkbook;
+
+// Read or modify the recovered workbook data here.
+```
+
+If the external workbook is unavailable and recovery is disabled, Aspose.Slides throws an `InvalidOperationException`. Enable recovery only when using the cached chart data is an acceptable fallback, because the cache may not contain changes made to the external workbook after the presentation was last updated.
+
 ## **FAQ**
 
-### Can I determine whether a specific chart is linked to an external or an embedded workbook?
+**Can I determine whether a specific chart is linked to an external or an embedded workbook?**
 
 Yes. A chart has a [data source type](https://reference.aspose.com/slides/net/aspose.slides.charts/chartdata/datasourcetype/) and a [path to an external workbook](https://reference.aspose.com/slides/net/aspose.slides.charts/chartdata/externalworkbookpath/); if the source is an external workbook, you can read the full path to make sure an external file is being used.
 
-### Are relative paths to external workbooks supported, and how are they stored?
+**Are relative paths to external workbooks supported, and how are they stored?**
 
 Yes. If you specify a relative path, it is automatically converted to an absolute path. This is convenient for project portability; however, be aware that the presentation will store the absolute path in the PPTX file.
 
-### Can I use workbooks located on network resources/shares?
+**Can I use workbooks located on network resources/shares?**
 
 Yes, such workbooks can be used as an external data source. However, editing remote workbooks directly from Aspose.Slides is not supported—they can only be used as a source.
 
-### Does Aspose.Slides overwrite the external XLSX when saving the presentation?
+**Does Aspose.Slides overwrite the external XLSX when saving the presentation?**
 
 No. The presentation stores a [link to the external file](https://reference.aspose.com/slides/net/aspose.slides.charts/chartdata/externalworkbookpath/) and uses it for reading data. The external file itself is not modified when the presentation is saved.
 
-### What should I do if the external file is password-protected?
+**What should I do if the external file is password-protected?**
 
 Aspose.Slides does not accept a password when linking. A common approach is to remove protection in advance or prepare a decrypted copy (for example, using [Aspose.Cells](/cells/net/)) and link to that copy.
 
-### Can multiple charts reference the same external workbook?
+**Can multiple charts reference the same external workbook?**
 
 Yes. Each chart stores its own link. If they all point to the same file, updating that file will be reflected in each chart the next time the data is loaded.

--- a/en/nodejs-java/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
+++ b/en/nodejs-java/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
@@ -13,6 +13,8 @@ keywords:
 - data source
 - external workbook
 - external data
+- chart cache
+- workbook recovery
 - PowerPoint
 - presentation
 - Node.js
@@ -289,28 +291,54 @@ try {
 }
 ```
 
+### **Recover a Workbook from the Chart Cache**
+
+If a chart uses an external workbook that is missing or unavailable, Aspose.Slides can reconstruct the chart workbook from the data cached in the presentation. Create [LoadOptions](https://reference.aspose.com/slides/nodejs-java/aspose.slides/loadoptions/), configure it with [SpreadsheetOptions](https://reference.aspose.com/slides/nodejs-java/aspose.slides/spreadsheetoptions/), and call [SpreadsheetOptions.setRecoverWorkbookFromChartCache](https://reference.aspose.com/slides/nodejs-java/aspose.slides/spreadsheetoptions/#setRecoverWorkbookFromChartCache) with `true` before opening the presentation.
+
+The following JavaScript example opens a presentation whose chart references an unavailable external workbook and accesses the recovered data through [ChartData.getChartDataWorkbook](https://reference.aspose.com/slides/nodejs-java/aspose.slides/chartdata/#getChartDataWorkbook):
+
+```javascript
+const spreadsheetOptions = new aspose.slides.SpreadsheetOptions();
+spreadsheetOptions.setRecoverWorkbookFromChartCache(true);
+
+const loadOptions = new aspose.slides.LoadOptions();
+loadOptions.setSpreadsheetOptions(spreadsheetOptions);
+
+const presentation = new aspose.slides.Presentation("presentation.pptx", loadOptions);
+try {
+    const chart = presentation.getSlides().get_Item(0).getShapes().get_Item(0);
+    const recoveredWorkbook = chart.getChartData().getChartDataWorkbook();
+
+    // Read or modify the recovered workbook data here.
+} finally {
+    presentation.dispose();
+}
+```
+
+If the external workbook is unavailable and recovery is disabled, Aspose.Slides throws an exception. Enable recovery only when using the cached chart data is an acceptable fallback, because the cache may not contain changes made to the external workbook after the presentation was last updated.
+
 ## **FAQ**
 
-### Can I determine whether a specific chart is linked to an external or an embedded workbook?
+**Can I determine whether a specific chart is linked to an external or an embedded workbook?**
 
 Yes. A chart has a [data source type](https://reference.aspose.com/slides/nodejs-java/aspose.slides/chartdata/getdatasourcetype/) and a [path to an external workbook](https://reference.aspose.com/slides/nodejs-java/aspose.slides/chartdata/getexternalworkbookpath/); if the source is an external workbook, you can read the full path to make sure an external file is being used.
 
-### Are relative paths to external workbooks supported, and how are they stored?
+**Are relative paths to external workbooks supported, and how are they stored?**
 
 Yes. If you specify a relative path, it is automatically converted to an absolute path. This is convenient for project portability; however, be aware that the presentation will store the absolute path in the PPTX file.
 
-### Can I use workbooks located on network resources/shares?
+**Can I use workbooks located on network resources/shares?**
 
 Yes, such workbooks can be used as an external data source. However, editing remote workbooks directly from Aspose.Slides is not supported—they can only be used as a source.
 
-### Does Aspose.Slides overwrite the external XLSX when saving the presentation?
+**Does Aspose.Slides overwrite the external XLSX when saving the presentation?**
 
 No. The presentation stores a [link to the external file](https://reference.aspose.com/slides/nodejs-java/aspose.slides/chartdata/getexternalworkbookpath/) and uses it for reading data. The external file itself is not modified when the presentation is saved.
 
-### What should I do if the external file is password-protected?
+**What should I do if the external file is password-protected?**
 
 Aspose.Slides does not accept a password when linking. A common approach is to remove protection in advance or prepare a decrypted copy (for example, using [Aspose.Cells](/cells/nodejs-java/)) and link to that copy.
 
-### Can multiple charts reference the same external workbook?
+**Can multiple charts reference the same external workbook?**
 
 Yes. Each chart stores its own link. If they all point to the same file, updating that file will be reflected in each chart the next time the data is loaded.

--- a/en/php-java/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
+++ b/en/php-java/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
@@ -13,6 +13,8 @@ keywords:
 - data source
 - external workbook
 - external data
+- chart cache
+- workbook recovery
 - PowerPoint
 - presentation
 - PHP
@@ -291,28 +293,54 @@ This PHP code is an implementation of the described process:
   }
 ```
 
+### **Recover a Workbook from the Chart Cache**
+
+If a chart uses an external workbook that is missing or unavailable, Aspose.Slides can reconstruct the chart workbook from the data cached in the presentation. Create [LoadOptions](https://reference.aspose.com/slides/php-java/aspose.slides/loadoptions/), configure it with [SpreadsheetOptions](https://reference.aspose.com/slides/php-java/aspose.slides/spreadsheetoptions/), and call [SpreadsheetOptions::setRecoverWorkbookFromChartCache](https://reference.aspose.com/slides/php-java/aspose.slides/spreadsheetoptions/#setRecoverWorkbookFromChartCache) with `true` before opening the presentation.
+
+The following PHP example opens a presentation whose chart references an unavailable external workbook and accesses the recovered data through [Chart::getChartData](https://reference.aspose.com/slides/php-java/aspose.slides/chart/#getChartData) and [ChartData::getChartDataWorkbook](https://reference.aspose.com/slides/php-java/aspose.slides/chartdata/#getChartDataWorkbook):
+
+```php
+$spreadsheetOptions = new SpreadsheetOptions();
+$spreadsheetOptions->setRecoverWorkbookFromChartCache(true);
+
+$loadOptions = new LoadOptions();
+$loadOptions->setSpreadsheetOptions($spreadsheetOptions);
+
+$presentation = new Presentation("presentation.pptx", $loadOptions);
+try {
+    $chart = $presentation->getSlides()->get_Item(0)->getShapes()->get_Item(0);
+    $recoveredWorkbook = $chart->getChartData()->getChartDataWorkbook();
+
+    # Read or modify the recovered workbook data here.
+} finally {
+    $presentation->dispose();
+}
+```
+
+If the external workbook is unavailable and recovery is disabled, Aspose.Slides throws an exception. Enable recovery only when using the cached chart data is an acceptable fallback, because the cache may not contain changes made to the external workbook after the presentation was last updated.
+
 ## **FAQ**
 
-### Can I determine whether a specific chart is linked to an external or an embedded workbook?
+**Can I determine whether a specific chart is linked to an external or an embedded workbook?**
 
 Yes. A chart has a [data source type](https://reference.aspose.com/slides/php-java/aspose.slides/chartdata/getdatasourcetype/) and a [path to an external workbook](https://reference.aspose.com/slides/php-java/aspose.slides/chartdata/getexternalworkbookpath/); if the source is an external workbook, you can read the full path to make sure an external file is being used.
 
-### Are relative paths to external workbooks supported, and how are they stored?
+**Are relative paths to external workbooks supported, and how are they stored?**
 
 Yes. If you specify a relative path, it is automatically converted to an absolute path. This is convenient for project portability; however, be aware that the presentation will store the absolute path in the PPTX file.
 
-### Can I use workbooks located on network resources/shares?
+**Can I use workbooks located on network resources/shares?**
 
 Yes, such workbooks can be used as an external data source. However, editing remote workbooks directly from Aspose.Slides is not supported—they can only be used as a source.
 
-### Does Aspose.Slides overwrite the external XLSX when saving the presentation?
+**Does Aspose.Slides overwrite the external XLSX when saving the presentation?**
 
 No. The presentation stores a [link to the external file](https://reference.aspose.com/slides/php-java/aspose.slides/chartdata/getexternalworkbookpath/) and uses it for reading data. The external file itself is not modified when the presentation is saved.
 
-### What should I do if the external file is password-protected?
+**What should I do if the external file is password-protected?**
 
 Aspose.Slides does not accept a password when linking. A common approach is to remove protection in advance or prepare a decrypted copy (for example, using [Aspose.Cells](/cells/php-java/)) and link to that copy.
 
-### Can multiple charts reference the same external workbook?
+**Can multiple charts reference the same external workbook?**
 
 Yes. Each chart stores its own link. If they all point to the same file, updating that file will be reflected in each chart the next time the data is loaded.

--- a/en/python-net/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
+++ b/en/python-net/developer-guide/presentation-content/powerpoint-charts/chart-workbook/_index.md
@@ -13,6 +13,8 @@ keywords:
 - data source
 - external workbook
 - external data
+- chart cache
+- workbook recovery
 - PowerPoint
 - presentation
 - Python
@@ -245,28 +247,49 @@ with slides.Presentation("sample.pptx") as presentation:
     presentation.save("output.pptx", slides.export.SaveFormat.PPTX)
 ```
 
+### **Recover a Workbook from the Chart Cache**
+
+If a chart uses an external workbook that is missing or unavailable, Aspose.Slides can reconstruct the chart workbook from the data cached in the presentation. Create [LoadOptions](https://reference.aspose.com/slides/python-net/aspose.slides/loadoptions/), then enable [SpreadsheetOptions.recover_workbook_from_chart_cache](https://reference.aspose.com/slides/python-net/aspose.slides/spreadsheetoptions/recover_workbook_from_chart_cache/) through [LoadOptions.spreadsheet_options](https://reference.aspose.com/slides/python-net/aspose.slides/loadoptions/spreadsheet_options/) before opening the presentation.
+
+The following Python example opens a presentation whose chart references an unavailable external workbook and accesses the recovered data through [Chart.chart_data](https://reference.aspose.com/slides/python-net/aspose.slides.charts/chart/chart_data/) and [ChartData.chart_data_workbook](https://reference.aspose.com/slides/python-net/aspose.slides.charts/chartdata/chart_data_workbook/):
+
+```python
+import aspose.slides as slides
+
+load_options = slides.LoadOptions()
+load_options.spreadsheet_options.recover_workbook_from_chart_cache = True
+
+with slides.Presentation("presentation.pptx", load_options) as presentation:
+    chart = presentation.slides[0].shapes[0]
+    recovered_workbook = chart.chart_data.chart_data_workbook
+
+    # Read or modify the recovered workbook data here.
+```
+
+If the external workbook is unavailable and recovery is disabled, Aspose.Slides raises an exception. Enable recovery only when using the cached chart data is an acceptable fallback, because the cache may not contain changes made to the external workbook after the presentation was last updated.
+
 ## **FAQ**
 
-### Can I determine whether a specific chart is linked to an external or an embedded workbook?
+**Can I determine whether a specific chart is linked to an external or an embedded workbook?**
 
 Yes. A chart has a [data source type](https://reference.aspose.com/slides/python-net/aspose.slides.charts/chartdata/data_source_type/) and a [path to an external workbook](https://reference.aspose.com/slides/python-net/aspose.slides.charts/chartdata/external_workbook_path/); if the source is an external workbook, you can read the full path to make sure an external file is being used.
 
-### Are relative paths to external workbooks supported, and how are they stored?
+**Are relative paths to external workbooks supported, and how are they stored?**
 
 Yes. If you specify a relative path, it is automatically converted to an absolute path. This is convenient for project portability; however, be aware that the presentation will store the absolute path in the PPTX file.
 
-### Can I use workbooks located on network resources/shares?
+**Can I use workbooks located on network resources/shares?**
 
 Yes, such workbooks can be used as an external data source. However, editing remote workbooks directly from Aspose.Slides is not supported—they can only be used as a source.
 
-### Does Aspose.Slides overwrite the external XLSX when saving the presentation?
+**Does Aspose.Slides overwrite the external XLSX when saving the presentation?**
 
 No. The presentation stores a [link to the external file](https://reference.aspose.com/slides/python-net/aspose.slides.charts/chartdata/external_workbook_path/) and uses it for reading data. The external file itself is not modified when the presentation is saved.
 
-### What should I do if the external file is password-protected?
+**What should I do if the external file is password-protected?**
 
 Aspose.Slides does not accept a password when linking. A common approach is to remove protection in advance or prepare a decrypted copy (for example, using [Aspose.Cells](/cells/python-net/)) and link to that copy.
 
-### Can multiple charts reference the same external workbook?
+**Can multiple charts reference the same external workbook?**
 
 Yes. Each chart stores its own link. If they all point to the same file, updating that file will be reflected in each chart the next time the data is loaded.


### PR DESCRIPTION
Added the section "Recover a Workbook from the Chart Cache" (.NET, Android via Java, C++, Java, Node.js via Java, PHP via Java, and Python via .NET). 
Added keywords.
Formatted the FAQ sections.