### PR TITLE
SLIDESDOC-812 Document custom XML parts in PowerPoint presentations

### DIFF
--- a/en/androidjava/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
+++ b/en/androidjava/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
@@ -8,6 +8,10 @@ keywords:
 - document properties
 - tag
 - custom data
+- custom XML
+- custom XML part
+- XML metadata
+- ItemId
 - add tag
 - pair values
 - PowerPoint
@@ -15,113 +19,412 @@ keywords:
 - Android
 - Java
 - Aspose.Slides
-description: "Add, read, update, and remove tags & custom data in Aspose.Slides for Android, with Java examples for PowerPoint and OpenDocument presentations."
+description: "Learn how to manage tags and custom XML data in PowerPoint presentations with Aspose.Slides for Android via Java, including adding, reading, updating, auditing, and removing custom XML parts."
 ---
 
 ## **Overview**
 
-This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. It briefly outlines how data is stored in PPTX files, notes that presentation-specific data can exist as tags and custom XML parts, and describes tags as key-value string pairs.
+This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. Presentation-specific data can be stored as tags or custom XML parts. Tags are simple key-value string pairs, while custom XML parts can store structured metadata and application-specific XML payloads.
 
-It also shows how to read tag values and how to add tags to a presentation, an individual slide, or a shape. In addition, the article covers common tag-management tasks such as clearing all tags, removing a tag by name, and retrieving the list of tag names.
+Aspose.Slides provides APIs for adding, reading, updating, auditing, and removing custom XML parts at the presentation, slide, and shape levels. Custom XML parts are useful for integrations that store information such as document-management identifiers, workflow state, compliance metadata, template-binding data, or other structured application data inside a presentation.
 
 ## **Data Storage in Presentation Files**
 
-PPTX files—items with the .pptx extension—are stored in the PresentationML format, which is part of the Office Open XML specification. The Office Open XML format defines the structure for data contained in presentations. 
+PPTX files—files with the `.pptx` extension—are stored in the PresentationML format, which is part of the Office Open XML specification. Office Open XML defines the package structure and relationships used to store presentation content and related data.
 
-With a *slide* being one of the elements in presentations, a *slide part* contains the content of a single slide. A slide part is allowed to have explicit relationships to many parts—such as User Defined Tags—defined by ISO/IEC 29500. 
+A presentation contains multiple parts connected by relationships. For example, a slide part contains the content of a single slide and can have explicit relationships to other parts defined by ISO/IEC 29500.
 
-Custom data (specific to a presentation) or user can exist as tags ([ITagCollection](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ITagCollection)) and CustomXmlParts ([ICustomXmlPartCollection](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPartCollection)).
+Custom data can be stored as tags ([ITagCollection](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ITagCollection)) or custom XML parts ([ICustomXmlPartCollection](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPartCollection)). Both are available through the [`ICustomData`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomData/) interface.
 
-{{% alert color="primary" %}} 
+{{% alert color="primary" %}}
 
-Tags are essentially string-key pair values. 
+Tags store simple string key-value pairs. Custom XML parts store structured XML data and can be associated with a presentation, slide, or shape.
 
-{{% /alert %}} 
+{{% /alert %}}
 
-## **Get Values of Tags**
+## **Work with Custom XML Parts**
 
