### PR TITLE
Update docs for forum topic 265405

### DIFF
--- a/en/net/developer-guide/presentation-design/powerpoint-fonts/custom-font/_index.md
+++ b/en/net/developer-guide/presentation-design/powerpoint-fonts/custom-font/_index.md
@@ -157,6 +157,8 @@ Yes. Configure [font substitution](/slides/net/font-substitution/), [replacement
 
 Yes. Point to your own font folders or load fonts from byte arrays. This removes any dependency on system font directories in the container image.
 
+> **Note for Linux/Docker**: When using `FontsLoader.LoadExternalFonts` with a full directory path inside a Linux container, ensure the path string is not empty. Passing an empty string (for example, when an environment variable used to build the path is undefined) triggers `System.ArgumentException: The value cannot be an empty string. (Parameter 'path')`. Using a relative path or validating the directory before calling `LoadExternalFonts` avoids this issue.
+
 ### What about licensing—can I embed any custom font without restrictions?
 
 You are responsible for font licensing compliance. Terms vary; some licenses prohibit embedding or commercial use. Always review the font’s EULA before distributing outputs.

--- a/en/net/developer-guide/presentation-design/powerpoint-fonts/custom-font/_index.md
+++ b/en/net/developer-guide/presentation-design/powerpoint-fonts/custom-font/_index.md
@@ -141,24 +141,24 @@ finally
 
 ## **FAQ**
 
-### Do custom fonts affect export to all formats (PDF, PNG, SVG, HTML)?
+**Do custom fonts affect export to all formats (PDF, PNG, SVG, HTML)?**
 
 Yes. Connected fonts are used by the renderer across all export formats.
 
-### Are custom fonts automatically embedded into the resulting PPTX?
+**Are custom fonts automatically embedded into the resulting PPTX?**
 
 No. Registering a font for rendering is not the same as embedding it into a PPTX. If you need the font carried inside the presentation file, you must use the explicit [embedding features](/slides/net/embedded-font/).
 
-### Can I control fallback behavior when a custom font lacks certain glyphs?
+**Can I control fallback behavior when a custom font lacks certain glyphs?**
 
 Yes. Configure [font substitution](/slides/net/font-substitution/), [replacement rules](/slides/net/font-replacement/), and [fallback sets](/slides/net/fallback-font/) to define exactly which font is used when the requested glyph is missing.
 
-### Can I use fonts in Linux/Docker containers without installing them system-wide?
+**Can I use fonts in Linux/Docker containers without installing them system-wide?**
 
 Yes. Point to your own font folders or load fonts from byte arrays. This removes any dependency on system font directories in the container image.
 
-> **Note for Linux/Docker**: When using `FontsLoader.LoadExternalFonts` with a full directory path inside a Linux container, ensure the path string is not empty. Passing an empty string (for example, when an environment variable used to build the path is undefined) triggers `System.ArgumentException: The value cannot be an empty string. (Parameter 'path')`. Using a relative path or validating the directory before calling `LoadExternalFonts` avoids this issue.
+> **Note for Linux/Docker**: When calling `FontsLoader.LoadExternalFonts`, ensure that every entry in the `directories` array contains a non-empty path to an existing directory. If an environment variable used to construct a font path is undefined or empty, Aspose.Slides may attempt to resolve the empty value as a full path, resulting in `System.ArgumentException`.
 
-### What about licensing—can I embed any custom font without restrictions?
+**What about licensing—can I embed any custom font without restrictions?**
 
 You are responsible for font licensing compliance. Terms vary; some licenses prohibit embedding or commercial use. Always review the font’s EULA before distributing outputs.


### PR DESCRIPTION
Forum topic: [265405](https://forum.aspose.com/t/exception-when-setting-external-font-directory-with-full-path-under-linux-in-c/265405) - Exception When Setting External Font Directory with Full Path under Linux in C#

Summary:
- Added Linux/Docker note about empty path causing ArgumentException
- Advised validating or using relative paths for LoadExternalFonts

Updated documentation:
- Updated section: Can I use fonts in Linux/Docker containers without installing them system-wide?