### PR TITLE
Update docs for forum topic 258673

### DIFF
--- a/en/net/developer-guide/presentation-design/powerpoint-fonts/custom-font/_index.md
+++ b/en/net/developer-guide/presentation-design/powerpoint-fonts/custom-font/_index.md
@@ -78,6 +78,10 @@ Fonts are initialized in this order:
 
 {{%/alert %}}
 
+{{% alert color="warning" title="Important for Linux/Docker containers" %}}
+When loading a custom font from a byte array (e.g., using `FontsLoader.LoadExternalFont`) you must call the loader **before** creating the `Presentation` instance. Otherwise the font may not be available during rendering and text can appear blank, as observed in Alpine-based .NET containers.
+{{% /alert %}}
+
 ## **Get Custom Font Folders**
 Aspose.Slides provides the [GetFontFolders](https://reference.aspose.com/slides/net/aspose.slides/fontsloader/getfontfolders/) method to allow you to find font folders. This method returns folders added through the `LoadExternalFonts` method and system font folders.
 


### PR DESCRIPTION
Forum topic: [258673](https://forum.aspose.com/t/text-with-custom-fonts-is-rendered-as-blank-on-mcr-microsoft-com-dotnet-aspnet-7-0-alpine/258673) - Text with Custom Fonts Is Rendered as Blank on mcr.microsoft.com/dotnet/aspnet:7.0-alpine

Summary:
- Add warning note for Linux/Docker containers about loading external fonts before creating Presentation
- Explain blank text issue in Alpine containers

Updated documentation:
- Updated section: Load Custom Fonts