-In slides, a tag corresponds to the [IDocumentProperties.getKeywords()](https://reference.aspose.com/slides/androidjava/com.aspose.slides/IDocumentProperties#getKeywords--) and [IDocumentProperties.setKeywords()](https://reference.aspose.com/slides/androidjava/com.aspose.slides/IDocumentProperties#setKeywords-java.lang.String-) methods. This sample code shows you how to get a tag’s value with Aspose.Slides for Android via Java for [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation):
+The [`ICustomData.getCustomXmlParts()`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomData#getCustomXmlParts--) method returns the collection of custom XML parts associated with a particular presentation object. For example:
+
+- `presentation.getCustomData().getCustomXmlParts()` contains custom XML parts associated with the presentation itself.
+- `slide.getCustomData().getCustomXmlParts()` contains custom XML parts associated with a specific slide.
+- `shape.getCustomData().getCustomXmlParts()` contains custom XML parts associated with a specific shape.
+
+Use [`Presentation.getAllCustomXmlParts()`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation#getAllCustomXmlParts--) when you need to inspect all custom XML parts in the presentation regardless of where they are associated.
+
+### **Add a Custom XML Part to a Presentation**
+
+Use [`ICustomXmlPartCollection.add`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPartCollection#add-java.lang.String-) to add XML data to a custom XML part collection. The XML must be valid and non-empty.
+
+The following example adds structured metadata to the presentation-level custom data collection:
+
+```java
+import com.aspose.slides.*;
+import java.util.UUID;
+
+String customXmlContent =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+    "<metadata xmlns=\"urn:example:metadata\">" +
+        "<documentId>DOC-1001</documentId>" +
+        "<workflowState>Draft</workflowState>" +
+    "</metadata>";
+
+Presentation presentation = new Presentation();
+try {
+    ICustomXmlPart customXmlPart = presentation.getCustomData().getCustomXmlParts().add(customXmlContent);
+
+    // add assigns an identifier automatically. Set a specific UUID only when required.
+    customXmlPart.setItemId(UUID.randomUUID());
+
+    presentation.save("presentation_with_custom_xml.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+The `add` method can also accept XML as a byte array or input stream, which is useful when XML content is already available in binary form.
+
+### **Add a Custom XML Part to a Slide or Shape**
+
+Custom XML data can be associated with a specific slide or shape instead of the whole presentation. This is useful when metadata describes only one object, such as a template key, external record identifier, or binding information.
+
+The following example adds one custom XML part to a slide and another to a shape:
 
 ```java
 import com.aspose.slides.*;
 
-Presentation pres = new Presentation("pres.pptx");
-try{
-    String keywords = pres.getDocumentProperties().getKeywords();
+Presentation presentation = new Presentation();
+try {
+    ISlide slide = presentation.getSlides().get_Item(0);
+
+    slide.getCustomData().getCustomXmlParts().add(
+        "<slideMetadata xmlns=\"urn:example:slides\">" +
+            "<templateKey>TitleSlide</templateKey>" +
+        "</slideMetadata>");
+
+    IAutoShape shape = slide.getShapes().addAutoShape(ShapeType.Rectangle, 50, 50, 250, 80);
+
+    shape.getTextFrame().setText("Customer data");
+    shape.getCustomData().getCustomXmlParts().add(
+        "<shapeMetadata xmlns=\"urn:example:shapes\">" +
+            "<recordId>CRM-4281</recordId>" +
+        "</shapeMetadata>");
+
+    presentation.save("object_custom_xml.pptx", SaveFormat.Pptx);
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
+}
+```
+
+The level at which a part is added determines which object's `getCustomData().getCustomXmlParts()` collection contains the relationship to that part. Presentation-level data is appropriate for document-wide metadata, slide-level data for information that belongs to a particular slide, and shape-level data for metadata tied to an individual shape.
+
+### **List and Audit All Custom XML Parts**
+
+Use [`Presentation.getAllCustomXmlParts()`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation#getAllCustomXmlParts--) to retrieve all custom XML parts from a presentation. Each [`ICustomXmlPart`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPart/) exposes its identifier, XML content, and associated namespace schemas.
+
+The following example lists all custom XML parts and their namespace schemas:
+
+```java
+import com.aspose.slides.*;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    for (ICustomXmlPart customXmlPart : presentation.getAllCustomXmlParts()) {
+        System.out.println("ItemId: " + customXmlPart.getItemId());
+        System.out.println("XML:");
+        System.out.println(customXmlPart.getXmlAsString());
+
+        for (String namespaceSchema : customXmlPart.getNamespaceSchemas()) {
+            System.out.println("Namespace schema: " + namespaceSchema);
+        }
+
+        System.out.println();
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
+[`ICustomXmlPart.getNamespaceSchemas()`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPart#getNamespaceSchemas--) returns the XML schemas associated with the custom XML part. This information can be useful when auditing presentations that contain XML produced by external systems.
+
+### **Read and Update XML Content and ItemId**
+
+Use [`ICustomXmlPart.getXmlAsString()`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPart#getXmlAsString--) and [`setXmlAsString()`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPart#setXmlAsString-java.lang.String-) to work with XML as a UTF-8 string, or [`getXmlData()`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPart#getXmlData--) and [`setXmlData()`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPart#setXmlData-byte:A-) to work with the raw XML bytes.
+
+The [`ICustomXmlPart.getItemId()`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPart#getItemId--) method returns the UUID that identifies the custom XML part in the Office Open XML document. Use [`setItemId()`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPart#setItemId-java.util.UUID-) when an integration requires a new identifier.
+
+The following example updates the XML content and the identifier:
+
+```java
+import com.aspose.slides.*;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    ICustomXmlPart customXmlPart = presentation.getAllCustomXmlParts()[0];
+
+    // Read the current XML as text.
+    String currentXmlContent = customXmlPart.getXmlAsString();
+    System.out.println(currentXmlContent);
+
+    // Update the XML as a UTF-8 string.
+    customXmlPart.setXmlAsString(
+        "<metadata xmlns=\"urn:example:metadata\">" +
+            "<documentId>DOC-1001</documentId>" +
+            "<workflowState>Approved</workflowState>" +
+        "</metadata>");
+
+    // getXmlData provides the same XML content as raw bytes.
+    byte[] customXmlData = customXmlPart.getXmlData();
+    System.out.println(new String(customXmlData, StandardCharsets.UTF_8));
+
+    // Replace the identifier when required by the integration.
+    customXmlPart.setItemId(UUID.randomUUID());
+
+    presentation.save("updated_custom_xml.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+When calling `setXmlAsString` or `setXmlData`, provide valid, non-empty XML. Use one representation or the other depending on whether the application works primarily with strings or byte data.
+
+### **Remove a Custom XML Part**
+
+Aspose.Slides provides several ways to remove custom XML data:
+
+- [`ICustomXmlPart.remove`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPart#remove--) removes the custom XML part from the presentation.
+- [`ICustomXmlPartCollection.remove`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPartCollection#remove-com.aspose.slides.ICustomXmlPart-) removes a specific part from a custom XML part collection.
+- [`ICustomXmlPartCollection.removeAt`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPartCollection#removeAt-int-) removes the part at a specified collection index.
+- [`ICustomXmlPartCollection.clear`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ICustomXmlPartCollection#clear--) removes all parts from a specific collection.
+
+The following example removes one presentation-level custom XML part by reference:
+
+```java
+import com.aspose.slides.*;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    ICustomXmlPartCollection customXmlParts = presentation.getCustomData().getCustomXmlParts();
+
+    if (customXmlParts.size() > 0) {
+        ICustomXmlPart customXmlPart = customXmlParts.get_Item(0);
+        customXmlParts.remove(customXmlPart);
+    }
+
+    presentation.save("custom_xml_removed.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+If you already have an `ICustomXmlPart` and want to remove that part from the presentation rather than addressing a particular collection, call `customXmlPart.remove()`.
+
+You can also remove an item by index:
+
+```java
+presentation.getCustomData().getCustomXmlParts().removeAt(0);
+```
+
+### **Clear All Custom XML Parts from a Collection**
+
+Use `clear` when all custom XML parts associated with a particular presentation object should be removed.
+
+```java
+import com.aspose.slides.*;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    presentation.getSlides().get_Item(0).getCustomData().getCustomXmlParts().clear();
+
+    presentation.save("slide_custom_xml_cleared.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+`clear` affects only the selected collection. For example, clearing a slide's collection does not clear the presentation-level or shape-level collections.
+
+To remove every custom XML part in the presentation, iterate through `getAllCustomXmlParts()` and remove each part:
+
+```java
+import com.aspose.slides.*;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    for (ICustomXmlPart customXmlPart : presentation.getAllCustomXmlParts()) {
+        customXmlPart.remove();
+    }
+
+    presentation.save("all_custom_xml_removed.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+### **Handle Linked or Shared Custom XML Parts**
+
+In an Office Open XML presentation, the same custom XML part can be referenced from more than one presentation object. For example, an existing file can contain relationships from multiple slides or shapes to the same underlying custom XML part.
+
+A shared part should be treated as one data object with multiple references:
+
+- Updating it with `setXmlAsString`, `setXmlData`, or `setItemId` changes the underlying custom XML part, so the change applies wherever that part is referenced.
+- `getItemId()` can be used to identify the same custom XML part while auditing object-level collections.
+- Removing a part from a specific `getCustomXmlParts()` collection removes it from that collection. Use `ICustomXmlPart.remove()` when the part itself should be removed from the presentation.
+- Before deleting or replacing a shared part, inspect the object-level collections to determine whether other slides or shapes still reference it.
+
+The `add` overloads create a new custom XML part from XML content; they do not accept an existing `ICustomXmlPart`. Therefore, shared relationships are most commonly encountered when loading presentations that already contain them.
+
+The following example audits presentation-, slide-, and shape-level collections by `ItemId` and reports parts referenced from more than one place:
+
+```java
+import com.aspose.slides.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    Map<UUID, List<String>> referencesByItemId = new HashMap<>();
+
+    BiConsumer<String, ICustomXmlPartCollection> registerCustomXmlParts =
+        (ownerName, customXmlParts) -> {
+            for (int i = 0; i < customXmlParts.size(); i++) {
+                ICustomXmlPart customXmlPart = customXmlParts.get_Item(i);
+                UUID itemId = customXmlPart.getItemId();
+
+                if (!referencesByItemId.containsKey(itemId)) {
+                    referencesByItemId.put(itemId, new ArrayList<>());
+                }
+
+                referencesByItemId.get(itemId).add(ownerName);
+            }
+        };
+
+    registerCustomXmlParts.accept("Presentation", presentation.getCustomData().getCustomXmlParts());
+
+    for (int slideIndex = 0; slideIndex < presentation.getSlides().size(); slideIndex++) {
+        ISlide slide = presentation.getSlides().get_Item(slideIndex);
+        registerCustomXmlParts.accept("Slide " + (slideIndex + 1), slide.getCustomData().getCustomXmlParts());
+
+        for (int shapeIndex = 0; shapeIndex < slide.getShapes().size(); shapeIndex++) {
+            IShape shape = slide.getShapes().get_Item(shapeIndex);
+            registerCustomXmlParts.accept("Slide " + (slideIndex + 1) + ", shape " + shapeIndex, shape.getCustomData().getCustomXmlParts());
+        }
+    }
+
+    for (Map.Entry<UUID, List<String>> referenceEntry : referencesByItemId.entrySet()) {
+        if (referenceEntry.getValue().size() > 1) {
+            System.out.println("Shared custom XML part: " + referenceEntry.getKey());
+
+            for (String ownerName : referenceEntry.getValue()) {
+                System.out.println("  Referenced by: " + ownerName);
+            }
+        }
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
+This type of audit is useful before modifying or deleting custom XML data in presentations created by external systems, because the same metadata part may participate in more than one relationship.
+
+## **Get Values of Tags**
+
+In slides, a tag corresponds to the `IDocumentProperties.getKeywords()` method. This sample code shows how to get a tag value with Aspose.Slides for Android via Java for [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation):
+
+```java
+import com.aspose.slides.*;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    String keywords = presentation.getDocumentProperties().getKeywords();
+} finally {
+    presentation.dispose();
 }
 ```
 
 ## **Add Tags to Presentations**
 
-Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items: 
+Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items:
 
-- the name of a custom property - `MyTag` 
-- the value of the custom property - `My Tag Value`
+- the name of a custom property, for example, `MyTag`;
+- the value of the custom property, for example, `My Tag Value`.
 
-If you need to classify some presentations based on a specific rule or property, then you may benefit from adding tags to those presentations. For example, if you want to categorize or put all presentations from North American countries together, you can create a North American tag and then assign the relevant countries (the U.S., Mexico, and Canada) as the values. 
+If you need to classify presentations based on a specific rule or property, you can add tags for that purpose. For example, if you want to categorize presentations from North American countries, you can create a North American tag and assign the relevant country as its value.
 
-This sample code shows you how to add a tag to a [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation) using Aspose.Slides for Android via Java:
+This sample code shows how to add a tag to a [Presentation](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation) using Aspose.Slides for Android via Java:
 
 ```java
 import com.aspose.slides.*;
 
-Presentation pres = new Presentation("pres.pptx");
+Presentation presentation = new Presentation("presentation.pptx");
 try {
-    ITagCollection tags = pres.getCustomData().getTags();
-    pres.getCustomData().getTags().set_Item("MyTag", "My Tag Value");
+    ITagCollection tags = presentation.getCustomData().getTags();
+    tags.set_Item("MyTag", "My Tag Value");
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
-Tags also can be set for [Slide](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ISlide):
+Tags can also be set for a [Slide](https://reference.aspose.com/slides/androidjava/com.aspose.slides/ISlide):
 
 ```java
 import com.aspose.slides.*;
 
-Presentation pres = new Presentation();
+Presentation presentation = new Presentation();
 try {
-    ISlide slide = pres.getSlides().get_Item(0);
+    ISlide slide = presentation.getSlides().get_Item(0);
     slide.getCustomData().getTags().set_Item("tag", "value");
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
-Or any individual [Shape](https://reference.aspose.com/slides/androidjava/com.aspose.slides/IAutoShape):
+Or for an individual [Shape](https://reference.aspose.com/slides/androidjava/com.aspose.slides/IAutoShape):
 
 ```java
 import com.aspose.slides.*;
 
-Presentation pres = new Presentation();
+Presentation presentation = new Presentation();
 try {
-    ISlide slide = pres.getSlides().get_Item(0);
+    ISlide slide = presentation.getSlides().get_Item(0);
     IAutoShape shape = slide.getShapes().addAutoShape(ShapeType.Rectangle, 10, 10, 100, 50);
     shape.getTextFrame().setText("My text");
     shape.getCustomData().getTags().set_Item("tag", "value");
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
 ### **Limitations**
 
-Tags added through the custom data tag collection using `getCustomData().getTags()` are stored only within the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
+Tags added through the `getCustomData().getTags()` collection are stored only in the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
 
-**Workaround**: You can store a custom identifier in the object's **Alt Text** (e.g., `shape.setAlternativeText("MyId")`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
+**Workaround**: You can store a custom identifier in the object's **Alt Text** (for example, `shape.setAlternativeText("MyId")`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
 
 ## **FAQ**
 
-### Can I remove all tags from a presentation, slide, or shape in one operation?
+**Can I remove all tags from a presentation, slide, or shape in one operation?**
 
-Yes. The [tag collection](https://reference.aspose.com/slides/androidjava/com.aspose.slides/tagcollection/) supports a [clear](https://reference.aspose.com/slides/androidjava/com.aspose.slides/tagcollection/#clear--) operation that deletes all key–value pairs at once.
+Yes. The [tag collection](https://reference.aspose.com/slides/androidjava/com.aspose.slides/tagcollection/) supports a [clear](https://reference.aspose.com/slides/androidjava/com.aspose.slides/tagcollection/#clear--) operation that deletes all key-value pairs at once.
 
-### How do I delete a single tag by its name without iterating over the whole collection?
+**How do I delete a single tag by its name without iterating over the whole collection?**
 
-Use the [remove(name)](https://reference.aspose.com/slides/androidjava/com.aspose.slides/tagcollection/#remove-java.lang.String-) operation on [tag collection](https://reference.aspose.com/slides/androidjava/com.aspose.slides/tagcollection/) to delete the tag by its key.
+Use [remove(name)](https://reference.aspose.com/slides/androidjava/com.aspose.slides/tagcollection/#remove-java.lang.String-) on the [tag collection](https://reference.aspose.com/slides/androidjava/com.aspose.slides/tagcollection/) to delete the tag by its key.
 
-### How can I retrieve the complete list of tag names for analytics or filtering?
+**How can I retrieve the complete list of tag names for analytics or filtering?**
 
 Use [getNamesOfTags](https://reference.aspose.com/slides/androidjava/com.aspose.slides/tagcollection/#getNamesOfTags--) on the [tag collection](https://reference.aspose.com/slides/androidjava/com.aspose.slides/tagcollection/); it returns an array of all tag names.
+
+**How can I find all custom XML parts regardless of where they are stored?**
+
+Use [`Presentation.getAllCustomXmlParts()`](https://reference.aspose.com/slides/androidjava/com.aspose.slides/Presentation#getAllCustomXmlParts--) to retrieve all custom XML parts in the presentation.
+
+**Should I use `getXmlAsString`/`setXmlAsString` or `getXmlData`/`setXmlData` to update a custom XML part?**
+
+Use `getXmlAsString` and `setXmlAsString` when the application works with UTF-8 XML text. Use `getXmlData` and `setXmlData` when the XML is already available as a byte array or when binary-oriented processing is more convenient. Both representations refer to the XML content of the same custom XML part.

--- a/en/cpp/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
+++ b/en/cpp/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
@@ -8,90 +8,444 @@ keywords:
 - document properties
 - tag
 - custom data
+- custom XML
+- custom XML part
+- XML metadata
+- ItemId
 - add tag
 - pair values
 - PowerPoint
 - presentation
 - C++
 - Aspose.Slides
-description: "Learn how to add, read, update, and remove tags & custom data in Aspose.Slides for C++, with examples for PowerPoint and OpenDocument presentations."
+description: "Learn how to manage tags and custom XML data in PowerPoint presentations with Aspose.Slides for C++, including adding, reading, updating, auditing, and removing custom XML parts."
 ---
 
 ## **Overview**
 
-This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. It briefly outlines how data is stored in PPTX files, notes that presentation-specific data can exist as tags and custom XML parts, and describes tags as key-value string pairs.
+This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. Presentation-specific data can be stored as tags or custom XML parts. Tags are simple key-value string pairs, while custom XML parts can store structured metadata and application-specific XML payloads.
 
-It also shows how to read tag values and how to add tags to a presentation, an individual slide, or a shape. In addition, the article covers common tag-management tasks such as clearing all tags, removing a tag by name, and retrieving the list of tag names.
+Aspose.Slides provides APIs for adding, reading, updating, auditing, and removing custom XML parts at the presentation, slide, and shape levels. Custom XML parts are useful for integrations that store information such as document-management identifiers, workflow state, compliance metadata, template-binding data, or other structured application data inside a presentation.
 
 ## **Data Storage in Presentation Files**
 
-PPTX files—items with the .pptx extension—are stored in the PresentationML format, which is part of the Office Open XML specification. The Office Open XML format defines the structure for data contained in presentations. 
+PPTX files—files with the `.pptx` extension—are stored in the PresentationML format, which is part of the Office Open XML specification. Office Open XML defines the package structure and relationships used to store presentation content and related data.
 
-With a *slide* being one of the elements in presentations, a *slide part* contains the content of a single slide. A slide part is allowed to have explicit relationships to many parts—such as User Defined Tags—defined by ISO/IEC 29500. 
+A presentation contains multiple parts connected by relationships. For example, a slide part contains the content of a single slide and can have explicit relationships to other parts defined by ISO/IEC 29500.
 
-Custom data (specific to a presentation) or user can exist as tags ([ITagCollection](https://reference.aspose.com/slides/cpp/aspose.slides/itagcollection/)) and CustomXmlParts ([ICustomXmlPartCollection](https://reference.aspose.com/slides/cpp/aspose.slides/icustomxmlpartcollection/)). 
+Custom data can be stored as tags ([ITagCollection](https://reference.aspose.com/slides/cpp/aspose.slides/itagcollection/)) or custom XML parts ([ICustomXmlPartCollection](https://reference.aspose.com/slides/cpp/aspose.slides/icustomxmlpartcollection/)). Both are available through the [`ICustomData`](https://reference.aspose.com/slides/cpp/aspose.slides/icustomdata/) interface.
 
-{{% alert color="primary" %}} 
+{{% alert color="primary" %}}
 
-Tags are essentially string-key pair values. 
+Tags store simple string key-value pairs. Custom XML parts store structured XML data and can be associated with a presentation, slide, or shape.
 
-{{% /alert %}} 
+{{% /alert %}}
+
+## **Work with Custom XML Parts**
+
+The [`ICustomData::get_CustomXmlParts`](https://reference.aspose.com/slides/cpp/aspose.slides/icustomdata/get_customxmlparts/) method returns the collection of custom XML parts associated with a particular presentation object. For example:
+
+- `presentation->get_CustomData()->get_CustomXmlParts()` contains custom XML parts associated with the presentation itself.
+- `slide->get_CustomData()->get_CustomXmlParts()` contains custom XML parts associated with a specific slide.
+- `shape->get_CustomData()->get_CustomXmlParts()` contains custom XML parts associated with a specific shape.
+
+Use [`Presentation::get_AllCustomXmlParts`](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/get_allcustomxmlparts/) when you need to inspect all custom XML parts in the presentation regardless of where they are associated.
+
+### **Add a Custom XML Part to a Presentation**
+
+Use [`ICustomXmlPartCollection::Add`](https://reference.aspose.com/slides/cpp/aspose.slides/icustomxmlpartcollection/add/) to add XML data to a custom XML part collection. The XML must be valid and non-empty.
+
+The following example adds structured metadata to the presentation-level custom data collection:
+
+```cpp
+#include <DOM/ICustomData.h>
+#include <DOM/ICustomXmlPart.h>
+#include <DOM/ICustomXmlPartCollection.h>
+#include <DOM/Presentation.h>
+#include <Export/SaveFormat.h>
+#include <system/guid.h>
+
+using namespace Aspose::Slides;
+using namespace Aspose::Slides::Export;
+
+System::String customXmlContent =
+    u"<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    u"<metadata xmlns=\"urn:example:metadata\">"
+        u"<documentId>DOC-1001</documentId>"
+        u"<workflowState>Draft</workflowState>"
+    u"</metadata>";
+
+auto presentation = System::MakeObject<Presentation>();
+auto customXmlPart = presentation->get_CustomData()->get_CustomXmlParts()->Add(customXmlContent);
+
+// Add assigns an identifier automatically. Set a specific GUID only when required.
+customXmlPart->set_ItemId(System::Guid::NewGuid());
+
+presentation->Save(u"presentation_with_custom_xml.pptx", SaveFormat::Pptx);
+```
+
+The `Add` method can also accept XML as a byte array or stream, which is useful when XML content is already available in binary form.
+
+### **Add a Custom XML Part to a Slide or Shape**
+
+Custom XML data can be associated with a specific slide or shape instead of the whole presentation. This is useful when metadata describes only one object, such as a template key, external record identifier, or binding information.
+
+The following example adds one custom XML part to a slide and another to a shape:
+
+```cpp
+#include <DOM/IAutoShape.h>
+#include <DOM/ICustomData.h>
+#include <DOM/ICustomXmlPartCollection.h>
+#include <DOM/IShapeCollection.h>
+#include <DOM/ISlide.h>
+#include <DOM/ISlideCollection.h>
+#include <DOM/ITextFrame.h>
+#include <DOM/Presentation.h>
+#include <DOM/ShapeType.h>
+#include <Export/SaveFormat.h>
+
+using namespace Aspose::Slides;
+using namespace Aspose::Slides::Export;
+
+auto presentation = System::MakeObject<Presentation>();
+auto slide = presentation->get_Slides()->idx_get(0);
+
+slide->get_CustomData()->get_CustomXmlParts()->Add(
+    u"<slideMetadata xmlns=\"urn:example:slides\">"
+        u"<templateKey>TitleSlide</templateKey>"
+    u"</slideMetadata>");
+
+auto shape = slide->get_Shapes()->AddAutoShape(ShapeType::Rectangle, 50.0f, 50.0f, 250.0f, 80.0f);
+
+shape->get_TextFrame()->set_Text(u"Customer data");
+shape->get_CustomData()->get_CustomXmlParts()->Add(
+    u"<shapeMetadata xmlns=\"urn:example:shapes\">"
+        u"<recordId>CRM-4281</recordId>"
+    u"</shapeMetadata>");
+
+presentation->Save(u"object_custom_xml.pptx", SaveFormat::Pptx);
+```
+
+The level at which a part is added determines which object's `get_CustomData()->get_CustomXmlParts()` collection contains the relationship to that part. Presentation-level data is appropriate for document-wide metadata, slide-level data for information that belongs to a particular slide, and shape-level data for metadata tied to an individual shape.
+
+### **List and Audit All Custom XML Parts**
+
+Use [`Presentation::get_AllCustomXmlParts`](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/get_allcustomxmlparts/) to retrieve all custom XML parts from a presentation. Each [`ICustomXmlPart`](https://reference.aspose.com/slides/cpp/aspose.slides/icustomxmlpart/) exposes its identifier, XML content, and associated namespace schemas.
+
+The following example lists all custom XML parts and their namespace schemas:
+
+```cpp
+#include <DOM/ICustomXmlPart.h>
+#include <DOM/Presentation.h>
+#include <system/console.h>
+
+using namespace Aspose::Slides;
+
+auto presentation = System::MakeObject<Presentation>(u"presentation.pptx");
+
+for (auto customXmlPart : presentation->get_AllCustomXmlParts())
+{
+    System::Console::WriteLine(System::String(u"ItemId: ") + customXmlPart->get_ItemId().ToString());
+    System::Console::WriteLine(u"XML:");
+    System::Console::WriteLine(customXmlPart->get_XmlAsString());
+
+    for (auto namespaceSchema : customXmlPart->get_NamespaceSchemas())
+    {
+        System::Console::WriteLine(System::String(u"Namespace schema: ") + namespaceSchema);
+    }
+
+    System::Console::WriteLine();
+}
+```
+
+[`ICustomXmlPart::get_NamespaceSchemas`](https://reference.aspose.com/slides/cpp/aspose.slides/icustomxmlpart/get_namespaceschemas/) returns the XML schemas associated with the custom XML part. This information can be useful when auditing presentations that contain XML produced by external systems.
+
+### **Read and Update XML Content and ItemId**
+
+Use [`ICustomXmlPart::get_XmlAsString`](https://reference.aspose.com/slides/cpp/aspose.slides/icustomxmlpart/get_xmlasstring/) and `set_XmlAsString` to work with XML as a UTF-8 string, or [`ICustomXmlPart::get_XmlData`](https://reference.aspose.com/slides/cpp/aspose.slides/icustomxmlpart/get_xmldata/) and `set_XmlData` to work with the raw XML bytes. Both representations can be read and updated.
+
+The [`ICustomXmlPart::get_ItemId`](https://reference.aspose.com/slides/cpp/aspose.slides/icustomxmlpart/get_itemid/) method returns the GUID that identifies the custom XML part in the Office Open XML document. The identifier can also be changed with `set_ItemId` when an integration requires a new identifier.
+
+The following example updates the XML content and the identifier:
+
+```cpp
+#include <DOM/ICustomXmlPart.h>
+#include <DOM/Presentation.h>
+#include <Export/SaveFormat.h>
+#include <system/console.h>
+#include <system/guid.h>
+#include <system/text/encoding.h>
+
+using namespace Aspose::Slides;
+using namespace Aspose::Slides::Export;
+
+auto presentation = System::MakeObject<Presentation>(u"presentation.pptx");
+auto customXmlPart = presentation->get_AllCustomXmlParts()->idx_get(0);
+
+// Read the current XML as text.
+auto currentXmlContent = customXmlPart->get_XmlAsString();
+System::Console::WriteLine(currentXmlContent);
+
+// Update the XML as a UTF-8 string.
+customXmlPart->set_XmlAsString(
+    u"<metadata xmlns=\"urn:example:metadata\">"
+        u"<documentId>DOC-1001</documentId>"
+        u"<workflowState>Approved</workflowState>"
+    u"</metadata>");
+
+// XmlData provides the same XML content as raw bytes.
+auto customXmlData = customXmlPart->get_XmlData();
+System::Console::WriteLine(System::Text::Encoding::get_UTF8()->GetString(customXmlData));
+
+// Replace the identifier when required by the integration.
+customXmlPart->set_ItemId(System::Guid::NewGuid());
+
+presentation->Save(u"updated_custom_xml.pptx", SaveFormat::Pptx);
+```
+
+When assigning XML with `set_XmlAsString` or `set_XmlData`, provide valid, non-empty XML. Use one representation or the other depending on whether the application works primarily with strings or byte data.
+
+### **Remove a Custom XML Part**
+
+Aspose.Slides provides several ways to remove custom XML data:
+
+- [`ICustomXmlPart::Remove`](https://reference.aspose.com/slides/cpp/aspose.slides/icustomxmlpart/remove/) removes the custom XML part from the presentation.
+- [`ICustomXmlPartCollection::Remove`](https://reference.aspose.com/slides/cpp/aspose.slides/icustomxmlpartcollection/remove/) removes a specific part from a custom XML part collection.
+- [`ICustomXmlPartCollection::RemoveAt`](https://reference.aspose.com/slides/cpp/aspose.slides/icustomxmlpartcollection/removeat/) removes the part at a specified collection index.
+- [`ICustomXmlPartCollection::Clear`](https://reference.aspose.com/slides/cpp/aspose.slides/icustomxmlpartcollection/clear/) removes all parts from a specific collection.
+
+The following example removes one presentation-level custom XML part by reference:
+
+```cpp
+#include <DOM/ICustomData.h>
+#include <DOM/ICustomXmlPartCollection.h>
+#include <DOM/Presentation.h>
+#include <Export/SaveFormat.h>
+
+using namespace Aspose::Slides;
+using namespace Aspose::Slides::Export;
+
+auto presentation = System::MakeObject<Presentation>(u"presentation.pptx");
+auto customXmlParts = presentation->get_CustomData()->get_CustomXmlParts();
+
+if (customXmlParts->get_Count() > 0)
+{
+    auto customXmlPart = customXmlParts->idx_get(0);
+    customXmlParts->Remove(customXmlPart);
+}
+
+presentation->Save(u"custom_xml_removed.pptx", SaveFormat::Pptx);
+```
+
+If you already have an `ICustomXmlPart` and want to remove that part from the presentation rather than addressing a particular collection, call `customXmlPart->Remove()`.
+
+You can also remove an item by index:
+
+```cpp
+presentation->get_CustomData()->get_CustomXmlParts()->RemoveAt(0);
+```
+
+### **Clear All Custom XML Parts from a Collection**
+
+Use `Clear` when all custom XML parts associated with a particular presentation object should be removed.
+
+```cpp
+#include <DOM/ICustomData.h>
+#include <DOM/ICustomXmlPartCollection.h>
+#include <DOM/ISlideCollection.h>
+#include <DOM/Presentation.h>
+#include <Export/SaveFormat.h>
+
+using namespace Aspose::Slides;
+using namespace Aspose::Slides::Export;
+
+auto presentation = System::MakeObject<Presentation>(u"presentation.pptx");
+presentation->get_Slides()->idx_get(0)->get_CustomData()->get_CustomXmlParts()->Clear();
+
+presentation->Save(u"slide_custom_xml_cleared.pptx", SaveFormat::Pptx);
+```
+
+`Clear` affects only the selected collection. For example, clearing a slide's collection does not clear the presentation-level or shape-level collections.
+
+To remove every custom XML part in the presentation, iterate through `get_AllCustomXmlParts()` and remove each part:
+
+```cpp
+#include <DOM/ICustomXmlPart.h>
+#include <DOM/Presentation.h>
+#include <Export/SaveFormat.h>
+
+using namespace Aspose::Slides;
+using namespace Aspose::Slides::Export;
+
+auto presentation = System::MakeObject<Presentation>(u"presentation.pptx");
+
+for (auto customXmlPart : presentation->get_AllCustomXmlParts())
+{
+    customXmlPart->Remove();
+}
+
+presentation->Save(u"all_custom_xml_removed.pptx", SaveFormat::Pptx);
+```
+
+### **Handle Linked or Shared Custom XML Parts**
+
+In an Office Open XML presentation, the same custom XML part can be referenced from more than one presentation object. For example, an existing file can contain relationships from multiple slides or shapes to the same underlying custom XML part.
+
+A shared part should be treated as one data object with multiple references:
+
+- Updating it with `set_XmlAsString`, `set_XmlData`, or `set_ItemId` changes the underlying custom XML part, so the change applies wherever that part is referenced.
+- `get_ItemId()` can be used to identify the same custom XML part while auditing object-level collections.
+- Removing a part from a specific `get_CustomXmlParts()` collection removes it from that collection. Use `ICustomXmlPart::Remove()` when the part itself should be removed from the presentation.
+- Before deleting or replacing a shared part, inspect the object-level collections to determine whether other slides or shapes still reference it.
+
+The `Add` overloads create a new custom XML part from XML content; they do not accept an existing `ICustomXmlPart`. Therefore, shared relationships are most commonly encountered when loading presentations that already contain them.
+
+The following example audits presentation-, slide-, and shape-level collections by `ItemId` and reports parts referenced from more than one place:
+
+```cpp
+#include <algorithm>
+#include <vector>
+#include <DOM/ICustomData.h>
+#include <DOM/ICustomXmlPart.h>
+#include <DOM/ICustomXmlPartCollection.h>
+#include <DOM/IShape.h>
+#include <DOM/IShapeCollection.h>
+#include <DOM/ISlide.h>
+#include <DOM/ISlideCollection.h>
+#include <DOM/Presentation.h>
+#include <system/console.h>
+#include <system/guid.h>
+#include <system/string.h>
+
+using namespace Aspose::Slides;
+
+struct CustomXmlReferenceEntry
+{
+    System::Guid itemId;
+    std::vector<System::String> owners;
+};
+
+auto presentation = System::MakeObject<Presentation>(u"presentation.pptx");
+std::vector<CustomXmlReferenceEntry> referencesByItemId;
+
+auto registerCustomXmlParts = [&referencesByItemId](
+    const System::String& ownerName,
+    const System::SharedPtr<ICustomXmlPartCollection>& customXmlParts)
+{
+    for (int32_t partIndex = 0; partIndex < customXmlParts->get_Count(); ++partIndex)
+    {
+        auto customXmlPart = customXmlParts->idx_get(partIndex);
+        auto itemId = customXmlPart->get_ItemId();
+
+        auto entry = std::find_if(
+            referencesByItemId.begin(),
+            referencesByItemId.end(),
+            [&itemId](const CustomXmlReferenceEntry& referenceEntry)
+            {
+                return referenceEntry.itemId == itemId;
+            });
+
+        if (entry == referencesByItemId.end())
+        {
+            referencesByItemId.push_back({ itemId, { ownerName } });
+        }
+        else
+        {
+            entry->owners.push_back(ownerName);
+        }
+    }
+};
+
+registerCustomXmlParts(u"Presentation", presentation->get_CustomData()->get_CustomXmlParts());
+
+for (int32_t slideIndex = 0; slideIndex < presentation->get_Slides()->get_Count(); ++slideIndex)
+{
+    auto slide = presentation->get_Slides()->idx_get(slideIndex);
+    registerCustomXmlParts(
+        System::String::Format(u"Slide {0}", slideIndex + 1),
+        slide->get_CustomData()->get_CustomXmlParts());
+
+    for (int32_t shapeIndex = 0; shapeIndex < slide->get_Shapes()->get_Count(); ++shapeIndex)
+    {
+        auto shape = slide->get_Shapes()->idx_get(shapeIndex);
+        registerCustomXmlParts(
+            System::String::Format(u"Slide {0}, shape {1}", slideIndex + 1, shapeIndex),
+            shape->get_CustomData()->get_CustomXmlParts());
+    }
+}
+
+for (const auto& referenceEntry : referencesByItemId)
+{
+    if (referenceEntry.owners.size() > 1)
+    {
+        System::Console::WriteLine(
+            System::String(u"Shared custom XML part: ") + referenceEntry.itemId.ToString());
+
+        for (const auto& ownerName : referenceEntry.owners)
+        {
+            System::Console::WriteLine(System::String(u"  Referenced by: ") + ownerName);
+        }
+    }
+}
+```
+
+This type of audit is useful before modifying or deleting custom XML data in presentations created by external systems, because the same metadata part may participate in more than one relationship.
 
 ## **Get Values of Tags**
 
-In slides, a tag corresponds to the IDocumentProperties.Keywords property. This sample code shows you how to get a tag’s value with Aspose.Slides for C++ for [Presentation](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/):
+In slides, a tag corresponds to the `IDocumentProperties::get_Keywords` property. This sample code shows how to get a tag value with Aspose.Slides for C++ for [Presentation](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/):
 
-``` cpp
+```cpp
 #include <DOM/IDocumentProperties.h>
 #include <DOM/Presentation.h>
+
 using namespace Aspose::Slides;
 
-auto pres = System::MakeObject<Presentation>(u"pres.pptx");
-System::String keywords = pres->get_DocumentProperties()->get_Keywords();
+auto presentation = System::MakeObject<Presentation>(u"presentation.pptx");
+auto keywords = presentation->get_DocumentProperties()->get_Keywords();
 ```
 
 ## **Add Tags to Presentations**
 
-Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items: 
+Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items:
 
-- the name of a custom property - `MyTag` 
-- the value of the custom property - `My Tag Value`
+- the name of a custom property, for example, `MyTag`;
+- the value of the custom property, for example, `My Tag Value`.
 
-If you need to classify some presentations based on a specific rule or property, then you may benefit from adding tags to those presentations. For example, if you want to categorize or put all presentations from North American countries together, you can create a North American tag and then assign the relevant countries (the U.S., Mexico, and Canada) as the values. 
+If you need to classify presentations based on a specific rule or property, you can add tags for that purpose. For example, if you want to categorize presentations from North American countries, you can create a North American tag and assign the relevant country as its value.
 
-This sample code shows you how to add a tag to a [Presentation](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/) using Aspose.Slides for C++:
+This sample code shows how to add a tag to a [Presentation](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/) using Aspose.Slides for C++:
 
-``` cpp
+```cpp
 #include <DOM/ICustomData.h>
 #include <DOM/ITagCollection.h>
 #include <DOM/Presentation.h>
+
 using namespace Aspose::Slides;
 
-auto pres = System::MakeObject<Presentation>(u"pres.pptx");
-
-System::SharedPtr<ITagCollection> tags = pres->get_CustomData()->get_Tags();
-pres->get_CustomData()->get_Tags()->idx_set(u"MyTag", u"My Tag Value");
+auto presentation = System::MakeObject<Presentation>(u"presentation.pptx");
+auto tags = presentation->get_CustomData()->get_Tags();
+tags->idx_set(u"MyTag", u"My Tag Value");
 ```
 
-Tags also can be set for [Slide](https://reference.aspose.com/slides/cpp/aspose.slides/slide/):
+Tags can also be set for a [Slide](https://reference.aspose.com/slides/cpp/aspose.slides/slide/):
 
-``` cpp
+```cpp
 #include <DOM/ICustomData.h>
-#include <DOM/ISlide.h>
 #include <DOM/ISlideCollection.h>
 #include <DOM/ITagCollection.h>
 #include <DOM/Presentation.h>
+
 using namespace Aspose::Slides;
 
-auto pres = System::MakeObject<Presentation>();
-
-auto slide = pres->get_Slides()->idx_get(0);
+auto presentation = System::MakeObject<Presentation>();
+auto slide = presentation->get_Slides()->idx_get(0);
 slide->get_CustomData()->get_Tags()->idx_set(u"tag", u"value");
 ```
 
-Or any individual [Shape](https://reference.aspose.com/slides/cpp/aspose.slides/shape/):
+Or for an individual [Shape](https://reference.aspose.com/slides/cpp/aspose.slides/shape/):
 
-``` cpp
+```cpp
 #include <DOM/IAutoShape.h>
 #include <DOM/ICustomData.h>
 #include <DOM/IShapeCollection.h>
@@ -101,11 +455,11 @@ Or any individual [Shape](https://reference.aspose.com/slides/cpp/aspose.slides/
 #include <DOM/ITextFrame.h>
 #include <DOM/Presentation.h>
 #include <DOM/ShapeType.h>
+
 using namespace Aspose::Slides;
 
-auto pres = System::MakeObject<Presentation>();
-
-auto slide = pres->get_Slides()->idx_get(0);
+auto presentation = System::MakeObject<Presentation>();
+auto slide = presentation->get_Slides()->idx_get(0);
 auto shape = slide->get_Shapes()->AddAutoShape(ShapeType::Rectangle, 10.0f, 10.0f, 100.0f, 50.0f);
 shape->get_TextFrame()->set_Text(u"My text");
 shape->get_CustomData()->get_Tags()->idx_set(u"tag", u"value");
@@ -113,20 +467,28 @@ shape->get_CustomData()->get_Tags()->idx_set(u"tag", u"value");
 
 ### **Limitations**
 
-Tags added through the custom data tag collection using `get_CustomData()->get_Tags()` are stored only within the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
+Tags added through the `get_CustomData()->get_Tags()` collection are stored only in the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
 
-**Workaround**: You can store a custom identifier in the object's **Alt Text** (e.g., `shape->set_AlternativeText(u"MyId")`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
+**Workaround**: You can store a custom identifier in the object's **Alt Text** (for example, `shape->set_AlternativeText(u"MyId")`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
 
 ## **FAQ**
 
-### Can I remove all tags from a presentation, slide, or shape in one operation?
+**Can I remove all tags from a presentation, slide, or shape in one operation?**
 
-Yes. The [tag collection](https://reference.aspose.com/slides/cpp/aspose.slides/tagcollection/) supports a [clear](https://reference.aspose.com/slides/cpp/aspose.slides/tagcollection/clear/) operation that deletes all key–value pairs at once.
+Yes. The [tag collection](https://reference.aspose.com/slides/cpp/aspose.slides/tagcollection/) supports a [Clear](https://reference.aspose.com/slides/cpp/aspose.slides/tagcollection/clear/) operation that deletes all key-value pairs at once.
 
-### How do I delete a single tag by its name without iterating over the whole collection?
+**How do I delete a single tag by its name without iterating over the whole collection?**
 
-Use the [Remove(name)](https://reference.aspose.com/slides/cpp/aspose.slides/tagcollection/remove/) operation on [TagCollection](https://reference.aspose.com/slides/cpp/aspose.slides/tagcollection/) to delete the tag by its key.
+Use [Remove(name)](https://reference.aspose.com/slides/cpp/aspose.slides/tagcollection/remove/) on [TagCollection](https://reference.aspose.com/slides/cpp/aspose.slides/tagcollection/) to delete the tag by its key.
 
-### How can I retrieve the complete list of tag names for analytics or filtering?
+**How can I retrieve the complete list of tag names for analytics or filtering?**
 
 Use [GetNamesOfTags](https://reference.aspose.com/slides/cpp/aspose.slides/tagcollection/getnamesoftags/) on the [tag collection](https://reference.aspose.com/slides/cpp/aspose.slides/tagcollection/); it returns an array of all tag names.
+
+**How can I find all custom XML parts regardless of where they are stored?**
+
+Use [`Presentation::get_AllCustomXmlParts`](https://reference.aspose.com/slides/cpp/aspose.slides/presentation/get_allcustomxmlparts/) to retrieve all custom XML parts in the presentation.
+
+**Should I use `get_XmlAsString`/`set_XmlAsString` or `get_XmlData`/`set_XmlData` to update a custom XML part?**
+
+Use `get_XmlAsString` and `set_XmlAsString` when the application works with UTF-8 XML text. Use `get_XmlData` and `set_XmlData` when the XML is already available as a byte array or when binary-oriented processing is more convenient. Both representations refer to the XML content of the same custom XML part.

--- a/en/java/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
+++ b/en/java/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
@@ -8,119 +8,422 @@ keywords:
 - document properties
 - tag
 - custom data
+- custom XML
+- custom XML part
+- XML metadata
+- ItemId
 - add tag
 - pair values
 - PowerPoint
 - presentation
 - Java
 - Aspose.Slides
-description: "Learn how to add, read, update, and remove tags & custom data in Aspose.Slides for Java, with examples for PowerPoint and OpenDocument presentations."
+description: "Learn how to manage tags and custom XML data in PowerPoint presentations with Aspose.Slides for Java, including adding, reading, updating, auditing, and removing custom XML parts."
 ---
 
 ## **Overview**
 
-This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. It briefly outlines how data is stored in PPTX files, notes that presentation-specific data can exist as tags and custom XML parts, and describes tags as key-value string pairs.
+This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. Presentation-specific data can be stored as tags or custom XML parts. Tags are simple key-value string pairs, while custom XML parts can store structured metadata and application-specific XML payloads.
 
-It also shows how to read tag values and how to add tags to a presentation, an individual slide, or a shape. In addition, the article covers common tag-management tasks such as clearing all tags, removing a tag by name, and retrieving the list of tag names.
+Aspose.Slides provides APIs for adding, reading, updating, auditing, and removing custom XML parts at the presentation, slide, and shape levels. Custom XML parts are useful for integrations that store information such as document-management identifiers, workflow state, compliance metadata, template-binding data, or other structured application data inside a presentation.
 
 ## **Data Storage in Presentation Files**
 
-PPTX files—items with the .pptx extension—are stored in the PresentationML format, which is part of the Office Open XML specification. The Office Open XML format defines the structure for data contained in presentations. 
+PPTX files—files with the `.pptx` extension—are stored in the PresentationML format, which is part of the Office Open XML specification. Office Open XML defines the package structure and relationships used to store presentation content and related data.
 
-With a *slide* being one of the elements in presentations, a *slide part* contains the content of a single slide. A slide part is allowed to have explicit relationships to many parts—such as User Defined Tags—defined by ISO/IEC 29500. 
+A presentation contains multiple parts connected by relationships. For example, a slide part contains the content of a single slide and can have explicit relationships to other parts defined by ISO/IEC 29500.
 
-Custom data (specific to a presentation) or user can exist as tags ([ITagCollection](https://reference.aspose.com/slides/java/com.aspose.slides/ITagCollection)) and CustomXmlParts ([ICustomXmlPartCollection](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPartCollection)). 
+Custom data can be stored as tags ([ITagCollection](https://reference.aspose.com/slides/java/com.aspose.slides/ITagCollection)) or custom XML parts ([ICustomXmlPartCollection](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPartCollection)). Both are available through the [`ICustomData`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomData/) interface.
 
-{{% alert color="primary" %}} 
+{{% alert color="primary" %}}
 
-Tags are essentially string-key pair values. 
+Tags store simple string key-value pairs. Custom XML parts store structured XML data and can be associated with a presentation, slide, or shape.
 
-{{% /alert %}} 
+{{% /alert %}}
 
-## **Get Values of Tags**
+## **Work with Custom XML Parts**
 
-In slides, a tag corresponds to the [IDocumentProperties.getKeywords()](https://reference.aspose.com/slides/java/com.aspose.slides/IDocumentProperties#getKeywords--) and [IDocumentProperties.setKeywords()](https://reference.aspose.com/slides/java/com.aspose.slides/IDocumentProperties#setKeywords-java.lang.String-) methods. This sample code shows you how to get a tag’s value with Aspose.Slides for Java for [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation):
+The [`ICustomData.getCustomXmlParts()`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomData#getCustomXmlParts--) method returns the collection of custom XML parts associated with a particular presentation object. For example:
+
+- `presentation.getCustomData().getCustomXmlParts()` contains custom XML parts associated with the presentation itself.
+- `slide.getCustomData().getCustomXmlParts()` contains custom XML parts associated with a specific slide.
+- `shape.getCustomData().getCustomXmlParts()` contains custom XML parts associated with a specific shape.
+
+Use [`Presentation.getAllCustomXmlParts()`](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation#getAllCustomXmlParts--) when you need to inspect all custom XML parts in the presentation regardless of where they are associated.
+
+### **Add a Custom XML Part to a Presentation**
+
+Use [`ICustomXmlPartCollection.add`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPartCollection#add-java.lang.String-) to add XML data to a custom XML part collection. The XML must be valid and non-empty.
+
+The following example adds structured metadata to the presentation-level custom data collection:
+
+```java
+import com.aspose.slides.*;
+import java.util.UUID;
+
+String customXmlContent =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+    "<metadata xmlns=\"urn:example:metadata\">" +
+        "<documentId>DOC-1001</documentId>" +
+        "<workflowState>Draft</workflowState>" +
+    "</metadata>";
+
+Presentation presentation = new Presentation();
+try {
+    ICustomXmlPart customXmlPart = presentation.getCustomData().getCustomXmlParts().add(customXmlContent);
+
+    // add assigns an identifier automatically. Set a specific UUID only when required.
+    customXmlPart.setItemId(UUID.randomUUID());
+
+    presentation.save("presentation_with_custom_xml.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+The `add` method can also accept XML as a byte array or input stream, which is useful when XML content is already available in binary form.
+
+### **Add a Custom XML Part to a Slide or Shape**
+
+Custom XML data can be associated with a specific slide or shape instead of the whole presentation. This is useful when metadata describes only one object, such as a template key, external record identifier, or binding information.
+
+The following example adds one custom XML part to a slide and another to a shape:
 
 ```java
 import com.aspose.slides.*;
 
-Presentation pres = new Presentation("pres.pptx");
-try{
-    String keywords = pres.getDocumentProperties().getKeywords();
+Presentation presentation = new Presentation();
+try {
+    ISlide slide = presentation.getSlides().get_Item(0);
+
+    slide.getCustomData().getCustomXmlParts().add(
+        "<slideMetadata xmlns=\"urn:example:slides\">" +
+            "<templateKey>TitleSlide</templateKey>" +
+        "</slideMetadata>");
+
+    IAutoShape shape = slide.getShapes().addAutoShape(ShapeType.Rectangle, 50, 50, 250, 80);
+
+    shape.getTextFrame().setText("Customer data");
+    shape.getCustomData().getCustomXmlParts().add(
+        "<shapeMetadata xmlns=\"urn:example:shapes\">" +
+            "<recordId>CRM-4281</recordId>" +
+        "</shapeMetadata>");
+
+    presentation.save("object_custom_xml.pptx", SaveFormat.Pptx);
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
+}
+```
+
+The level at which a part is added determines which object's `getCustomData().getCustomXmlParts()` collection contains the relationship to that part. Presentation-level data is appropriate for document-wide metadata, slide-level data for information that belongs to a particular slide, and shape-level data for metadata tied to an individual shape.
+
+### **List and Audit All Custom XML Parts**
+
+Use [`Presentation.getAllCustomXmlParts()`](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation#getAllCustomXmlParts--) to retrieve all custom XML parts from a presentation. Each [`ICustomXmlPart`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPart/) exposes its identifier, XML content, and associated namespace schemas.
+
+The following example lists all custom XML parts and their namespace schemas:
+
+```java
+import com.aspose.slides.*;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    for (ICustomXmlPart customXmlPart : presentation.getAllCustomXmlParts()) {
+        System.out.println("ItemId: " + customXmlPart.getItemId());
+        System.out.println("XML:");
+        System.out.println(customXmlPart.getXmlAsString());
+
+        for (String namespaceSchema : customXmlPart.getNamespaceSchemas()) {
+            System.out.println("Namespace schema: " + namespaceSchema);
+        }
+
+        System.out.println();
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
+[`ICustomXmlPart.getNamespaceSchemas()`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPart#getNamespaceSchemas--) returns the XML schemas associated with the custom XML part. This information can be useful when auditing presentations that contain XML produced by external systems.
+
+### **Read and Update XML Content and ItemId**
+
+Use [`ICustomXmlPart.getXmlAsString()`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPart#getXmlAsString--) and [`setXmlAsString()`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPart#setXmlAsString-java.lang.String-) to work with XML as a UTF-8 string, or [`getXmlData()`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPart#getXmlData--) and [`setXmlData()`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPart#setXmlData-byte:A-) to work with the raw XML bytes.
+
+The [`ICustomXmlPart.getItemId()`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPart#getItemId--) method returns the UUID that identifies the custom XML part in the Office Open XML document. Use [`setItemId()`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPart#setItemId-java.util.UUID-) when an integration requires a new identifier.
+
+The following example updates the XML content and the identifier:
+
+```java
+import com.aspose.slides.*;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    ICustomXmlPart customXmlPart = presentation.getAllCustomXmlParts()[0];
+
+    // Read the current XML as text.
+    String currentXmlContent = customXmlPart.getXmlAsString();
+    System.out.println(currentXmlContent);
+
+    // Update the XML as a UTF-8 string.
+    customXmlPart.setXmlAsString(
+        "<metadata xmlns=\"urn:example:metadata\">" +
+            "<documentId>DOC-1001</documentId>" +
+            "<workflowState>Approved</workflowState>" +
+        "</metadata>");
+
+    // getXmlData provides the same XML content as raw bytes.
+    byte[] customXmlData = customXmlPart.getXmlData();
+    System.out.println(new String(customXmlData, StandardCharsets.UTF_8));
+
+    // Replace the identifier when required by the integration.
+    customXmlPart.setItemId(UUID.randomUUID());
+
+    presentation.save("updated_custom_xml.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+When calling `setXmlAsString` or `setXmlData`, provide valid, non-empty XML. Use one representation or the other depending on whether the application works primarily with strings or byte data.
+
+### **Remove a Custom XML Part**
+
+Aspose.Slides provides several ways to remove custom XML data:
+
+- [`ICustomXmlPart.remove`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPart#remove--) removes the custom XML part from the presentation.
+- [`ICustomXmlPartCollection.remove`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPartCollection#remove-com.aspose.slides.ICustomXmlPart-) removes a specific part from a custom XML part collection.
+- [`ICustomXmlPartCollection.removeAt`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPartCollection#removeAt-int-) removes the part at a specified collection index.
+- [`ICustomXmlPartCollection.clear`](https://reference.aspose.com/slides/java/com.aspose.slides/ICustomXmlPartCollection#clear--) removes all parts from a specific collection.
+
+The following example removes one presentation-level custom XML part by reference:
+
+```java
+import com.aspose.slides.*;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    ICustomXmlPartCollection customXmlParts = presentation.getCustomData().getCustomXmlParts();
+
+    if (customXmlParts.size() > 0) {
+        ICustomXmlPart customXmlPart = customXmlParts.get_Item(0);
+        customXmlParts.remove(customXmlPart);
+    }
+
+    presentation.save("custom_xml_removed.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+If you already have an `ICustomXmlPart` and want to remove that part from the presentation rather than addressing a particular collection, call `customXmlPart.remove()`.
+
+You can also remove an item by index:
+
+```java
+presentation.getCustomData().getCustomXmlParts().removeAt(0);
+```
+
+### **Clear All Custom XML Parts from a Collection**
+
+Use `clear` when all custom XML parts associated with a particular presentation object should be removed.
+
+```java
+import com.aspose.slides.*;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    presentation.getSlides().get_Item(0).getCustomData().getCustomXmlParts().clear();
+
+    presentation.save("slide_custom_xml_cleared.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+`clear` affects only the selected collection. For example, clearing a slide's collection does not clear the presentation-level or shape-level collections.
+
+To remove every custom XML part in the presentation, iterate through `getAllCustomXmlParts()` and remove each part:
+
+```java
+import com.aspose.slides.*;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    for (ICustomXmlPart customXmlPart : presentation.getAllCustomXmlParts()) {
+        customXmlPart.remove();
+    }
+
+    presentation.save("all_custom_xml_removed.pptx", SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+### **Handle Linked or Shared Custom XML Parts**
+
+In an Office Open XML presentation, the same custom XML part can be referenced from more than one presentation object. For example, an existing file can contain relationships from multiple slides or shapes to the same underlying custom XML part.
+
+A shared part should be treated as one data object with multiple references:
+
+- Updating it with `setXmlAsString`, `setXmlData`, or `setItemId` changes the underlying custom XML part, so the change applies wherever that part is referenced.
+- `getItemId()` can be used to identify the same custom XML part while auditing object-level collections.
+- Removing a part from a specific `getCustomXmlParts()` collection removes it from that collection. Use `ICustomXmlPart.remove()` when the part itself should be removed from the presentation.
+- Before deleting or replacing a shared part, inspect the object-level collections to determine whether other slides or shapes still reference it.
+
+The `add` overloads create a new custom XML part from XML content; they do not accept an existing `ICustomXmlPart`. Therefore, shared relationships are most commonly encountered when loading presentations that already contain them.
+
+The following example audits presentation-, slide-, and shape-level collections by `ItemId` and reports parts referenced from more than one place:
+
+```java
+import com.aspose.slides.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    Map<UUID, List<String>> referencesByItemId = new HashMap<>();
+
+    BiConsumer<String, ICustomXmlPartCollection> registerCustomXmlParts =
+        (ownerName, customXmlParts) -> {
+            for (int i = 0; i < customXmlParts.size(); i++) {
+                ICustomXmlPart customXmlPart = customXmlParts.get_Item(i);
+                UUID itemId = customXmlPart.getItemId();
+
+                if (!referencesByItemId.containsKey(itemId)) {
+                    referencesByItemId.put(itemId, new ArrayList<>());
+                }
+
+                referencesByItemId.get(itemId).add(ownerName);
+            }
+        };
+
+    registerCustomXmlParts.accept("Presentation", presentation.getCustomData().getCustomXmlParts());
+
+    for (int slideIndex = 0; slideIndex < presentation.getSlides().size(); slideIndex++) {
+        ISlide slide = presentation.getSlides().get_Item(slideIndex);
+        registerCustomXmlParts.accept("Slide " + (slideIndex + 1), slide.getCustomData().getCustomXmlParts());
+
+        for (int shapeIndex = 0; shapeIndex < slide.getShapes().size(); shapeIndex++) {
+            IShape shape = slide.getShapes().get_Item(shapeIndex);
+            registerCustomXmlParts.accept("Slide " + (slideIndex + 1) + ", shape " + shapeIndex, shape.getCustomData().getCustomXmlParts());
+        }
+    }
+
+    for (Map.Entry<UUID, List<String>> referenceEntry : referencesByItemId.entrySet()) {
+        if (referenceEntry.getValue().size() > 1) {
+            System.out.println("Shared custom XML part: " + referenceEntry.getKey());
+
+            for (String ownerName : referenceEntry.getValue()) {
+                System.out.println("  Referenced by: " + ownerName);
+            }
+        }
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
+This type of audit is useful before modifying or deleting custom XML data in presentations created by external systems, because the same metadata part may participate in more than one relationship.
+
+## **Get Values of Tags**
+
+In slides, a tag corresponds to the `IDocumentProperties.getKeywords()` method. This sample code shows how to get a tag value with Aspose.Slides for Java for [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation):
+
+```java
+import com.aspose.slides.*;
+
+Presentation presentation = new Presentation("presentation.pptx");
+try {
+    String keywords = presentation.getDocumentProperties().getKeywords();
+} finally {
+    presentation.dispose();
 }
 ```
 
 ## **Add Tags to Presentations**
 
-Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items: 
+Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items:
 
-- the name of a custom property - `MyTag` 
-- the value of the custom property - `My Tag Value`
+- the name of a custom property, for example, `MyTag`;
+- the value of the custom property, for example, `My Tag Value`.
 
-If you need to classify some presentations based on a specific rule or property, then you may benefit from adding tags to those presentations. For example, if you want to categorize or put all presentations from North American countries together, you can create a North American tag and then assign the relevant countries (the U.S., Mexico, and Canada) as the values. 
+If you need to classify presentations based on a specific rule or property, you can add tags for that purpose. For example, if you want to categorize presentations from North American countries, you can create a North American tag and assign the relevant country as its value.
 
-This sample code shows you how to add a tag to a [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation) using Aspose.Slides for Java:
+This sample code shows how to add a tag to a [Presentation](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation) using Aspose.Slides for Java:
 
 ```java
 import com.aspose.slides.*;
 
-Presentation pres = new Presentation("pres.pptx");
+Presentation presentation = new Presentation("presentation.pptx");
 try {
-    ITagCollection tags = pres.getCustomData().getTags();
-    pres.getCustomData().getTags().set_Item("MyTag", "My Tag Value");
+    ITagCollection tags = presentation.getCustomData().getTags();
+    tags.set_Item("MyTag", "My Tag Value");
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
-Tags also can be set for [Slide](https://reference.aspose.com/slides/java/com.aspose.slides/ISlide):
+Tags can also be set for a [Slide](https://reference.aspose.com/slides/java/com.aspose.slides/ISlide):
 
 ```java
 import com.aspose.slides.*;
 
-Presentation pres = new Presentation();
+Presentation presentation = new Presentation();
 try {
-    ISlide slide = pres.getSlides().get_Item(0);
+    ISlide slide = presentation.getSlides().get_Item(0);
     slide.getCustomData().getTags().set_Item("tag", "value");
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
-Or any individual [Shape](https://reference.aspose.com/slides/java/com.aspose.slides/IAutoShape):
+Or for an individual [Shape](https://reference.aspose.com/slides/java/com.aspose.slides/IAutoShape):
 
 ```java
 import com.aspose.slides.*;
 
-Presentation pres = new Presentation();
+Presentation presentation = new Presentation();
 try {
-    ISlide slide = pres.getSlides().get_Item(0);
+    ISlide slide = presentation.getSlides().get_Item(0);
     IAutoShape shape = slide.getShapes().addAutoShape(ShapeType.Rectangle, 10, 10, 100, 50);
     shape.getTextFrame().setText("My text");
     shape.getCustomData().getTags().set_Item("tag", "value");
 } finally {
-    if (pres != null) pres.dispose();
+    presentation.dispose();
 }
 ```
 
 ### **Limitations**
 
-Tags added through the custom data tag collection using `getCustomData().getTags()` are stored only within the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
+Tags added through the `getCustomData().getTags()` collection are stored only in the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
 
-**Workaround**: You can store a custom identifier in the object's **Alt Text** (e.g., `shape.setAlternativeText("MyId")`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
+**Workaround**: You can store a custom identifier in the object's **Alt Text** (for example, `shape.setAlternativeText("MyId")`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
 
 ## **FAQ**
 
-### Can I remove all tags from a presentation, slide, or shape in one operation?
+**Can I remove all tags from a presentation, slide, or shape in one operation?**
 
-Yes. The [tag collection](https://reference.aspose.com/slides/java/com.aspose.slides/tagcollection/) supports a [clear](https://reference.aspose.com/slides/java/com.aspose.slides/tagcollection/#clear--) operation that deletes all key–value pairs at once.
+Yes. The [tag collection](https://reference.aspose.com/slides/java/com.aspose.slides/tagcollection/) supports a [clear](https://reference.aspose.com/slides/java/com.aspose.slides/tagcollection/#clear--) operation that deletes all key-value pairs at once.
 
-### How do I delete a single tag by its name without iterating over the whole collection?
+**How do I delete a single tag by its name without iterating over the whole collection?**
 
-Use the [Remove(name)](https://reference.aspose.com/slides/java/com.aspose.slides/tagcollection/#remove-java.lang.String-) operation on [tag collection](https://reference.aspose.com/slides/java/com.aspose.slides/tagcollection/) to delete the tag by its key.
+Use [remove(name)](https://reference.aspose.com/slides/java/com.aspose.slides/tagcollection/#remove-java.lang.String-) on the [tag collection](https://reference.aspose.com/slides/java/com.aspose.slides/tagcollection/) to delete the tag by its key.
 
-### How can I retrieve the complete list of tag names for analytics or filtering?
+**How can I retrieve the complete list of tag names for analytics or filtering?**
 
 Use [getNamesOfTags](https://reference.aspose.com/slides/java/com.aspose.slides/tagcollection/#getNamesOfTags--) on the [tag collection](https://reference.aspose.com/slides/java/com.aspose.slides/tagcollection/); it returns an array of all tag names.
+
+**How can I find all custom XML parts regardless of where they are stored?**
+
+Use [`Presentation.getAllCustomXmlParts()`](https://reference.aspose.com/slides/java/com.aspose.slides/Presentation#getAllCustomXmlParts--) to retrieve all custom XML parts in the presentation.
+
+**Should I use `getXmlAsString`/`setXmlAsString` or `getXmlData`/`setXmlData` to update a custom XML part?**
+
+Use `getXmlAsString` and `setXmlAsString` when the application works with UTF-8 XML text. Use `getXmlData` and `setXmlData` when the XML is already available as a byte array or when binary-oriented processing is more convenient. Both representations refer to the XML content of the same custom XML part.

--- a/en/net/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
+++ b/en/net/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
@@ -8,6 +8,10 @@ keywords:
 - document properties
 - tag
 - custom data
+- custom XML
+- custom XML part
+- XML metadata
+- ItemId
 - add tag
 - pair values
 - PowerPoint
@@ -15,105 +19,371 @@ keywords:
 - .NET
 - C#
 - Aspose.Slides
-description: "Learn how to add, read, update, and remove tags & custom data in Aspose.Slides for .NET, with examples for PowerPoint and OpenDocument presentations."
+description: "Learn how to manage tags and custom XML data in PowerPoint presentations with Aspose.Slides for .NET, including adding, reading, updating, auditing, and removing custom XML parts."
 ---
 
 ## **Overview**
 
-This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. It briefly outlines how data is stored in PPTX files, notes that presentation-specific data can exist as tags and custom XML parts, and describes tags as key-value string pairs.
+This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. Presentation-specific data can be stored as tags or custom XML parts. Tags are simple key-value string pairs, while custom XML parts can store structured metadata and application-specific XML payloads.
 
-It also shows how to read tag values and how to add tags to a presentation, an individual slide, or a shape. In addition, the article covers common tag-management tasks such as clearing all tags, removing a tag by name, and retrieving the list of tag names.
+Aspose.Slides provides APIs for adding, reading, updating, auditing, and removing custom XML parts at the presentation, slide, and shape levels. Custom XML parts are useful for integrations that store information such as document-management identifiers, workflow state, compliance metadata, template-binding data, or other structured application data inside a presentation.
 
 ## **Data Storage in Presentation Files**
 
-PPTX files—items with the .pptx extension—are stored in the PresentationML format, which is part of the Office Open XML specification. The Office Open XML format defines the structure for data contained in presentations. 
+PPTX files—files with the `.pptx` extension—are stored in the PresentationML format, which is part of the Office Open XML specification. Office Open XML defines the package structure and relationships used to store presentation content and related data.
 
-With a *slide* being one of the elements in presentations, a *slide part* contains the content of a single slide. A slide part is allowed to have explicit relationships to many parts—such as User Defined Tags—defined by ISO/IEC 29500. 
+A presentation contains multiple parts connected by relationships. For example, a slide part contains the content of a single slide and can have explicit relationships to other parts defined by ISO/IEC 29500.
 
-Custom data (specific to a presentation) or user can exist as tags ([ITagCollection](https://reference.aspose.com/slides/net/aspose.slides/itagcollection)) and CustomXmlParts ([ICustomXmlPartCollection](https://reference.aspose.com/slides/net/aspose.slides/icustomxmlpartcollection)). 
+Custom data can be stored as tags ([ITagCollection](https://reference.aspose.com/slides/net/aspose.slides/itagcollection)) or custom XML parts ([ICustomXmlPartCollection](https://reference.aspose.com/slides/net/aspose.slides/icustomxmlpartcollection)). Both are available through the [`ICustomData`](https://reference.aspose.com/slides/net/aspose.slides/icustomdata/) interface.
 
-{{% alert color="primary" %}} 
+{{% alert color="primary" %}}
 
-Tags are essentially string-key pair values. 
+Tags store simple string key-value pairs. Custom XML parts store structured XML data and can be associated with a presentation, slide, or shape.
 
-{{% /alert %}} 
+{{% /alert %}}
+
+## **Work with Custom XML Parts**
+
+The [`ICustomData.CustomXmlParts`](https://reference.aspose.com/slides/net/aspose.slides/icustomdata/customxmlparts/) property returns the collection of custom XML parts associated with a particular presentation object. For example:
+
+- `presentation.CustomData.CustomXmlParts` contains custom XML parts associated with the presentation itself.
+- `slide.CustomData.CustomXmlParts` contains custom XML parts associated with a specific slide.
+- `shape.CustomData.CustomXmlParts` contains custom XML parts associated with a specific shape.
+
+Use [`Presentation.AllCustomXmlParts`](https://reference.aspose.com/slides/net/aspose.slides/presentation/allcustomxmlparts/) when you need to inspect all custom XML parts in the presentation regardless of where they are associated.
+
+### **Add a Custom XML Part to a Presentation**
+
+Use [`ICustomXmlPartCollection.Add`](https://reference.aspose.com/slides/net/aspose.slides/icustomxmlpartcollection/add/) to add XML data to a custom XML part collection. The XML must be valid and non-empty.
+
+The following example adds structured metadata to the presentation-level custom data collection:
+
+```csharp
+using System;
+using Aspose.Slides;
+
+var customXmlContent =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+    "<metadata xmlns=\"urn:example:metadata\">" +
+        "<documentId>DOC-1001</documentId>" +
+        "<workflowState>Draft</workflowState>" +
+    "</metadata>";
+
+using var presentation = new Presentation();
+var customXmlPart = presentation.CustomData.CustomXmlParts.Add(customXmlContent);
+
+// Add assigns an identifier automatically. Set a specific GUID only when required.
+customXmlPart.ItemId = Guid.NewGuid();
+
+presentation.Save("presentation_with_custom_xml.pptx", SaveFormat.Pptx);
+```
+
+The `Add` method can also accept XML as a byte array or stream, which is useful when XML content is already available in binary form.
+
+### **Add a Custom XML Part to a Slide or Shape**
+
+Custom XML data can be associated with a specific slide or shape instead of the whole presentation. This is useful when metadata describes only one object, such as a template key, external record identifier, or binding information.
+
+The following example adds one custom XML part to a slide and another to a shape:
+
+```csharp
+using Aspose.Slides;
+
+using var presentation = new Presentation();
+var slide = presentation.Slides[0];
+
+slide.CustomData.CustomXmlParts.Add(
+    "<slideMetadata xmlns=\"urn:example:slides\">" +
+        "<templateKey>TitleSlide</templateKey>" +
+    "</slideMetadata>");
+
+var shape = slide.Shapes.AddAutoShape(ShapeType.Rectangle, 50, 50, 250, 80);
+
+shape.TextFrame.Text = "Customer data";
+shape.CustomData.CustomXmlParts.Add(
+    "<shapeMetadata xmlns=\"urn:example:shapes\">" +
+        "<recordId>CRM-4281</recordId>" +
+    "</shapeMetadata>");
+
+presentation.Save("object_custom_xml.pptx", SaveFormat.Pptx);
+```
+
+The level at which a part is added determines which object's `CustomData.CustomXmlParts` collection contains the relationship to that part. Presentation-level data is appropriate for document-wide metadata, slide-level data for information that belongs to a particular slide, and shape-level data for metadata tied to an individual shape.
+
+### **List and Audit All Custom XML Parts**
+
+Use [`Presentation.AllCustomXmlParts`](https://reference.aspose.com/slides/net/aspose.slides/presentation/allcustomxmlparts/) to retrieve all custom XML parts from a presentation. Each [`ICustomXmlPart`](https://reference.aspose.com/slides/net/aspose.slides/icustomxmlpart/) exposes its identifier, XML content, and associated namespace schemas.
+
+The following example lists all custom XML parts and their namespace schemas:
+
+```csharp
+using System;
+using Aspose.Slides;
+
+using var presentation = new Presentation("presentation.pptx");
+
+foreach (var customXmlPart in presentation.AllCustomXmlParts)
+{
+    Console.WriteLine("ItemId: " + customXmlPart.ItemId);
+    Console.WriteLine("XML:");
+    Console.WriteLine(customXmlPart.XmlAsString);
+
+    foreach (var namespaceSchema in customXmlPart.NamespaceSchemas)
+    {
+        Console.WriteLine("Namespace schema: " + namespaceSchema);
+    }
+
+    Console.WriteLine();
+}
+```
+
+[`ICustomXmlPart.NamespaceSchemas`](https://reference.aspose.com/slides/net/aspose.slides/icustomxmlpart/namespaceschemas/) returns the XML schemas associated with the custom XML part. This information can be useful when auditing presentations that contain XML produced by external systems.
+
+### **Read and Update XML Content and ItemId**
+
+Use [`ICustomXmlPart.XmlAsString`](https://reference.aspose.com/slides/net/aspose.slides/icustomxmlpart/xmlasstring/) to work with XML as a UTF-8 string, or [`ICustomXmlPart.XmlData`](https://reference.aspose.com/slides/net/aspose.slides/icustomxmlpart/xmldata/) to work with the raw XML bytes. Both properties can be read and updated.
+
+The [`ICustomXmlPart.ItemId`](https://reference.aspose.com/slides/net/aspose.slides/icustomxmlpart/itemid/) property contains the GUID that identifies the custom XML part in the Office Open XML document. It can also be changed when an integration requires a new identifier.
+
+The following example updates the XML content and the identifier:
+
+```csharp
+using System;
+using System.Text;
+using Aspose.Slides;
+
+using var presentation = new Presentation("presentation.pptx");
+var customXmlPart = presentation.AllCustomXmlParts[0];
+
+// Read the current XML as text.
+var currentXmlContent = customXmlPart.XmlAsString;
+Console.WriteLine(currentXmlContent);
+
+// Update the XML as a UTF-8 string.
+customXmlPart.XmlAsString =
+    "<metadata xmlns=\"urn:example:metadata\">" +
+        "<documentId>DOC-1001</documentId>" +
+        "<workflowState>Approved</workflowState>" +
+    "</metadata>";
+
+// XmlData provides the same XML content as raw bytes.
+var customXmlData = customXmlPart.XmlData;
+Console.WriteLine(Encoding.UTF8.GetString(customXmlData));
+
+// Replace the identifier when required by the integration.
+customXmlPart.ItemId = Guid.NewGuid();
+
+presentation.Save("updated_custom_xml.pptx", SaveFormat.Pptx);
+```
+
+When assigning `XmlAsString` or `XmlData`, provide valid, non-empty XML. Use one representation or the other depending on whether the application works primarily with strings or byte data.
+
+### **Remove a Custom XML Part**
+
+Aspose.Slides provides several ways to remove custom XML data:
+
+- [`ICustomXmlPart.Remove`](https://reference.aspose.com/slides/net/aspose.slides/icustomxmlpart/remove/) removes the custom XML part from the presentation.
+- [`ICustomXmlPartCollection.Remove`](https://reference.aspose.com/slides/net/aspose.slides/icustomxmlpartcollection/remove/) removes a specific part from a custom XML part collection.
+- [`ICustomXmlPartCollection.RemoveAt`](https://reference.aspose.com/slides/net/aspose.slides/icustomxmlpartcollection/removeat/) removes the part at a specified collection index.
+- [`ICustomXmlPartCollection.Clear`](https://reference.aspose.com/slides/net/aspose.slides/icustomxmlpartcollection/clear/) removes all parts from a specific collection.
+
+The following example removes one presentation-level custom XML part by reference:
+
+```csharp
+using Aspose.Slides;
+
+using var presentation = new Presentation("presentation.pptx");
+var customXmlParts = presentation.CustomData.CustomXmlParts;
+
+if (customXmlParts.Count > 0)
+{
+    var customXmlPart = customXmlParts[0];
+    customXmlParts.Remove(customXmlPart);
+}
+
+presentation.Save("custom_xml_removed.pptx", SaveFormat.Pptx);
+```
+
+If you already have an `ICustomXmlPart` and want to remove that part from the presentation rather than addressing a particular collection, call `customXmlPart.Remove()`.
+
+You can also remove an item by index:
+
+```csharp
+presentation.CustomData.CustomXmlParts.RemoveAt(0);
+```
+
+### **Clear All Custom XML Parts from a Collection**
+
+Use `Clear` when all custom XML parts associated with a particular presentation object should be removed.
+
+```csharp
+using Aspose.Slides;
+
+using var presentation = new Presentation("presentation.pptx");
+presentation.Slides[0].CustomData.CustomXmlParts.Clear();
+
+presentation.Save("slide_custom_xml_cleared.pptx", SaveFormat.Pptx);
+```
+
+`Clear` affects only the selected collection. For example, clearing a slide's collection does not clear the presentation-level or shape-level collections.
+
+To remove every custom XML part in the presentation, iterate through `AllCustomXmlParts` and remove each part:
+
+```csharp
+using Aspose.Slides;
+
+using var presentation = new Presentation("presentation.pptx");
+
+foreach (var customXmlPart in presentation.AllCustomXmlParts)
+{
+    customXmlPart.Remove();
+}
+
+presentation.Save("all_custom_xml_removed.pptx", SaveFormat.Pptx);
+```
+
+### **Handle Linked or Shared Custom XML Parts**
+
+In an Office Open XML presentation, the same custom XML part can be referenced from more than one presentation object. For example, an existing file can contain relationships from multiple slides or shapes to the same underlying custom XML part.
+
+A shared part should be treated as one data object with multiple references:
+
+- Updating its `XmlAsString`, `XmlData`, or `ItemId` changes the underlying custom XML part, so the change applies wherever that part is referenced.
+- `ItemId` can be used to identify the same custom XML part while auditing object-level collections.
+- Removing a part from a specific `CustomXmlParts` collection removes it from that collection. Use `ICustomXmlPart.Remove()` when the part itself should be removed from the presentation.
+- Before deleting or replacing a shared part, inspect the object-level collections to determine whether other slides or shapes still reference it.
+
+The `Add` overloads create a new custom XML part from XML content; they do not accept an existing `ICustomXmlPart`. Therefore, shared relationships are most commonly encountered when loading presentations that already contain them.
+
+The following example audits presentation-, slide-, and shape-level collections by `ItemId` and reports parts referenced from more than one place:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using Aspose.Slides;
+
+using var presentation = new Presentation("presentation.pptx");
+var referencesByItemId = new Dictionary<Guid, List<string>>();
+
+var registerCustomXmlParts = (string ownerName, ICustomXmlPartCollection customXmlParts) =>
+    {
+        foreach (var customXmlPart in customXmlParts)
+        {
+            if (!referencesByItemId.ContainsKey(customXmlPart.ItemId))
+            {
+                referencesByItemId[customXmlPart.ItemId] = new List<string>();
+            }
+
+            referencesByItemId[customXmlPart.ItemId].Add(ownerName);
+        }
+    };
+
+registerCustomXmlParts("Presentation", presentation.CustomData.CustomXmlParts);
+
+for (var slideIndex = 0; slideIndex < presentation.Slides.Count; slideIndex++)
+{
+    var slide = presentation.Slides[slideIndex];
+    registerCustomXmlParts("Slide " + (slideIndex + 1), slide.CustomData.CustomXmlParts);
+
+    for (var shapeIndex = 0; shapeIndex < slide.Shapes.Count; shapeIndex++)
+    {
+        var shape = slide.Shapes[shapeIndex];
+        registerCustomXmlParts("Slide " + (slideIndex + 1) + ", shape " + shapeIndex, shape.CustomData.CustomXmlParts);
+    }
+}
+
+foreach (var referenceEntry in referencesByItemId)
+{
+    if (referenceEntry.Value.Count > 1)
+    {
+        Console.WriteLine("Shared custom XML part: " + referenceEntry.Key);
+
+        foreach (var ownerName in referenceEntry.Value)
+        {
+            Console.WriteLine("  Referenced by: " + ownerName);
+        }
+    }
+}
+```
+
+This type of audit is useful before modifying or deleting custom XML data in presentations created by external systems, because the same metadata part may participate in more than one relationship.
 
 ## **Get Values of Tags**
 
-In slides, a tag corresponds to the IDocumentProperties.Keywords property. This sample code shows you how to get a tag’s value with Aspose.Slides for .NET for [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation):
+In slides, a tag corresponds to the `IDocumentProperties.Keywords` property. This sample code shows how to get a tag value with Aspose.Slides for .NET for [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation):
 
-```c#
+```csharp
 using Aspose.Slides;
 
-using (Presentation pres = new Presentation("pres.pptx"))
-{
-   string keywords = pres.DocumentProperties.Keywords;
-}
+using var presentation = new Presentation("presentation.pptx");
+var keywords = presentation.DocumentProperties.Keywords;
 ```
 
 ## **Add Tags to Presentations**
 
-Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items: 
+Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items:
 
-- the name of a custom property - `MyTag` 
-- the value of the custom property - `My Tag Value`
+- the name of a custom property, for example, `MyTag`;
+- the value of the custom property, for example, `My Tag Value`.
 
-If you need to classify some presentations based on a specific rule or property, then you may benefit from adding tags to those presentations. For example, if you want to categorize or put all presentations from North American countries together, you can create a North American tag and then assign the relevant countries (the U.S., Mexico, and Canada) as the values. 
+If you need to classify presentations based on a specific rule or property, you can add tags for that purpose. For example, if you want to categorize presentations from North American countries, you can create a North American tag and assign the relevant country as its value.
 
-This sample code shows you how to add a tag to a [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation) using Aspose.Slides for .NET:
-
-```c#
-using Aspose.Slides;
-
-using (Presentation pres = new Presentation("pres.pptx"))
-{
-   ITagCollection tags = pres.CustomData.Tags;
-   pres.CustomData.Tags["MyTag"] = "My Tag Value";
-}
-```
-
-Tags also can be set for [Slide](https://reference.aspose.com/slides/net/aspose.slides/slide):
+This sample code shows how to add a tag to a [Presentation](https://reference.aspose.com/slides/net/aspose.slides/presentation) using Aspose.Slides for .NET:
 
 ```csharp
 using Aspose.Slides;
 
-using(Presentation pres = new Presentation())
-{
-    ISlide slide = pres.Slides[0];
-    slide.CustomData.Tags["tag"] = "value";
-}
+using var presentation = new Presentation("presentation.pptx");
+var tags = presentation.CustomData.Tags;
+tags["MyTag"] = "My Tag Value";
 ```
 
-Or any individual [Shape](https://reference.aspose.com/slides/net/aspose.slides/shape):
+Tags can also be set for a [Slide](https://reference.aspose.com/slides/net/aspose.slides/slide):
 
 ```csharp
 using Aspose.Slides;
 
-using(Presentation pres = new Presentation())
-{
-    ISlide slide = pres.Slides[0];
-    IAutoShape shape = slide.Shapes.AddAutoShape(ShapeType.Rectangle, 10, 10, 100, 50);
-    shape.TextFrame.Text = "My text";
-    shape.CustomData.Tags["tag"] = "value";
-}
+using var presentation = new Presentation();
+var slide = presentation.Slides[0];
+slide.CustomData.Tags["tag"] = "value";
+```
+
+Or for an individual [Shape](https://reference.aspose.com/slides/net/aspose.slides/shape):
+
+```csharp
+using Aspose.Slides;
+
+using var presentation = new Presentation();
+var slide = presentation.Slides[0];
+var shape = slide.Shapes.AddAutoShape(ShapeType.Rectangle, 10, 10, 100, 50);
+shape.TextFrame.Text = "My text";
+shape.CustomData.Tags["tag"] = "value";
 ```
 
 ### **Limitations**
 
-Tags added via the `CustomData.Tags` collection are stored only within the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
+Tags added through the `CustomData.Tags` collection are stored only in the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
 
-**Workaround**: You can store a custom identifier in the object's **Alt Text** (e.g., `shape.AlternativeText = "MyId"`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
+**Workaround**: You can store a custom identifier in the object's **Alt Text** (for example, `shape.AlternativeText = "MyId"`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
 
 ## **FAQ**
 
-### Can I remove all tags from a presentation, slide, or shape in one operation?
+**Can I remove all tags from a presentation, slide, or shape in one operation?**
 
-Yes. The [tag collection](https://reference.aspose.com/slides/net/aspose.slides/tagcollection/) supports a [clear](https://reference.aspose.com/slides/net/aspose.slides/tagcollection/clear/) operation that deletes all key–value pairs at once.
+Yes. The [tag collection](https://reference.aspose.com/slides/net/aspose.slides/tagcollection/) supports a [Clear](https://reference.aspose.com/slides/net/aspose.slides/tagcollection/clear/) operation that deletes all key-value pairs at once.
 
-### How do I delete a single tag by its name without iterating over the whole collection?
+**How do I delete a single tag by its name without iterating over the whole collection?**
 
-Use the [Remove(name)](https://reference.aspose.com/slides/net/aspose.slides/tagcollection/remove/) operation on [TagCollection](https://reference.aspose.com/slides/net/aspose.slides/tagcollection/) to delete the tag by its key.
+Use [Remove(name)](https://reference.aspose.com/slides/net/aspose.slides/tagcollection/remove/) on [TagCollection](https://reference.aspose.com/slides/net/aspose.slides/tagcollection/) to delete the tag by its key.
 
-### How can I retrieve the complete list of tag names for analytics or filtering?
+**How can I retrieve the complete list of tag names for analytics or filtering?**
 
 Use [GetNamesOfTags](https://reference.aspose.com/slides/net/aspose.slides/tagcollection/getnamesoftags/) on the [tag collection](https://reference.aspose.com/slides/net/aspose.slides/tagcollection/); it returns an array of all tag names.
+
+**How can I find all custom XML parts regardless of where they are stored?**
+
+Use [`Presentation.AllCustomXmlParts`](https://reference.aspose.com/slides/net/aspose.slides/presentation/allcustomxmlparts/) to retrieve all custom XML parts in the presentation.
+
+**Should I use `XmlAsString` or `XmlData` to update a custom XML part?**
+
+Use `XmlAsString` when the application works with UTF-8 XML text. Use `XmlData` when the XML is already available as a byte array or when binary-oriented processing is more convenient. Both properties represent the XML content of the same custom XML part.

--- a/en/nodejs-java/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
+++ b/en/nodejs-java/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
@@ -8,6 +8,10 @@ keywords:
 - document properties
 - tag
 - custom data
+- custom XML
+- custom XML part
+- XML metadata
+- ItemId
 - add tag
 - pair values
 - PowerPoint
@@ -15,125 +19,416 @@ keywords:
 - Node.js
 - JavaScript
 - Aspose.Slides
-description: "Learn how to add, read, update, and remove tags & custom data in Aspose.Slides for Node.js, with examples for PowerPoint and OpenDocument presentations."
+description: "Learn how to manage tags and custom XML data in PowerPoint presentations with Aspose.Slides for Node.js via Java, including adding, reading, updating, auditing, and removing custom XML parts."
 ---
 
 ## **Overview**
 
-This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. It briefly outlines how data is stored in PPTX files, notes that presentation-specific data can exist as tags and custom XML parts, and describes tags as key-value string pairs.
+This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. Presentation-specific data can be stored as tags or custom XML parts. Tags are simple key-value string pairs, while custom XML parts can store structured metadata and application-specific XML payloads.
 
-It also shows how to read tag values and how to add tags to a presentation, an individual slide, or a shape. In addition, the article covers common tag-management tasks such as clearing all tags, removing a tag by name, and retrieving the list of tag names.
+Aspose.Slides provides APIs for adding, reading, updating, auditing, and removing custom XML parts at the presentation, slide, and shape levels. Custom XML parts are useful for integrations that store information such as document-management identifiers, workflow state, compliance metadata, template-binding data, or other structured application data inside a presentation.
 
 ## **Data Storage in Presentation Files**
 
-PPTX files—items with the .pptx extension—are stored in the PresentationML format, which is part of the Office Open XML specification. The Office Open XML format defines the structure for data contained in presentations. 
+PPTX files—files with the `.pptx` extension—are stored in the PresentationML format, which is part of the Office Open XML specification. Office Open XML defines the package structure and relationships used to store presentation content and related data.
 
-With a *slide* being one of the elements in presentations, a *slide part* contains the content of a single slide. A slide part is allowed to have explicit relationships to many parts—such as User Defined Tags—defined by ISO/IEC 29500. 
+A presentation contains multiple parts connected by relationships. For example, a slide part contains the content of a single slide and can have explicit relationships to other parts defined by ISO/IEC 29500.
 
-Custom data (specific to a presentation) or user can exist as tags ([TagCollection](https://reference.aspose.com/slides/nodejs-java/aspose.slides/TagCollection)) and CustomXmlParts ([CustomXmlPartCollection](https://reference.aspose.com/slides/nodejs-java/aspose.slides/CustomXmlPartCollection)).
+Custom data can be stored as tags ([TagCollection](https://reference.aspose.com/slides/nodejs-java/aspose.slides/tagcollection/)) or custom XML parts ([CustomXmlPartCollection](https://reference.aspose.com/slides/nodejs-java/aspose.slides/customxmlpartcollection/)). Both are available through the [`CustomData`](https://reference.aspose.com/slides/nodejs-java/aspose.slides/customdata/) class.
 
-{{% alert color="primary" %}} 
+{{% alert color="primary" %}}
 
-Tags are essentially string-key pair values. 
+Tags store simple string key-value pairs. Custom XML parts store structured XML data and can be associated with a presentation, slide, or shape.
 
-{{% /alert %}} 
+{{% /alert %}}
 
-## **Getting the Values for Tags**
+## **Work with Custom XML Parts**
 
-In slides, a tag corresponds to the [DocumentProperties.getKeywords()](https://reference.aspose.com/slides/nodejs-java/aspose.slides/DocumentProperties#getKeywords--) and [DocumentProperties.setKeywords()](https://reference.aspose.com/slides/nodejs-java/aspose.slides/DocumentProperties#setKeywords-java.lang.String-) methods. This sample code shows you how to get a tag’s value with Aspose.Slides for Node.js via Java for [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Presentation):
+The `getCustomXmlParts()` method of [`CustomData`](https://reference.aspose.com/slides/nodejs-java/aspose.slides/customdata/) returns the collection of custom XML parts associated with a particular presentation object. For example:
+
+- `presentation.getCustomData().getCustomXmlParts()` contains custom XML parts associated with the presentation itself.
+- `slide.getCustomData().getCustomXmlParts()` contains custom XML parts associated with a specific slide.
+- `shape.getCustomData().getCustomXmlParts()` contains custom XML parts associated with a specific shape.
+
+Use [`Presentation.getAllCustomXmlParts()`](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/) when you need to inspect all custom XML parts in the presentation regardless of where they are associated.
+
+### **Add a Custom XML Part to a Presentation**
+
+Use the `add` method of [`CustomXmlPartCollection`](https://reference.aspose.com/slides/nodejs-java/aspose.slides/customxmlpartcollection/) to add XML data to a custom XML part collection. The XML must be valid and non-empty.
+
+The following example adds structured metadata to the presentation-level custom data collection:
 
 ```javascript
-var aspose = aspose || {};
-aspose.slides = require("aspose.slides.via.java");
+const aspose = { slides: require("aspose.slides.via.java") };
+const java = require("java");
 
-var pres = new aspose.slides.Presentation("pres.pptx");
+const customXmlContent =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<metadata xmlns="urn:example:metadata">' +
+        '<documentId>DOC-1001</documentId>' +
+        '<workflowState>Draft</workflowState>' +
+    '</metadata>';
+
+const presentation = new aspose.slides.Presentation();
 try {
-    var keywords = pres.getDocumentProperties().getKeywords();
+    const customXmlPart = presentation.getCustomData().getCustomXmlParts().add(customXmlContent);
+
+    // add assigns an identifier automatically. Set a specific UUID only when required.
+    const itemId = java.callStaticMethodSync("java.util.UUID", "randomUUID");
+    customXmlPart.setItemId(itemId);
+
+    presentation.save("presentation_with_custom_xml.pptx", aspose.slides.SaveFormat.Pptx);
 } finally {
-    if (pres != null) {
-        pres.dispose();
-    }
+    presentation.dispose();
 }
 ```
 
-## **Adding Tags to Presentations**
+The `add` method can also accept XML as a byte array, which is useful when XML content is already available in binary form.
 
-Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items: 
+### **Add a Custom XML Part to a Slide or Shape**
 
-- the name of a custom property - `MyTag` 
-- the value of the custom property - `My Tag Value`
+Custom XML data can be associated with a specific slide or shape instead of the whole presentation. This is useful when metadata describes only one object, such as a template key, external record identifier, or binding information.
 
-If you need to classify some presentations based on a specific rule or property, then you may benefit from adding tags to those presentations. For example, if you want to categorize or put all presentations from North American countries together, you can create a North American tag and then assign the relevant countries (the U.S., Mexico, and Canada) as the values. 
-
-This sample code shows you how to add a tag to a [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Presentation) using Aspose.Slides for Node.js via Java:
+The following example adds one custom XML part to a slide and another to a shape:
 
 ```javascript
-var aspose = aspose || {};
-aspose.slides = require("aspose.slides.via.java");
+const aspose = { slides: require("aspose.slides.via.java") };
 
-var pres = new aspose.slides.Presentation("pres.pptx");
+const presentation = new aspose.slides.Presentation();
 try {
-    var tags = pres.getCustomData().getTags();
-    pres.getCustomData().getTags().set_Item("MyTag", "My Tag Value");
+    const slide = presentation.getSlides().get_Item(0);
+
+    slide.getCustomData().getCustomXmlParts().add(
+        '<slideMetadata xmlns="urn:example:slides">' +
+            '<templateKey>TitleSlide</templateKey>' +
+        '</slideMetadata>');
+
+    const shape = slide.getShapes().addAutoShape(aspose.slides.ShapeType.Rectangle, 50, 50, 250, 80);
+
+    shape.getTextFrame().setText("Customer data");
+    shape.getCustomData().getCustomXmlParts().add(
+        '<shapeMetadata xmlns="urn:example:shapes">' +
+            '<recordId>CRM-4281</recordId>' +
+        '</shapeMetadata>');
+
+    presentation.save("object_custom_xml.pptx", aspose.slides.SaveFormat.Pptx);
 } finally {
-    if (pres != null) {
-        pres.dispose();
-    }
+    presentation.dispose();
 }
 ```
 
-Tags also can be set for [Slide](https://reference.aspose.com/slides/nodejs-java/aspose.slides/Slide):
+The level at which a part is added determines which object's `getCustomData().getCustomXmlParts()` collection contains the relationship to that part. Presentation-level data is appropriate for document-wide metadata, slide-level data for information that belongs to a particular slide, and shape-level data for metadata tied to an individual shape.
+
+### **List and Audit All Custom XML Parts**
+
+Use [`Presentation.getAllCustomXmlParts()`](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/) to retrieve all custom XML parts from a presentation. Each [`CustomXmlPart`](https://reference.aspose.com/slides/nodejs-java/aspose.slides/customxmlpart/) exposes its identifier, XML content, and associated namespace schemas.
+
+The following example lists all custom XML parts and their namespace schemas:
 
 ```javascript
-var aspose = aspose || {};
-aspose.slides = require("aspose.slides.via.java");
+const aspose = { slides: require("aspose.slides.via.java") };
 
-var pres = new aspose.slides.Presentation();
+const presentation = new aspose.slides.Presentation("presentation.pptx");
 try {
-    var slide = pres.getSlides().get_Item(0);
+    const customXmlParts = presentation.getAllCustomXmlParts();
+
+    for (let partIndex = 0; partIndex < customXmlParts.length; partIndex++) {
+        const customXmlPart = customXmlParts[partIndex];
+
+        console.log("ItemId: " + customXmlPart.getItemId());
+        console.log("XML:");
+        console.log(customXmlPart.getXmlAsString());
+
+        const namespaceSchemas = customXmlPart.getNamespaceSchemas();
+        for (let schemaIndex = 0; schemaIndex < namespaceSchemas.length; schemaIndex++) {
+            console.log("Namespace schema: " + namespaceSchemas[schemaIndex]);
+        }
+
+        console.log();
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
+[`CustomXmlPart.getNamespaceSchemas()`](https://reference.aspose.com/slides/nodejs-java/aspose.slides/customxmlpart/) returns the XML schemas associated with the custom XML part. This information can be useful when auditing presentations that contain XML produced by external systems.
+
+### **Read and Update XML Content and ItemId**
+
+Use `getXmlAsString()` and `setXmlAsString()` from [`CustomXmlPart`](https://reference.aspose.com/slides/nodejs-java/aspose.slides/customxmlpart/) to work with XML as a UTF-8 string, or `getXmlData()` and `setXmlData()` to work with the raw XML bytes.
+
+The `getItemId()` method returns the UUID that identifies the custom XML part in the Office Open XML document. Use `setItemId()` when an integration requires a new identifier.
+
+The following example updates the XML content and the identifier:
+
+```javascript
+const aspose = { slides: require("aspose.slides.via.java") };
+const java = require("java");
+
+const presentation = new aspose.slides.Presentation("presentation.pptx");
+try {
+    const customXmlPart = presentation.getAllCustomXmlParts()[0];
+
+    // Read the current XML as text.
+    const currentXmlContent = customXmlPart.getXmlAsString();
+    console.log(currentXmlContent);
+
+    // Update the XML as a UTF-8 string.
+    customXmlPart.setXmlAsString(
+        '<metadata xmlns="urn:example:metadata">' +
+            '<documentId>DOC-1001</documentId>' +
+            '<workflowState>Approved</workflowState>' +
+        '</metadata>');
+
+    // getXmlData provides the same XML content as raw bytes.
+    const customXmlData = customXmlPart.getXmlData();
+    console.log(Buffer.from(customXmlData).toString("utf8"));
+
+    // Replace the identifier when required by the integration.
+    const itemId = java.callStaticMethodSync("java.util.UUID", "randomUUID");
+    customXmlPart.setItemId(itemId);
+
+    presentation.save("updated_custom_xml.pptx", aspose.slides.SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+When calling `setXmlAsString` or `setXmlData`, provide valid, non-empty XML. Use one representation or the other depending on whether the application works primarily with strings or byte data.
+
+### **Remove a Custom XML Part**
+
+Aspose.Slides provides several ways to remove custom XML data:
+
+- [`CustomXmlPart.remove`](https://reference.aspose.com/slides/nodejs-java/aspose.slides/customxmlpart/) removes the custom XML part from the presentation.
+- [`CustomXmlPartCollection.remove`](https://reference.aspose.com/slides/nodejs-java/aspose.slides/customxmlpartcollection/) removes a specific part from a custom XML part collection.
+- [`CustomXmlPartCollection.removeAt`](https://reference.aspose.com/slides/nodejs-java/aspose.slides/customxmlpartcollection/) removes the part at a specified collection index.
+- [`CustomXmlPartCollection.clear`](https://reference.aspose.com/slides/nodejs-java/aspose.slides/customxmlpartcollection/) removes all parts from a specific collection.
+
+The following example removes one presentation-level custom XML part by reference:
+
+```javascript
+const aspose = { slides: require("aspose.slides.via.java") };
+
+const presentation = new aspose.slides.Presentation("presentation.pptx");
+try {
+    const customXmlParts = presentation.getCustomData().getCustomXmlParts();
+
+    if (customXmlParts.size() > 0) {
+        const customXmlPart = customXmlParts.get_Item(0);
+        customXmlParts.remove(customXmlPart);
+    }
+
+    presentation.save("custom_xml_removed.pptx", aspose.slides.SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+If you already have a `CustomXmlPart` and want to remove that part from the presentation rather than addressing a particular collection, call `customXmlPart.remove()`.
+
+You can also remove an item by index:
+
+```javascript
+presentation.getCustomData().getCustomXmlParts().removeAt(0);
+```
+
+### **Clear All Custom XML Parts from a Collection**
+
+Use `clear` when all custom XML parts associated with a particular presentation object should be removed.
+
+```javascript
+const aspose = { slides: require("aspose.slides.via.java") };
+
+const presentation = new aspose.slides.Presentation("presentation.pptx");
+try {
+    presentation.getSlides().get_Item(0).getCustomData().getCustomXmlParts().clear();
+
+    presentation.save("slide_custom_xml_cleared.pptx", aspose.slides.SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+`clear` affects only the selected collection. For example, clearing a slide's collection does not clear the presentation-level or shape-level collections.
+
+To remove every custom XML part in the presentation, iterate through `getAllCustomXmlParts()` and remove each part:
+
+```javascript
+const aspose = { slides: require("aspose.slides.via.java") };
+
+const presentation = new aspose.slides.Presentation("presentation.pptx");
+try {
+    const customXmlParts = presentation.getAllCustomXmlParts();
+
+    for (let partIndex = 0; partIndex < customXmlParts.length; partIndex++) {
+        customXmlParts[partIndex].remove();
+    }
+
+    presentation.save("all_custom_xml_removed.pptx", aspose.slides.SaveFormat.Pptx);
+} finally {
+    presentation.dispose();
+}
+```
+
+### **Handle Linked or Shared Custom XML Parts**
+
+In an Office Open XML presentation, the same custom XML part can be referenced from more than one presentation object. For example, an existing file can contain relationships from multiple slides or shapes to the same underlying custom XML part.
+
+A shared part should be treated as one data object with multiple references:
+
+- Updating it with `setXmlAsString`, `setXmlData`, or `setItemId` changes the underlying custom XML part, so the change applies wherever that part is referenced.
+- `getItemId()` can be used to identify the same custom XML part while auditing object-level collections.
+- Removing a part from a specific `getCustomXmlParts()` collection removes it from that collection. Use `CustomXmlPart.remove()` when the part itself should be removed from the presentation.
+- Before deleting or replacing a shared part, inspect the object-level collections to determine whether other slides or shapes still reference it.
+
+The `add` overloads create a new custom XML part from XML content; they do not accept an existing `CustomXmlPart`. Therefore, shared relationships are most commonly encountered when loading presentations that already contain them.
+
+The following example audits presentation-, slide-, and shape-level collections by `ItemId` and reports parts referenced from more than one place:
+
+```javascript
+const aspose = { slides: require("aspose.slides.via.java") };
+
+const presentation = new aspose.slides.Presentation("presentation.pptx");
+try {
+    const referencesByItemId = new Map();
+
+    const registerCustomXmlParts = (ownerName, customXmlParts) => {
+        for (let partIndex = 0; partIndex < customXmlParts.size(); partIndex++) {
+            const customXmlPart = customXmlParts.get_Item(partIndex);
+            const itemId = customXmlPart.getItemId().toString();
+
+            if (!referencesByItemId.has(itemId)) {
+                referencesByItemId.set(itemId, []);
+            }
+
+            referencesByItemId.get(itemId).push(ownerName);
+        }
+    };
+
+    registerCustomXmlParts("Presentation", presentation.getCustomData().getCustomXmlParts());
+
+    for (let slideIndex = 0; slideIndex < presentation.getSlides().size(); slideIndex++) {
+        const slide = presentation.getSlides().get_Item(slideIndex);
+
+        registerCustomXmlParts("Slide " + (slideIndex + 1), slide.getCustomData().getCustomXmlParts());
+
+        for (let shapeIndex = 0; shapeIndex < slide.getShapes().size(); shapeIndex++) {
+            const shape = slide.getShapes().get_Item(shapeIndex);
+
+            registerCustomXmlParts("Slide " + (slideIndex + 1) + ", shape " + shapeIndex, shape.getCustomData().getCustomXmlParts());
+        }
+    }
+
+    for (const [itemId, owners] of referencesByItemId) {
+        if (owners.length > 1) {
+            console.log("Shared custom XML part: " + itemId);
+
+            for (const ownerName of owners) {
+                console.log("  Referenced by: " + ownerName);
+            }
+        }
+    }
+} finally {
+    presentation.dispose();
+}
+```
+
+This type of audit is useful before modifying or deleting custom XML data in presentations created by external systems, because the same metadata part may participate in more than one relationship.
+
+## **Get Values of Tags**
+
+In slides, a tag corresponds to the `DocumentProperties.getKeywords()` method. This sample code shows how to get a tag value with Aspose.Slides for Node.js via Java for [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/):
+
+```javascript
+const aspose = { slides: require("aspose.slides.via.java") };
+
+const presentation = new aspose.slides.Presentation("presentation.pptx");
+try {
+    const keywords = presentation.getDocumentProperties().getKeywords();
+} finally {
+    presentation.dispose();
+}
+```
+
+## **Add Tags to Presentations**
+
+Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items:
+
+- the name of a custom property, for example, `MyTag`;
+- the value of the custom property, for example, `My Tag Value`.
+
+If you need to classify presentations based on a specific rule or property, you can add tags for that purpose. For example, if you want to categorize presentations from North American countries, you can create a North American tag and assign the relevant country as its value.
+
+This sample code shows how to add a tag to a [Presentation](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/) using Aspose.Slides for Node.js via Java:
+
+```javascript
+const aspose = { slides: require("aspose.slides.via.java") };
+
+const presentation = new aspose.slides.Presentation("presentation.pptx");
+try {
+    const tags = presentation.getCustomData().getTags();
+    tags.set_Item("MyTag", "My Tag Value");
+} finally {
+    presentation.dispose();
+}
+```
+
+Tags can also be set for a [Slide](https://reference.aspose.com/slides/nodejs-java/aspose.slides/slide/):
+
+```javascript
+const aspose = { slides: require("aspose.slides.via.java") };
+
+const presentation = new aspose.slides.Presentation();
+try {
+    const slide = presentation.getSlides().get_Item(0);
     slide.getCustomData().getTags().set_Item("tag", "value");
 } finally {
-    if (pres != null) {
-        pres.dispose();
-    }
+    presentation.dispose();
 }
 ```
 
-Or any individual [Shape](https://reference.aspose.com/slides/nodejs-java/aspose.slides/AutoShape):
+Or for an individual [Shape](https://reference.aspose.com/slides/nodejs-java/aspose.slides/autoshape/):
 
 ```javascript
-var aspose = aspose || {};
-aspose.slides = require("aspose.slides.via.java");
+const aspose = { slides: require("aspose.slides.via.java") };
 
-var pres = new aspose.slides.Presentation();
+const presentation = new aspose.slides.Presentation();
 try {
-    var slide = pres.getSlides().get_Item(0);
-    var shape = slide.getShapes().addAutoShape(aspose.slides.ShapeType.Rectangle, 10, 10, 100, 50);
+    const slide = presentation.getSlides().get_Item(0);
+    const shape = slide.getShapes().addAutoShape(aspose.slides.ShapeType.Rectangle, 10, 10, 100, 50);
+
     shape.getTextFrame().setText("My text");
     shape.getCustomData().getTags().set_Item("tag", "value");
 } finally {
-    if (pres != null) {
-        pres.dispose();
-    }
+    presentation.dispose();
 }
 ```
 
 ### **Limitations**
 
-Tags added through the custom data tag collection using `getCustomData().getTags()` are stored only within the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
+Tags added through the `getCustomData().getTags()` collection are stored only in the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
 
-**Workaround**: You can store a custom identifier in the object's **Alt Text** (e.g., `shape.setAlternativeText("MyId")`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
+**Workaround**: You can store a custom identifier in the object's **Alt Text** (for example, `shape.setAlternativeText("MyId")`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
 
 ## **FAQ**
 
-### Can I remove all tags from a presentation, slide, or shape in one operation?
+**Can I remove all tags from a presentation, slide, or shape in one operation?**
 
-Yes. The [tag collection](https://reference.aspose.com/slides/nodejs-java/aspose.slides/tagcollection/) supports a [clear](https://reference.aspose.com/slides/nodejs-java/aspose.slides/tagcollection/clear/) operation that deletes all key–value pairs at once.
+Yes. The [tag collection](https://reference.aspose.com/slides/nodejs-java/aspose.slides/tagcollection/) supports a [clear](https://reference.aspose.com/slides/nodejs-java/aspose.slides/tagcollection/) operation that deletes all key-value pairs at once.
 
-### How do I delete a single tag by its name without iterating over the whole collection?
+**How do I delete a single tag by its name without iterating over the whole collection?**
 
-Use the [remove(name)](https://reference.aspose.com/slides/nodejs-java/aspose.slides/tagcollection/remove/) operation on [TagCollection](https://reference.aspose.com/slides/nodejs-java/aspose.slides/tagcollection/) to delete the tag by its key.
+Use `remove(name)` on the [tag collection](https://reference.aspose.com/slides/nodejs-java/aspose.slides/tagcollection/) to delete the tag by its key.
 
-### How can I retrieve the complete list of tag names for analytics or filtering?
+**How can I retrieve the complete list of tag names for analytics or filtering?**
 
-Use [getNamesOfTags](https://reference.aspose.com/slides/nodejs-java/aspose.slides/tagcollection/getnamesoftags/) on the [tag collection](https://reference.aspose.com/slides/nodejs-java/aspose.slides/tagcollection/); it returns an array of all tag names.
+Use `getNamesOfTags()` on the [tag collection](https://reference.aspose.com/slides/nodejs-java/aspose.slides/tagcollection/); it returns an array of all tag names.
+
+**How can I find all custom XML parts regardless of where they are stored?**
+
+Use [`Presentation.getAllCustomXmlParts()`](https://reference.aspose.com/slides/nodejs-java/aspose.slides/presentation/) to retrieve all custom XML parts in the presentation.
+
+**Should I use `getXmlAsString`/`setXmlAsString` or `getXmlData`/`setXmlData` to update a custom XML part?**
+
+Use `getXmlAsString` and `setXmlAsString` when the application works with UTF-8 XML text. Use `getXmlData` and `setXmlData` when the XML is already available as a byte array or when binary-oriented processing is more convenient. Both representations refer to the XML content of the same custom XML part.

--- a/en/php-java/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
+++ b/en/php-java/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
@@ -8,119 +8,408 @@ keywords:
 - document properties
 - tag
 - custom data
+- custom XML
+- custom XML part
+- XML metadata
+- ItemId
 - add tag
 - pair values
 - PowerPoint
 - presentation
 - PHP
 - Aspose.Slides
-description: "Learn how to add, read, update, and remove tags & custom data in Aspose.Slides for PHP via Java, with examples for PowerPoint and OpenDocument presentations."
+description: "Learn how to manage tags and custom XML data in PowerPoint presentations with Aspose.Slides for PHP via Java, including adding, reading, updating, auditing, and removing custom XML parts."
 ---
 
 ## **Overview**
 
-This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. It briefly outlines how data is stored in PPTX files, notes that presentation-specific data can exist as tags and custom XML parts, and describes tags as key-value string pairs.
+This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. Presentation-specific data can be stored as tags or custom XML parts. Tags are simple key-value string pairs, while custom XML parts can store structured metadata and application-specific XML payloads.
 
-It also shows how to read tag values and how to add tags to a presentation, an individual slide, or a shape. In addition, the article covers common tag-management tasks such as clearing all tags, removing a tag by name, and retrieving the list of tag names.
+Aspose.Slides provides APIs for adding, reading, updating, auditing, and removing custom XML parts at the presentation, slide, and shape levels. Custom XML parts are useful for integrations that store information such as document-management identifiers, workflow state, compliance metadata, template-binding data, or other structured application data inside a presentation.
 
 ## **Data Storage in Presentation Files**
 
-PPTX files—items with the .pptx extension—are stored in the PresentationML format, which is part of the Office Open XML specification. The Office Open XML format defines the structure for data contained in presentations. 
+PPTX files—files with the `.pptx` extension—are stored in the PresentationML format, which is part of the Office Open XML specification. Office Open XML defines the package structure and relationships used to store presentation content and related data.
 
-With a *slide* being one of the elements in presentations, a *slide part* contains the content of a single slide. A slide part is allowed to have explicit relationships to many parts—such as User Defined Tags—defined by ISO/IEC 29500. 
+A presentation contains multiple parts connected by relationships. For example, a slide part contains the content of a single slide and can have explicit relationships to other parts defined by ISO/IEC 29500.
 
-Custom data (specific to a presentation) or user can exist as tags ([TagCollection](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/)) and CustomXmlParts ([CustomXmlPartCollection](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpartcollection/)).
+Custom data can be stored as tags ([TagCollection](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/)) or custom XML parts ([CustomXmlPartCollection](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpartcollection/)). Both are available through the [`CustomData`](https://reference.aspose.com/slides/php-java/aspose.slides/customdata/) class.
 
-{{% alert color="primary" %}} 
+{{% alert color="primary" %}}
 
-Tags are essentially string-key pair values. 
+Tags store simple string key-value pairs. Custom XML parts store structured XML data and can be associated with a presentation, slide, or shape.
 
-{{% /alert %}} 
+{{% /alert %}}
+
+## **Work with Custom XML Parts**
+
+The [`CustomData::getCustomXmlParts()`](https://reference.aspose.com/slides/php-java/aspose.slides/customdata/#getCustomXmlParts) method returns the collection of custom XML parts associated with a particular presentation object. For example:
+
+- `$presentation->getCustomData()->getCustomXmlParts()` contains custom XML parts associated with the presentation itself.
+- `$slide->getCustomData()->getCustomXmlParts()` contains custom XML parts associated with a specific slide.
+- `$shape->getCustomData()->getCustomXmlParts()` contains custom XML parts associated with a specific shape.
+
+Use [`Presentation::getAllCustomXmlParts()`](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/#getAllCustomXmlParts) when you need to inspect all custom XML parts in the presentation regardless of where they are associated.
+
+### **Add a Custom XML Part to a Presentation**
+
+Use [`CustomXmlPartCollection::add`](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpartcollection/#add) to add XML data to a custom XML part collection. The XML must be valid and non-empty.
+
+The following example adds structured metadata to the presentation-level custom data collection:
+
+```php
+$customXmlContent =
+    '<?xml version="1.0" encoding="UTF-8"?>' .
+    '<metadata xmlns="urn:example:metadata">' .
+        '<documentId>DOC-1001</documentId>' .
+        '<workflowState>Draft</workflowState>' .
+    '</metadata>';
+
+$presentation = new Presentation();
+try {
+    $customXmlPart = $presentation->getCustomData()->getCustomXmlParts()->add($customXmlContent);
+
+    // add assigns an identifier automatically. Set a specific UUID only when required.
+    $UUID = new JavaClass("java.util.UUID");
+    $customXmlPart->setItemId($UUID->randomUUID());
+
+    $presentation->save("presentation_with_custom_xml.pptx", SaveFormat::Pptx);
+} finally {
+    $presentation->dispose();
+}
+```
+
+The `add` method can also accept XML as a byte array or input stream, which is useful when XML content is already available in binary form.
+
+### **Add a Custom XML Part to a Slide or Shape**
+
+Custom XML data can be associated with a specific slide or shape instead of the whole presentation. This is useful when metadata describes only one object, such as a template key, external record identifier, or binding information.
+
+The following example adds one custom XML part to a slide and another to a shape:
+
+```php
+$presentation = new Presentation();
+try {
+    $slide = $presentation->getSlides()->get_Item(0);
+
+    $slide->getCustomData()->getCustomXmlParts()->add(
+        '<slideMetadata xmlns="urn:example:slides">' .
+            '<templateKey>TitleSlide</templateKey>' .
+        '</slideMetadata>'
+    );
+
+    $shape = $slide->getShapes()->addAutoShape(ShapeType::Rectangle, 50, 50, 250, 80);
+
+    $shape->getTextFrame()->setText("Customer data");
+    $shape->getCustomData()->getCustomXmlParts()->add(
+        '<shapeMetadata xmlns="urn:example:shapes">' .
+            '<recordId>CRM-4281</recordId>' .
+        '</shapeMetadata>'
+    );
+
+    $presentation->save("object_custom_xml.pptx", SaveFormat::Pptx);
+} finally {
+    $presentation->dispose();
+}
+```
+
+The level at which a part is added determines which object's `getCustomData()->getCustomXmlParts()` collection contains the relationship to that part. Presentation-level data is appropriate for document-wide metadata, slide-level data for information that belongs to a particular slide, and shape-level data for metadata tied to an individual shape.
+
+### **List and Audit All Custom XML Parts**
+
+Use [`Presentation::getAllCustomXmlParts()`](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/#getAllCustomXmlParts) to retrieve all custom XML parts from a presentation. Each [`CustomXmlPart`](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpart/) exposes its identifier, XML content, and associated namespace schemas.
+
+The following example lists all custom XML parts and their namespace schemas:
+
+```php
+$presentation = new Presentation("presentation.pptx");
+try {
+    foreach ($presentation->getAllCustomXmlParts() as $customXmlPart) {
+        echo "ItemId: " . $customXmlPart->getItemId() . PHP_EOL;
+        echo "XML:" . PHP_EOL;
+        echo $customXmlPart->getXmlAsString() . PHP_EOL;
+
+        foreach ($customXmlPart->getNamespaceSchemas() as $namespaceSchema) {
+            echo "Namespace schema: " . $namespaceSchema . PHP_EOL;
+        }
+
+        echo PHP_EOL;
+    }
+} finally {
+    $presentation->dispose();
+}
+```
+
+[`CustomXmlPart::getNamespaceSchemas()`](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpart/#getNamespaceSchemas) returns the XML schemas associated with the custom XML part. This information can be useful when auditing presentations that contain XML produced by external systems.
+
+### **Read and Update XML Content and ItemId**
+
+Use [`CustomXmlPart::getXmlAsString()`](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpart/#getXmlAsString) and [`setXmlAsString()`](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpart/#setXmlAsString) to work with XML as a UTF-8 string, or [`getXmlData()`](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpart/#getXmlData) and [`setXmlData()`](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpart/#setXmlData) to work with the raw XML bytes.
+
+The [`CustomXmlPart::getItemId()`](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpart/#getItemId) method returns the UUID that identifies the custom XML part in the Office Open XML document. Use [`setItemId()`](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpart/#setItemId) when an integration requires a new identifier.
+
+The following example updates the XML content and the identifier:
+
+```php
+$presentation = new Presentation("presentation.pptx");
+try {
+    $customXmlPart = $presentation->getAllCustomXmlParts()[0];
+
+    // Read the current XML as text.
+    $currentXmlContent = $customXmlPart->getXmlAsString();
+    echo $currentXmlContent . PHP_EOL;
+
+    // Update the XML as a UTF-8 string.
+    $customXmlPart->setXmlAsString(
+        '<metadata xmlns="urn:example:metadata">' .
+            '<documentId>DOC-1001</documentId>' .
+            '<workflowState>Approved</workflowState>' .
+        '</metadata>'
+    );
+
+    // getXmlData provides the same XML content as raw bytes.
+    $customXmlData = $customXmlPart->getXmlData();
+
+    // Replace the identifier when required by the integration.
+    $UUID = new JavaClass("java.util.UUID");
+    $customXmlPart->setItemId($UUID->randomUUID());
+
+    $presentation->save("updated_custom_xml.pptx", SaveFormat::Pptx);
+} finally {
+    $presentation->dispose();
+}
+```
+
+When calling `setXmlAsString` or `setXmlData`, provide valid, non-empty XML. Use one representation or the other depending on whether the application works primarily with strings or byte data.
+
+### **Remove a Custom XML Part**
+
+Aspose.Slides provides several ways to remove custom XML data:
+
+- [`CustomXmlPart::remove`](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpart/#remove) removes the custom XML part from the presentation.
+- [`CustomXmlPartCollection::remove`](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpartcollection/#remove) removes a specific part from a custom XML part collection.
+- [`CustomXmlPartCollection::removeAt`](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpartcollection/#removeAt) removes the part at a specified collection index.
+- [`CustomXmlPartCollection::clear`](https://reference.aspose.com/slides/php-java/aspose.slides/customxmlpartcollection/#clear) removes all parts from a specific collection.
+
+The following example removes one presentation-level custom XML part by reference:
+
+```php
+$presentation = new Presentation("presentation.pptx");
+try {
+    $customXmlParts = $presentation->getCustomData()->getCustomXmlParts();
+
+    if (java_values($customXmlParts->size()) > 0) {
+        $customXmlPart = $customXmlParts->get_Item(0);
+        $customXmlParts->remove($customXmlPart);
+    }
+
+    $presentation->save("custom_xml_removed.pptx", SaveFormat::Pptx);
+} finally {
+    $presentation->dispose();
+}
+```
+
+If you already have a `CustomXmlPart` and want to remove that part from the presentation rather than addressing a particular collection, call `$customXmlPart->remove()`.
+
+You can also remove an item by index:
+
+```php
+$presentation->getCustomData()->getCustomXmlParts()->removeAt(0);
+```
+
+### **Clear All Custom XML Parts from a Collection**
+
+Use `clear` when all custom XML parts associated with a particular presentation object should be removed.
+
+```php
+$presentation = new Presentation("presentation.pptx");
+try {
+    $presentation->getSlides()->get_Item(0)->getCustomData()->getCustomXmlParts()->clear();
+
+    $presentation->save("slide_custom_xml_cleared.pptx", SaveFormat::Pptx);
+} finally {
+    $presentation->dispose();
+}
+```
+
+`clear` affects only the selected collection. For example, clearing a slide's collection does not clear the presentation-level or shape-level collections.
+
+To remove every custom XML part in the presentation, iterate through `getAllCustomXmlParts()` and remove each part:
+
+```php
+$presentation = new Presentation("presentation.pptx");
+try {
+    foreach ($presentation->getAllCustomXmlParts() as $customXmlPart) {
+        $customXmlPart->remove();
+    }
+
+    $presentation->save("all_custom_xml_removed.pptx", SaveFormat::Pptx);
+} finally {
+    $presentation->dispose();
+}
+```
+
+### **Handle Linked or Shared Custom XML Parts**
+
+In an Office Open XML presentation, the same custom XML part can be referenced from more than one presentation object. For example, an existing file can contain relationships from multiple slides or shapes to the same underlying custom XML part.
+
+A shared part should be treated as one data object with multiple references:
+
+- Updating it with `setXmlAsString`, `setXmlData`, or `setItemId` changes the underlying custom XML part, so the change applies wherever that part is referenced.
+- `getItemId()` can be used to identify the same custom XML part while auditing object-level collections.
+- Removing a part from a specific `getCustomXmlParts()` collection removes it from that collection. Use `CustomXmlPart::remove()` when the part itself should be removed from the presentation.
+- Before deleting or replacing a shared part, inspect the object-level collections to determine whether other slides or shapes still reference it.
+
+The `add` overloads create a new custom XML part from XML content; they do not accept an existing `CustomXmlPart`. Therefore, shared relationships are most commonly encountered when loading presentations that already contain them.
+
+The following example audits presentation-, slide-, and shape-level collections by `ItemId` and reports parts referenced from more than one place:
+
+```php
+function registerCustomXmlParts($ownerName, $customXmlParts, &$referencesByItemId) {
+    $partCount = java_values($customXmlParts->size());
+
+    for ($i = 0; $i < $partCount; $i++) {
+        $customXmlPart = $customXmlParts->get_Item($i);
+        $itemId = java_values($customXmlPart->getItemId()->toString());
+
+        if (!isset($referencesByItemId[$itemId])) {
+            $referencesByItemId[$itemId] = [];
+        }
+
+        $referencesByItemId[$itemId][] = $ownerName;
+    }
+}
+
+$presentation = new Presentation("presentation.pptx");
+try {
+    $referencesByItemId = [];
+
+    registerCustomXmlParts(
+        "Presentation",
+        $presentation->getCustomData()->getCustomXmlParts(),
+        $referencesByItemId
+    );
+
+    $slideCount = java_values($presentation->getSlides()->size());
+    for ($slideIndex = 0; $slideIndex < $slideCount; $slideIndex++) {
+        $slide = $presentation->getSlides()->get_Item($slideIndex);
+        registerCustomXmlParts(
+            "Slide " . ($slideIndex + 1),
+            $slide->getCustomData()->getCustomXmlParts(),
+            $referencesByItemId
+        );
+
+        $shapeCount = java_values($slide->getShapes()->size());
+        for ($shapeIndex = 0; $shapeIndex < $shapeCount; $shapeIndex++) {
+            $shape = $slide->getShapes()->get_Item($shapeIndex);
+            registerCustomXmlParts(
+                "Slide " . ($slideIndex + 1) . ", shape " . $shapeIndex,
+                $shape->getCustomData()->getCustomXmlParts(),
+                $referencesByItemId
+            );
+        }
+    }
+
+    foreach ($referencesByItemId as $itemId => $owners) {
+        if (count($owners) > 1) {
+            echo "Shared custom XML part: " . $itemId . PHP_EOL;
+
+            foreach ($owners as $ownerName) {
+                echo "  Referenced by: " . $ownerName . PHP_EOL;
+            }
+        }
+    }
+} finally {
+    $presentation->dispose();
+}
+```
+
+This type of audit is useful before modifying or deleting custom XML data in presentations created by external systems, because the same metadata part may participate in more than one relationship.
 
 ## **Get Values of Tags**
 
-In slides, a tag corresponds to the [DocumentProperties::getKeywords()](https://reference.aspose.com/slides/php-java/aspose.slides/documentproperties/#getKeywords) and [DocumentProperties::setKeywords()](https://reference.aspose.com/slides/php-java/aspose.slides/documentproperties/#setKeywords) methods. This sample code shows you how to get a tag’s value with Aspose.Slides for PHP via Java for [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/Presentation):
+In slides, a tag corresponds to the `DocumentProperties::getKeywords()` method. This sample code shows how to get a tag value with Aspose.Slides for PHP via Java for [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/):
 
 ```php
-  $pres = new Presentation("pres.pptx");
-  try {
-    $keywords = $pres->getDocumentProperties()->getKeywords();
-  } finally {
-    if (!java_is_null($pres)) {
-      $pres->dispose();
-    }
-  }
+$presentation = new Presentation("presentation.pptx");
+try {
+    $keywords = $presentation->getDocumentProperties()->getKeywords();
+} finally {
+    $presentation->dispose();
+}
 ```
 
 ## **Add Tags to Presentations**
 
-Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items: 
+Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items:
 
-- the name of a custom property - `MyTag` 
-- the value of the custom property - `My Tag Value`
+- the name of a custom property, for example, `MyTag`;
+- the value of the custom property, for example, `My Tag Value`.
 
-If you need to classify some presentations based on a specific rule or property, then you may benefit from adding tags to those presentations. For example, if you want to categorize or put all presentations from North American countries together, you can create a North American tag and then assign the relevant countries (the U.S., Mexico, and Canada) as the values. 
+If you need to classify presentations based on a specific rule or property, you can add tags for that purpose. For example, if you want to categorize presentations from North American countries, you can create a North American tag and assign the relevant country as its value.
 
-This sample code shows you how to add a tag to a [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/Presentation) using Aspose.Slides for PHP via Java:
+This sample code shows how to add a tag to a [Presentation](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/) using Aspose.Slides for PHP via Java:
 
 ```php
-  $pres = new Presentation("pres.pptx");
-  try {
-    $tags = $pres->getCustomData()->getTags();
-    $pres->getCustomData()->getTags()->set_Item("MyTag", "My Tag Value");
-  } finally {
-    if (!java_is_null($pres)) {
-      $pres->dispose();
-    }
-  }
+$presentation = new Presentation("presentation.pptx");
+try {
+    $tags = $presentation->getCustomData()->getTags();
+    $tags->set_Item("MyTag", "My Tag Value");
+} finally {
+    $presentation->dispose();
+}
 ```
 
-Tags also can be set for [Slide](https://reference.aspose.com/slides/php-java/aspose.slides/slide/):
+Tags can also be set for a [Slide](https://reference.aspose.com/slides/php-java/aspose.slides/slide/):
 
 ```php
-  $pres = new Presentation();
-  try {
-    $slide = $pres->getSlides()->get_Item(0);
+$presentation = new Presentation();
+try {
+    $slide = $presentation->getSlides()->get_Item(0);
     $slide->getCustomData()->getTags()->set_Item("tag", "value");
-  } finally {
-    if (!java_is_null($pres)) {
-      $pres->dispose();
-    }
-  }
+} finally {
+    $presentation->dispose();
+}
 ```
 
-Or any individual [Shape](https://reference.aspose.com/slides/php-java/aspose.slides/shape/):
+Or for an individual [Shape](https://reference.aspose.com/slides/php-java/aspose.slides/autoshape/):
 
 ```php
-  $pres = new Presentation();
-  try {
-    $slide = $pres->getSlides()->get_Item(0);
+$presentation = new Presentation();
+try {
+    $slide = $presentation->getSlides()->get_Item(0);
     $shape = $slide->getShapes()->addAutoShape(ShapeType::Rectangle, 10, 10, 100, 50);
     $shape->getTextFrame()->setText("My text");
     $shape->getCustomData()->getTags()->set_Item("tag", "value");
-  } finally {
-    if (!java_is_null($pres)) {
-      $pres->dispose();
-    }
-  }
+} finally {
+    $presentation->dispose();
+}
 ```
 
 ### **Limitations**
 
-Tags added through the custom data tag collection using `getCustomData()->getTags()` are stored only within the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
+Tags added through the `getCustomData()->getTags()` collection are stored only in the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
 
-**Workaround**: You can store a custom identifier in the object's **Alt Text** (e.g., `$shape->setAlternativeText("MyId")`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
+**Workaround**: You can store a custom identifier in the object's **Alt Text** (for example, `$shape->setAlternativeText("MyId")`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
 
 ## **FAQ**
 
-### Can I remove all tags from a presentation, slide, or shape in one operation?
+**Can I remove all tags from a presentation, slide, or shape in one operation?**
 
-Yes. The [tag collection](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/) supports a [clear](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/clear/) operation that deletes all key–value pairs at once.
+Yes. The [tag collection](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/) supports a [clear](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/#clear) operation that deletes all key-value pairs at once.
 
-### How do I delete a single tag by its name without iterating over the whole collection?
+**How do I delete a single tag by its name without iterating over the whole collection?**
 
-Use the [remove(name)](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/remove/) operation on [tag collection](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/) to delete the tag by its key.
+Use [remove(name)](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/#remove) on the [tag collection](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/) to delete the tag by its key.
 
-### How can I retrieve the complete list of tag names for analytics or filtering?
+**How can I retrieve the complete list of tag names for analytics or filtering?**
 
-Use [getNamesOfTags](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/getnamesoftags/) on the [tag collection](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/); it returns an array of all tag names.
+Use [getNamesOfTags](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/#getNamesOfTags) on the [tag collection](https://reference.aspose.com/slides/php-java/aspose.slides/tagcollection/); it returns an array of all tag names.
+
+**How can I find all custom XML parts regardless of where they are stored?**
+
+Use [`Presentation::getAllCustomXmlParts()`](https://reference.aspose.com/slides/php-java/aspose.slides/presentation/#getAllCustomXmlParts) to retrieve all custom XML parts in the presentation.
+
+**Should I use `getXmlAsString`/`setXmlAsString` or `getXmlData`/`setXmlData` to update a custom XML part?**
+
+Use `getXmlAsString` and `setXmlAsString` when the application works with UTF-8 XML text. Use `getXmlData` and `setXmlData` when the XML is already available as a byte array or when binary-oriented processing is more convenient. Both representations refer to the XML content of the same custom XML part.

--- a/en/python-net/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
+++ b/en/python-net/developer-guide/presentation-content/managing-tags-and-custom-data/_index.md
@@ -8,83 +8,327 @@ keywords:
 - document properties
 - tag
 - custom data
+- custom XML
+- custom XML part
+- XML metadata
+- ItemId
 - add tag
 - pair values
 - PowerPoint
 - presentation
 - Python
 - Aspose.Slides
-description: "Learn how to add, read, update, and remove tags & custom data in Aspose.Slides for Python via .NET, with examples for PowerPoint and OpenDocument presentations."
+description: "Learn how to manage tags and custom XML data in PowerPoint presentations with Aspose.Slides for Python via .NET, including adding, reading, updating, auditing, and removing custom XML parts."
 ---
 
 ## **Overview**
 
-This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. It briefly outlines how data is stored in PPTX files, notes that presentation-specific data can exist as tags and custom XML parts, and describes tags as key-value string pairs.
+This article explains how Aspose.Slides works with tags and custom data in PowerPoint presentations. Presentation-specific data can be stored as tags or custom XML parts. Tags are simple key-value string pairs, while custom XML parts can store structured metadata and application-specific XML payloads.
 
-It also shows how to read tag values and how to add tags to a presentation, an individual slide, or a shape. In addition, the article covers common tag-management tasks such as clearing all tags, removing a tag by name, and retrieving the list of tag names.
+Aspose.Slides provides APIs for adding, reading, updating, auditing, and removing custom XML parts at the presentation, slide, and shape levels. Custom XML parts are useful for integrations that store information such as document-management identifiers, workflow state, compliance metadata, template-binding data, or other structured application data inside a presentation.
 
 ## **Data Storage in Presentation Files**
 
-PPTX files—items with the .pptx extension—are stored in the PresentationML format, which is part of the Office Open XML specification. The Office Open XML format defines the structure for data contained in presentations. 
+PPTX files—files with the `.pptx` extension—are stored in the PresentationML format, which is part of the Office Open XML specification. Office Open XML defines the package structure and relationships used to store presentation content and related data.
 
-With a *slide* being one of the elements in presentations, a *slide part* contains the content of a single slide. A slide part is allowed to have explicit relationships to many parts—such as User Defined Tags—defined by ISO/IEC 29500. 
+A presentation contains multiple parts connected by relationships. For example, a slide part contains the content of a single slide and can have explicit relationships to other parts defined by ISO/IEC 29500.
 
-Custom data (specific to a presentation) or user can exist as tags ([ITagCollection](https://reference.aspose.com/slides/python-net/aspose.slides/itagcollection/)) and CustomXmlParts ([ICustomXmlPartCollection](https://reference.aspose.com/slides/python-net/aspose.slides/icustomxmlpartcollection/)). 
+Custom data can be stored as tags ([TagCollection](https://reference.aspose.com/slides/python-net/aspose.slides/tagcollection/)) or custom XML parts ([CustomXmlPartCollection](https://reference.aspose.com/slides/python-net/aspose.slides/customxmlpartcollection/)). Both are available through the [`CustomData`](https://reference.aspose.com/slides/python-net/aspose.slides/customdata/) class.
 
-{{% alert color="primary" %}} 
+{{% alert color="primary" %}}
 
-Tags are essentially string-key pair values. 
+Tags store simple string key-value pairs. Custom XML parts store structured XML data and can be associated with a presentation, slide, or shape.
 
-{{% /alert %}} 
+{{% /alert %}}
 
-## **Get the Values of Tags**
+## **Work with Custom XML Parts**
 
-In slides, a tag corresponds to the IDocumentProperties.Keywords property. This sample code shows you how to get a tag’s value with Aspose.Slides for Python via .NET for [Presentation](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/):
+The [`CustomData.custom_xml_parts`](https://reference.aspose.com/slides/python-net/aspose.slides/customdata/custom_xml_parts/) property returns the collection of custom XML parts associated with a particular presentation object. For example:
+
+- `presentation.custom_data.custom_xml_parts` contains custom XML parts associated with the presentation itself.
+- `slide.custom_data.custom_xml_parts` contains custom XML parts associated with a specific slide.
+- `shape.custom_data.custom_xml_parts` contains custom XML parts associated with a specific shape.
+
+Use [`Presentation.all_custom_xml_parts`](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/all_custom_xml_parts/) when you need to inspect all custom XML parts in the presentation regardless of where they are associated.
+
+### **Add a Custom XML Part to a Presentation**
+
+Use [`CustomXmlPartCollection.add`](https://reference.aspose.com/slides/python-net/aspose.slides/customxmlpartcollection/add/) to add XML data to a custom XML part collection. The XML must be valid and non-empty.
+
+The following example adds structured metadata to the presentation-level custom data collection:
+
+```py
+import uuid
+import aspose.slides as slides
+
+custom_xml_content = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<metadata xmlns="urn:example:metadata">'
+    '<documentId>DOC-1001</documentId>'
+    '<workflowState>Draft</workflowState>'
+    '</metadata>'
+)
+
+with slides.Presentation() as presentation:
+    custom_xml_part = presentation.custom_data.custom_xml_parts.add(custom_xml_content)
+
+    # add assigns an identifier automatically. Set a specific GUID only when required.
+    custom_xml_part.item_id = uuid.uuid4()
+
+    presentation.save("presentation_with_custom_xml.pptx", slides.export.SaveFormat.PPTX)
+```
+
+The `add` method can also accept XML as a byte array or stream, which is useful when XML content is already available in binary form.
+
+### **Add a Custom XML Part to a Slide or Shape**
+
+Custom XML data can be associated with a specific slide or shape instead of the whole presentation. This is useful when metadata describes only one object, such as a template key, external record identifier, or binding information.
+
+The following example adds one custom XML part to a slide and another to a shape:
 
 ```py
 import aspose.slides as slides
 
-with slides.Presentation("pres.pptx") as pres:
-    print(pres.document_properties.keywords)
+with slides.Presentation() as presentation:
+    slide = presentation.slides[0]
+
+    slide.custom_data.custom_xml_parts.add(
+        '<slideMetadata xmlns="urn:example:slides">'
+        '<templateKey>TitleSlide</templateKey>'
+        '</slideMetadata>'
+    )
+
+    shape = slide.shapes.add_auto_shape(slides.ShapeType.RECTANGLE, 50, 50, 250, 80)
+
+    shape.text_frame.text = "Customer data"
+    shape.custom_data.custom_xml_parts.add(
+        '<shapeMetadata xmlns="urn:example:shapes">'
+        '<recordId>CRM-4281</recordId>'
+        '</shapeMetadata>'
+    )
+
+    presentation.save("object_custom_xml.pptx", slides.export.SaveFormat.PPTX)
+```
+
+The level at which a part is added determines which object's `custom_data.custom_xml_parts` collection contains the relationship to that part. Presentation-level data is appropriate for document-wide metadata, slide-level data for information that belongs to a particular slide, and shape-level data for metadata tied to an individual shape.
+
+### **List and Audit All Custom XML Parts**
+
+Use [`Presentation.all_custom_xml_parts`](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/all_custom_xml_parts/) to retrieve all custom XML parts from a presentation. Each [`CustomXmlPart`](https://reference.aspose.com/slides/python-net/aspose.slides/customxmlpart/) exposes its identifier, XML content, and associated namespace schemas.
+
+The following example lists all custom XML parts and their namespace schemas:
+
+```py
+import aspose.slides as slides
+
+with slides.Presentation("presentation.pptx") as presentation:
+    for custom_xml_part in presentation.all_custom_xml_parts:
+        print("ItemId: " + str(custom_xml_part.item_id))
+        print("XML:")
+        print(custom_xml_part.xml_as_string)
+
+        for namespace_schema in custom_xml_part.namespace_schemas:
+            print("Namespace schema: " + namespace_schema)
+
+        print()
+```
+
+[`CustomXmlPart.namespace_schemas`](https://reference.aspose.com/slides/python-net/aspose.slides/customxmlpart/namespace_schemas/) returns the XML schemas associated with the custom XML part. This information can be useful when auditing presentations that contain XML produced by external systems.
+
+### **Read and Update XML Content and ItemId**
+
+Use [`CustomXmlPart.xml_as_string`](https://reference.aspose.com/slides/python-net/aspose.slides/customxmlpart/xml_as_string/) to work with XML as a UTF-8 string, or [`CustomXmlPart.xml_data`](https://reference.aspose.com/slides/python-net/aspose.slides/customxmlpart/xml_data/) to work with the raw XML bytes. Both properties can be read and updated.
+
+The [`CustomXmlPart.item_id`](https://reference.aspose.com/slides/python-net/aspose.slides/customxmlpart/item_id/) property contains the GUID that identifies the custom XML part in the Office Open XML document. It can also be changed when an integration requires a new identifier.
+
+The following example updates the XML content and the identifier:
+
+```py
+import uuid
+import aspose.slides as slides
+
+with slides.Presentation("presentation.pptx") as presentation:
+    custom_xml_part = presentation.all_custom_xml_parts[0]
+
+    # Read the current XML as text.
+    current_xml_content = custom_xml_part.xml_as_string
+    print(current_xml_content)
+
+    # Update the XML as a UTF-8 string.
+    custom_xml_part.xml_as_string = (
+        '<metadata xmlns="urn:example:metadata">'
+        '<documentId>DOC-1001</documentId>'
+        '<workflowState>Approved</workflowState>'
+        '</metadata>'
+    )
+
+    # xml_data provides the same XML content as raw bytes.
+    custom_xml_data = custom_xml_part.xml_data
+    print(custom_xml_data.decode("utf-8"))
+
+    # Replace the identifier when required by the integration.
+    custom_xml_part.item_id = uuid.uuid4()
+
+    presentation.save("updated_custom_xml.pptx", slides.export.SaveFormat.PPTX)
+```
+
+When assigning `xml_as_string` or `xml_data`, provide valid, non-empty XML. Use one representation or the other depending on whether the application works primarily with strings or byte data.
+
+### **Remove a Custom XML Part**
+
+Aspose.Slides provides several ways to remove custom XML data:
+
+- [`CustomXmlPart.remove`](https://reference.aspose.com/slides/python-net/aspose.slides/customxmlpart/remove/) removes the custom XML part from the presentation.
+- [`CustomXmlPartCollection.remove`](https://reference.aspose.com/slides/python-net/aspose.slides/customxmlpartcollection/remove/) removes a specific part from a custom XML part collection.
+- [`CustomXmlPartCollection.remove_at`](https://reference.aspose.com/slides/python-net/aspose.slides/customxmlpartcollection/remove_at/) removes the part at a specified collection index.
+- [`CustomXmlPartCollection.clear`](https://reference.aspose.com/slides/python-net/aspose.slides/customxmlpartcollection/clear/) removes all parts from a specific collection.
+
+The following example removes one presentation-level custom XML part by reference:
+
+```py
+import aspose.slides as slides
+
+with slides.Presentation("presentation.pptx") as presentation:
+    custom_xml_parts = presentation.custom_data.custom_xml_parts
+
+    if len(custom_xml_parts) > 0:
+        custom_xml_part = custom_xml_parts[0]
+        custom_xml_parts.remove(custom_xml_part)
+
+    presentation.save("custom_xml_removed.pptx", slides.export.SaveFormat.PPTX)
+```
+
+If you already have a `CustomXmlPart` and want to remove that part from the presentation rather than addressing a particular collection, call `custom_xml_part.remove()`.
+
+You can also remove an item by index:
+
+```py
+presentation.custom_data.custom_xml_parts.remove_at(0)
+```
+
+### **Clear All Custom XML Parts from a Collection**
+
+Use `clear` when all custom XML parts associated with a particular presentation object should be removed.
+
+```py
+import aspose.slides as slides
+
+with slides.Presentation("presentation.pptx") as presentation:
+    presentation.slides[0].custom_data.custom_xml_parts.clear()
+
+    presentation.save("slide_custom_xml_cleared.pptx", slides.export.SaveFormat.PPTX)
+```
+
+`clear` affects only the selected collection. For example, clearing a slide's collection does not clear the presentation-level or shape-level collections.
+
+To remove every custom XML part in the presentation, iterate through `all_custom_xml_parts` and remove each part:
+
+```py
+import aspose.slides as slides
+
+with slides.Presentation("presentation.pptx") as presentation:
+    for custom_xml_part in presentation.all_custom_xml_parts:
+        custom_xml_part.remove()
+
+    presentation.save("all_custom_xml_removed.pptx", slides.export.SaveFormat.PPTX)
+```
+
+### **Handle Linked or Shared Custom XML Parts**
+
+In an Office Open XML presentation, the same custom XML part can be referenced from more than one presentation object. For example, an existing file can contain relationships from multiple slides or shapes to the same underlying custom XML part.
+
+A shared part should be treated as one data object with multiple references:
+
+- Updating its `xml_as_string`, `xml_data`, or `item_id` changes the underlying custom XML part, so the change applies wherever that part is referenced.
+- `item_id` can be used to identify the same custom XML part while auditing object-level collections.
+- Removing a part from a specific `custom_xml_parts` collection removes it from that collection. Use `CustomXmlPart.remove()` when the part itself should be removed from the presentation.
+- Before deleting or replacing a shared part, inspect the object-level collections to determine whether other slides or shapes still reference it.
+
+The `add` overloads create a new custom XML part from XML content; they do not accept an existing `CustomXmlPart`. Therefore, shared relationships are most commonly encountered when loading presentations that already contain them.
+
+The following example audits presentation-, slide-, and shape-level collections by `item_id` and reports parts referenced from more than one place:
+
+```py
+import aspose.slides as slides
+
+with slides.Presentation("presentation.pptx") as presentation:
+    references_by_item_id = {}
+
+    def register_custom_xml_parts(owner_name, custom_xml_parts):
+        for custom_xml_part in custom_xml_parts:
+            references_by_item_id.setdefault(custom_xml_part.item_id, []).append(owner_name)
+
+    register_custom_xml_parts("Presentation", presentation.custom_data.custom_xml_parts)
+
+    for slide_index, slide in enumerate(presentation.slides):
+        register_custom_xml_parts(
+            "Slide " + str(slide_index + 1),
+            slide.custom_data.custom_xml_parts
+        )
+
+        for shape_index, shape in enumerate(slide.shapes):
+            register_custom_xml_parts(
+                "Slide " + str(slide_index + 1) + ", shape " + str(shape_index),
+                shape.custom_data.custom_xml_parts
+            )
+
+    for item_id, owner_names in references_by_item_id.items():
+        if len(owner_names) > 1:
+            print("Shared custom XML part: " + str(item_id))
+
+            for owner_name in owner_names:
+                print("  Referenced by: " + owner_name)
+```
+
+This type of audit is useful before modifying or deleting custom XML data in presentations created by external systems, because the same metadata part may participate in more than one relationship.
+
+## **Get Values of Tags**
+
+In slides, a tag corresponds to the `DocumentProperties.keywords` property. This sample code shows how to get a tag value with Aspose.Slides for Python via .NET for [Presentation](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/):
+
+```py
+import aspose.slides as slides
+
+with slides.Presentation("presentation.pptx") as presentation:
+    keywords = presentation.document_properties.keywords
 ```
 
 ## **Add Tags to Presentations**
 
-Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items: 
+Aspose.Slides allows you to add tags to presentations. A tag typically consists of two items:
 
-- the name of a custom property - `MyTag` 
-- the value of the custom property - `My Tag Value`
+- the name of a custom property, for example, `MyTag`;
+- the value of the custom property, for example, `My Tag Value`.
 
-If you need to classify some presentations based on a specific rule or property, then you may benefit from adding tags to those presentations. For example, if you want to categorize or put all presentations from North American countries together, you can create a North American tag and then assign the relevant countries (the U.S., Mexico, and Canada) as the values. 
+If you need to classify presentations based on a specific rule or property, you can add tags for that purpose. For example, if you want to categorize presentations from North American countries, you can create a North American tag and assign the relevant country as its value.
 
-This sample code shows you how to add a tag to a [Presentation](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/) using Aspose.Slides for Python via .NET:
+This sample code shows how to add a tag to a [Presentation](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/) using Aspose.Slides for Python via .NET:
 
 ```py
 import aspose.slides as slides
 
-with slides.Presentation("pres.pptx") as pres:
-   tags = pres.custom_data.tags 
-   tags.add("MyTag", "My Tag Value")
+with slides.Presentation("presentation.pptx") as presentation:
+    tags = presentation.custom_data.tags
+    tags.add("MyTag", "My Tag Value")
 ```
 
-Tags also can be set for [Slide](https://reference.aspose.com/slides/python-net/aspose.slides/slide/):
+Tags can also be set for a [Slide](https://reference.aspose.com/slides/python-net/aspose.slides/slide/):
 
 ```py
 import aspose.slides as slides
 
-with slides.Presentation("pres.pptx") as pres:
-    slide = pres.slides[0]
-    tags = slide.custom_data.tags
-    tags.add("tag", "value")
+with slides.Presentation() as presentation:
+    slide = presentation.slides[0]
+    slide.custom_data.tags.add("tag", "value")
 ```
 
-Or any individual [Shape](https://reference.aspose.com/slides/python-net/aspose.slides/shape/):
+Or for an individual [Shape](https://reference.aspose.com/slides/python-net/aspose.slides/shape/):
 
 ```py
 import aspose.slides as slides
 
-with slides.Presentation("pres.pptx") as pres:
-    slide = pres.slides[0]
+with slides.Presentation() as presentation:
+    slide = presentation.slides[0]
     shape = slide.shapes.add_auto_shape(slides.ShapeType.RECTANGLE, 10, 10, 100, 50)
     shape.text_frame.text = "My text"
     shape.custom_data.tags.add("tag", "value")
@@ -92,20 +336,28 @@ with slides.Presentation("pres.pptx") as pres:
 
 ### **Limitations**
 
-Tags added via the `custom_data.tags` collection are stored only within the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
+Tags added through the `custom_data.tags` collection are stored only in the PowerPoint file. They are **not** transferred to the PDF tag structure when the presentation is exported to PDF. Consequently, a custom identifier assigned as a tag cannot be retrieved from the tagged PDF.
 
-**Workaround**: You can store a custom identifier in the object's **Alt Text** (e.g., `shape.alternative_text = "MyId"`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
+**Workaround**: You can store a custom identifier in the object's **Alt Text** (for example, `shape.alternative_text = "MyId"`). After exporting to PDF, the Alt Text may appear in the PDF tag structure.
 
 ## **FAQ**
 
-### Can I remove all tags from a presentation, slide, or shape in one operation?
+**Can I remove all tags from a presentation, slide, or shape in one operation?**
 
-Yes. The [tag collection](https://reference.aspose.com/slides/python-net/aspose.slides/tagcollection/) supports a [clear](https://reference.aspose.com/slides/python-net/aspose.slides/tagcollection/clear/) operation that deletes all key–value pairs at once.
+Yes. The [tag collection](https://reference.aspose.com/slides/python-net/aspose.slides/tagcollection/) supports a [clear](https://reference.aspose.com/slides/python-net/aspose.slides/tagcollection/clear/) operation that deletes all key-value pairs at once.
 
-### How do I delete a single tag by its name without iterating over the whole collection?
+**How do I delete a single tag by its name without iterating over the whole collection?**
 
-Use the [remove(name)](https://reference.aspose.com/slides/python-net/aspose.slides/tagcollection/remove/) operation on [TagCollection](https://reference.aspose.com/slides/python-net/aspose.slides/tagcollection/) to delete the tag by its key.
+Use [remove(name)](https://reference.aspose.com/slides/python-net/aspose.slides/tagcollection/remove/) on [TagCollection](https://reference.aspose.com/slides/python-net/aspose.slides/tagcollection/) to delete the tag by its key.
 
-### How can I retrieve the complete list of tag names for analytics or filtering?
+**How can I retrieve the complete list of tag names for analytics or filtering?**
 
 Use [get_names_of_tags](https://reference.aspose.com/slides/python-net/aspose.slides/tagcollection/get_names_of_tags/) on the [tag collection](https://reference.aspose.com/slides/python-net/aspose.slides/tagcollection/); it returns an array of all tag names.
+
+**How can I find all custom XML parts regardless of where they are stored?**
+
+Use [`Presentation.all_custom_xml_parts`](https://reference.aspose.com/slides/python-net/aspose.slides/presentation/all_custom_xml_parts/) to retrieve all custom XML parts in the presentation.
+
+**Should I use `xml_as_string` or `xml_data` to update a custom XML part?**
+
+Use `xml_as_string` when the application works with UTF-8 XML text. Use `xml_data` when the XML is already available as a byte array or when binary-oriented processing is more convenient. Both properties represent the XML content of the same custom XML part.


### PR DESCRIPTION
Expanded the article to cover custom XML data management, including adding, reading, updating, auditing, and removing custom XML parts at the presentation, slide, and shape levels, and added examples for working with shared custom XML parts and ItemId (.NET, Android via Java, C++, Java, Node.js via Java, PHP via Java, and Python via .NET).